### PR TITLE
Divide IconScoreContext class

### DIFF
--- a/iconservice/deploy/icon_score_deploy_engine.py
+++ b/iconservice/deploy/icon_score_deploy_engine.py
@@ -362,4 +362,3 @@ class DirectoryNameChanger:
         converted_tx_hash = f'0x{bytes.hex(tx_hash)}'
         install_path = path.join(score_root_path, converted_tx_hash)
         return install_path
-

--- a/iconservice/deploy/icon_score_deploy_storage.py
+++ b/iconservice/deploy/icon_score_deploy_storage.py
@@ -18,6 +18,7 @@ import warnings
 from struct import pack, unpack
 from typing import TYPE_CHECKING, Optional, Tuple
 
+from iconservice.iconscore.icon_score_context_util import IconScoreContextUtil
 from . import DeployType, DeployState
 from ..base.address import Address, ICON_EOA_ADDRESS_BYTES_SIZE, ICON_CONTRACT_ADDRESS_BYTES_SIZE
 from ..base.exception import ServerErrorException
@@ -240,7 +241,7 @@ class IconScoreDeployStorage(object):
             if deploy_info.owner != owner:
                 raise ServerErrorException(f'invalid owner: {deploy_info.owner} != {owner}')
             if deploy_info.next_tx_hash is not None:
-                if context.get_revision() >= REVISION_2:
+                if IconScoreContextUtil.get_revision(context) >= REVISION_2:
                     self._db.delete(context, self._create_db_key(
                         self._DEPLOY_STORAGE_DEPLOY_TX_PARAMS_PREFIX, deploy_info.next_tx_hash))
                 else:

--- a/iconservice/deploy/icon_score_deploy_storage.py
+++ b/iconservice/deploy/icon_score_deploy_storage.py
@@ -18,11 +18,11 @@ import warnings
 from struct import pack, unpack
 from typing import TYPE_CHECKING, Optional, Tuple
 
-from iconservice.iconscore.icon_score_context_util import IconScoreContextUtil
 from . import DeployType, DeployState
 from ..base.address import Address, ICON_EOA_ADDRESS_BYTES_SIZE, ICON_CONTRACT_ADDRESS_BYTES_SIZE
 from ..base.exception import ServerErrorException
 from ..icon_constant import DEFAULT_BYTE_SIZE, REVISION_2
+from ..iconscore.icon_score_context_util import IconScoreContextUtil
 
 if TYPE_CHECKING:
     from ..iconscore.icon_score_context import IconScoreContext

--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -20,7 +20,7 @@ from os import makedirs
 from typing import TYPE_CHECKING, List, Any, Optional
 
 from iconcommons.logger import Logger
-from iconservice.iconscore.icon_score_context_util import IconScoreContextUtil
+from .iconscore.icon_score_context_util import IconScoreContextUtil
 from .base.address import Address, generate_score_address, generate_score_address_for_tbears
 from .base.address import ZERO_SCORE_ADDRESS, GOVERNANCE_SCORE_ADDRESS
 from .base.block import Block

--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -140,11 +140,10 @@ class IconServiceEngine(ContextContainer):
                                                     self._icon_score_deploy_storage)
 
         InternalCall.icx_engine = self._icx_engine
+        IconScoreContext.icon_score_mapper = self._icon_score_mapper
         IconScoreContext.icon_score_deploy_engine = self._icon_score_deploy_engine
-        IconScoreContextUtil.icon_score_mapper = self._icon_score_mapper
-        IconScoreContextUtil.icon_score_deploy_engine = self._icon_score_deploy_engine
-        IconScoreContextUtil.icon_service_flag = service_config_flag
-        IconScoreContextUtil.legacy_tbears_mode = self._conf.get(ConfigKey.TBEARS_MODE, False)
+        IconScoreContext.icon_service_flag = service_config_flag
+        IconScoreContext.legacy_tbears_mode = self._conf.get(ConfigKey.TBEARS_MODE, False)
 
         self._icx_engine.open(self._icx_storage)
         self._icon_score_engine.open(

--- a/iconservice/iconscore/icon_score_base.py
+++ b/iconservice/iconscore/icon_score_base.py
@@ -21,6 +21,7 @@ from inspect import isfunction, getmembers, signature, Parameter
 from functools import partial, wraps
 from typing import TYPE_CHECKING, Callable, Any, List, Tuple, Optional, Union
 
+from iconservice.iconscore.icon_score_context_util import IconScoreContextUtil
 from ..icon_constant import ICX_TRANSFER_EVENT_LOG
 from .icon_score_api_generator import ScoreApiGenerator
 from .icon_score_constant import CONST_INDEXED_ARGS_COUNT, FORMAT_IS_NOT_FUNCTION_OBJECT, CONST_BIT_FLAG, \
@@ -543,12 +544,12 @@ class IconScoreBase(IconScoreObject, ContextGetter,
         revert(message, code)
 
     def is_score_active(self, score_address: 'Address')-> bool:
-        return self._context.is_score_active(self._context, score_address)
+        return IconScoreContextUtil.is_score_active(self._context, score_address)
 
     def get_owner(self, score_address: Optional['Address']) -> Optional['Address']:
         if not score_address:
             score_address = self.address
-        return self._context.get_owner(self._context, score_address)
+        return IconScoreContextUtil.get_owner(self._context, score_address)
 
     def create_interface_score(self,
                                addr_to: 'Address',
@@ -566,7 +567,7 @@ class IconScoreBase(IconScoreObject, ContextGetter,
             tmp_sender = self._context.msg.sender
             self._context.msg.sender = owner
             try:
-                self._context.deploy(tx_hash)
+                IconScoreContextUtil.deploy(self._context, tx_hash)
             finally:
                 self._context.msg = tmp_sender
         else:
@@ -575,9 +576,9 @@ class IconScoreBase(IconScoreObject, ContextGetter,
     def get_tx_hashes_by_score_address(self,
                                        score_address: 'Address') -> Tuple[Optional[bytes], Optional[bytes]]:
         warnings.warn("legacy function don't use.", DeprecationWarning, stacklevel=2)
-        return self._context.get_tx_hashes_by_score_address(self._context, score_address)
+        return IconScoreContextUtil.get_tx_hashes_by_score_address(self._context, score_address)
 
     def get_score_address_by_tx_hash(self,
                                      tx_hash: bytes) -> Optional['Address']:
         warnings.warn("legacy function don't use.", DeprecationWarning, stacklevel=2)
-        return self._context.get_score_address_by_tx_hash(self._context, tx_hash)
+        return IconScoreContextUtil.get_score_address_by_tx_hash(self._context, tx_hash)

--- a/iconservice/iconscore/icon_score_base.py
+++ b/iconservice/iconscore/icon_score_base.py
@@ -16,20 +16,18 @@
 
 import warnings
 from abc import abstractmethod, ABC, ABCMeta
-from inspect import isfunction, getmembers, signature, Parameter
-
 from functools import partial, wraps
+from inspect import isfunction, getmembers, signature, Parameter
 from typing import TYPE_CHECKING, Callable, Any, List, Tuple, Optional, Union
 
-from iconservice.iconscore.icon_score_context_util import IconScoreContextUtil
-from ..icon_constant import ICX_TRANSFER_EVENT_LOG
 from .icon_score_api_generator import ScoreApiGenerator
+from .icon_score_base2 import InterfaceScore, revert, Block
 from .icon_score_constant import CONST_INDEXED_ARGS_COUNT, FORMAT_IS_NOT_FUNCTION_OBJECT, CONST_BIT_FLAG, \
     ConstBitFlag, FORMAT_DECORATOR_DUPLICATED, FORMAT_IS_NOT_DERIVED_OF_OBJECT, STR_FALLBACK, CONST_CLASS_EXTERNALS, \
     CONST_CLASS_PAYABLES, CONST_CLASS_API, T, BaseType
-from .icon_score_base2 import InterfaceScore, revert, Block
 from .icon_score_context import ContextGetter
 from .icon_score_context import IconScoreContextType
+from .icon_score_context_util import IconScoreContextUtil
 from .icon_score_event_log import EventLogEmitter
 from .icon_score_step import StepType
 from .icx import Icx
@@ -37,6 +35,7 @@ from ..base.address import Address, GOVERNANCE_SCORE_ADDRESS
 from ..base.exception import IconScoreException, IconTypeError, InterfaceException, PayableException, ExceptionCode, \
     EventLogException, ExternalException, ServerErrorException
 from ..database.db import IconScoreDatabase, DatabaseObserver
+from ..icon_constant import ICX_TRANSFER_EVENT_LOG
 from ..utils import get_main_type_from_annotations_type
 
 if TYPE_CHECKING:

--- a/iconservice/iconscore/icon_score_context.py
+++ b/iconservice/iconscore/icon_score_context.py
@@ -92,8 +92,11 @@ class ContextGetter(object):
 
 
 class IconScoreContext(object):
-    # TODO should remove after update GOVERNANCE 0.0.6 afterward
+
+    icon_score_mapper: 'IconScoreMapper' = None
     icon_score_deploy_engine: 'IconScoreDeployEngine' = None
+    icon_service_flag: int = 0
+    legacy_tbears_mode = False
 
     """Contains the useful information to process user's jsonrpc request
     """

--- a/iconservice/iconscore/icon_score_context.py
+++ b/iconservice/iconscore/icon_score_context.py
@@ -13,28 +13,26 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import warnings
 
 import threading
-from typing import TYPE_CHECKING, Optional, List, Tuple
+import warnings
+from typing import TYPE_CHECKING, Optional, List
 
 from .icon_score_trace import Trace
 from .internal_call import InternalCall
-from ..base.address import GOVERNANCE_SCORE_ADDRESS
 from ..base.block import Block
-from ..base.exception import ServerErrorException, InvalidParamsException
+from ..base.exception import ServerErrorException
 from ..base.message import Message
 from ..base.transaction import Transaction
 from ..database.batch import BlockBatch, TransactionBatch
-from ..icon_constant import IconScoreContextType, IconScoreFuncType, DEFAULT_BYTE_SIZE, IconServiceFlag
+from ..icon_constant import IconScoreContextType, IconScoreFuncType
 
 if TYPE_CHECKING:
     from .icon_score_mapper import IconScoreMapper
     from .icon_score_step import IconScoreStepCounter
     from .icon_score_event_log import EventLog
-    from ..deploy.icon_score_deploy_engine import IconScoreDeployEngine
-    from .icon_score_base import IconScoreBase
     from ..base.address import Address
+    from ..deploy.icon_score_deploy_engine import IconScoreDeployEngine
 
 _thread_local_data = threading.local()
 
@@ -94,12 +92,11 @@ class ContextGetter(object):
 
 
 class IconScoreContext(object):
+    # TODO should remove after update GOVERNANCE 0.0.6 afterward
+    icon_score_deploy_engine: 'IconScoreDeployEngine' = None
+
     """Contains the useful information to process user's jsonrpc request
     """
-    icon_score_mapper: 'IconScoreMapper' = None
-    icon_score_deploy_engine: 'IconScoreDeployEngine'
-    icon_service_flag: int = 0
-    legacy_tbears_mode = False
 
     def __init__(self,
                  context_type: 'IconScoreContextType' = IconScoreContextType.QUERY,
@@ -126,7 +123,7 @@ class IconScoreContext(object):
         self.block = block
         self.tx = tx
         self.msg = msg
-        self.current_address: Address = None
+        self.current_address: 'Address' = None
         self.block_batch = block_batch
         self.tx_batch = tx_batch
         self.new_icon_score_mapper = new_icon_score_mapper
@@ -162,154 +159,10 @@ class IconScoreContext(object):
         self.msg_stack.clear()
         self.event_log_stack.clear()
 
-    def is_score_active(self,
-                        context: Optional['IconScoreContext'],
-                        icon_score_address: 'Address') -> bool:
-        return self.icon_score_deploy_engine.icon_deploy_storage.is_score_active(context, icon_score_address)
-
-    def get_owner(self,
-                  context: Optional['IconScoreContext'],
-                  icon_score_address: 'Address') -> Optional['Address']:
-        return self.icon_score_deploy_engine.icon_deploy_storage.get_score_owner(context, icon_score_address)
-
+    # TODO should remove after update GOVERNANCE 0.0.6 afterward
     def deploy(self, tx_hash: bytes) -> None:
+        warnings.warn("legacy function don't use.", DeprecationWarning, stacklevel=2)
         self.icon_score_deploy_engine.deploy(self, tx_hash)
-
-    def get_icon_score(self, address: 'Address') -> Optional['IconScoreBase']:
-        score = None
-
-        if self.type == IconScoreContextType.INVOKE:
-            if self.new_icon_score_mapper is not None:
-                score = self.new_icon_score_mapper.get(address)
-        if score is None:
-            score = self._get_icon_score(address)
-
-        return score
-
-    def _get_icon_score(self, address: 'Address') -> Optional['IconScoreBase']:
-        is_score_active = self.icon_score_deploy_engine.icon_deploy_storage.is_score_active(self, address)
-
-        if not is_score_active:
-            raise InvalidParamsException(f'SCORE is inactive: {address}')
-
-        deploy_info = self.icon_score_deploy_engine.icon_deploy_storage.get_deploy_info(self, address)
-        if deploy_info is None:
-            current_tx_hash = None
-        else:
-            current_tx_hash = deploy_info.current_tx_hash
-
-        if current_tx_hash is None:
-            current_tx_hash = bytes(DEFAULT_BYTE_SIZE)
-
-        return self.icon_score_mapper.get_icon_score(address, current_tx_hash)
-
-    def try_score_package_validate(self, address: 'Address', tx_hash: bytes):
-        self.icon_score_mapper.try_score_package_validate(address, tx_hash)
-
-    def validate_score_blacklist(self, score_address: 'Address'):
-        """Prevent SCOREs in blacklist
-
-        :param score_address:
-        """
-        if not score_address.is_contract:
-            raise ServerErrorException(f'Invalid SCORE address: {score_address}')
-
-        # Gets the governance SCORE
-        governance_score: 'Governance' = self.get_icon_score(GOVERNANCE_SCORE_ADDRESS)
-        if governance_score is None:
-            raise ServerErrorException(f'governance_score is None')
-
-        if governance_score.isInScoreBlackList(score_address):
-            raise ServerErrorException(f'SCORE in blacklist: {score_address}')
-
-    def validate_deployer(self, deployer: 'Address'):
-        """Check if a given deployer is allowed to deploy a SCORE
-
-        :param deployer: EOA address to deploy a SCORE
-        """
-        # Gets the governance SCORE
-        governance_score: 'Governance' = self.get_icon_score(GOVERNANCE_SCORE_ADDRESS)
-        if governance_score is None:
-            raise ServerErrorException(f'governance_score is None')
-
-        if not governance_score.isDeployer(deployer):
-            raise ServerErrorException(f'Invalid deployer: no permission (address: {deployer})')
-
-    def is_service_flag_on(self, flag: 'IconServiceFlag'):
-        service_flag = self._get_service_flag()
-        return self._is_flag_on(service_flag, flag)
-
-    @staticmethod
-    def _is_flag_on(src_flag: int, dst_flag: int):
-        return src_flag & dst_flag == dst_flag
-
-    def _get_service_flag(self) -> int:
-        governance_score = self.get_icon_score(GOVERNANCE_SCORE_ADDRESS)
-        if governance_score is None:
-            raise ServerErrorException(f'governance_score is None')
-
-        service_config = self.icon_service_flag
-        try:
-            service_config = governance_score.service_config
-        except AttributeError:
-            pass
-        return service_config
-
-    def get_revision(self) -> int:
-        try:
-            governance_score = self.get_icon_score(GOVERNANCE_SCORE_ADDRESS)
-            if governance_score is not None:
-                if hasattr(governance_score, 'revision_code'):
-                    return governance_score.revision_code
-        except:
-            pass
-
-        return 0
-
-    def get_tx_hashes_by_score_address(self,
-                                       context: 'IconScoreContext',
-                                       score_address: 'Address') -> Tuple[Optional[bytes], Optional[bytes]]:
-        warnings.warn("legacy function don't use.", DeprecationWarning, stacklevel=2)
-        return self.icon_score_deploy_engine.icon_deploy_storage.get_tx_hashes_by_score_address(context, score_address)
-
-    def get_score_address_by_tx_hash(self,
-                                     context: 'IconScoreContext',
-                                     tx_hash: bytes) -> Optional['Address']:
-        warnings.warn("legacy function don't use.", DeprecationWarning, stacklevel=2)
-        return self.icon_score_deploy_engine.icon_deploy_storage.get_score_address_by_tx_hash(context, tx_hash)
-
-    def enter_call(self):
-        """Start to call external function provided by other SCORE
-        """
-        if self.type != IconScoreContextType.INVOKE:
-            return
-
-        self.tx_batch.enter_call()
-
-        self.event_log_stack.append(self.event_logs)
-        self.event_logs = []
-
-    def revert_call(self):
-        """An exception happens during calling an external function provided by other SCORE
-        Revert the states changed by this function call
-        """
-        if self.type != IconScoreContextType.INVOKE:
-            return
-
-        self.tx_batch.revert_call()
-
-        self.event_logs.clear()
-
-    def leave_call(self):
-        """Finish to call external function provided by other SCORE
-        """
-        if self.type != IconScoreContextType.INVOKE:
-            return
-
-        self.tx_batch.leave_call()
-
-        prev_event_logs = self.event_log_stack.pop()
-        self.event_logs = prev_event_logs + self.event_logs
 
 
 class IconScoreContextFactory(object):

--- a/iconservice/iconscore/icon_score_context_util.py
+++ b/iconservice/iconscore/icon_score_context_util.py
@@ -1,0 +1,204 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 ICON Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import warnings
+
+from typing import TYPE_CHECKING, Optional, Tuple
+
+from ..base.address import GOVERNANCE_SCORE_ADDRESS
+from ..base.exception import ServerErrorException, InvalidParamsException
+from ..icon_constant import IconScoreContextType, DEFAULT_BYTE_SIZE, IconServiceFlag
+
+if TYPE_CHECKING:
+    from .icon_score_mapper import IconScoreMapper
+    from ..deploy.icon_score_deploy_engine import IconScoreDeployEngine
+    from .icon_score_base import IconScoreBase
+    from ..base.address import Address
+    from .icon_score_context import IconScoreContext
+
+
+class IconScoreContextUtil(object):
+    """Contains the useful information to process user's jsonrpc request
+    """
+    icon_score_mapper: 'IconScoreMapper' = None
+    icon_score_deploy_engine: 'IconScoreDeployEngine'
+    icon_service_flag: int = 0
+    legacy_tbears_mode = False
+
+    @classmethod
+    def is_score_active(cls,
+                        context: Optional['IconScoreContext'],
+                        icon_score_address: 'Address') -> bool:
+        return cls.icon_score_deploy_engine.icon_deploy_storage.is_score_active(context, icon_score_address)
+
+    @classmethod
+    def get_owner(cls,
+                  context: Optional['IconScoreContext'],
+                  icon_score_address: 'Address') -> Optional['Address']:
+        return cls.icon_score_deploy_engine.icon_deploy_storage.get_score_owner(context, icon_score_address)
+
+    @classmethod
+    def deploy(cls, context: 'IconScoreContext', tx_hash: bytes) -> None:
+        cls.icon_score_deploy_engine.deploy(context, tx_hash)
+
+    @classmethod
+    def get_icon_score(cls, context: 'IconScoreContext', address: 'Address') -> Optional['IconScoreBase']:
+        score = None
+
+        if context.type == IconScoreContextType.INVOKE:
+            if context.new_icon_score_mapper is not None:
+                score = context.new_icon_score_mapper.get(address)
+        if score is None:
+            score = cls._get_icon_score(context, address)
+
+        return score
+
+    @classmethod
+    def _get_icon_score(cls, context: 'IconScoreContext', address: 'Address') -> Optional['IconScoreBase']:
+        is_score_active = cls.icon_score_deploy_engine.icon_deploy_storage.is_score_active(context, address)
+
+        if not is_score_active:
+            raise InvalidParamsException(f'SCORE is inactive: {address}')
+
+        deploy_info = cls.icon_score_deploy_engine.icon_deploy_storage.get_deploy_info(context, address)
+        if deploy_info is None:
+            current_tx_hash = None
+        else:
+            current_tx_hash = deploy_info.current_tx_hash
+
+        if current_tx_hash is None:
+            current_tx_hash = bytes(DEFAULT_BYTE_SIZE)
+
+        return cls.icon_score_mapper.get_icon_score(address, current_tx_hash)
+
+    @classmethod
+    def try_score_package_validate(cls, address: 'Address', tx_hash: bytes):
+        cls.icon_score_mapper.try_score_package_validate(address, tx_hash)
+
+    @classmethod
+    def validate_score_blacklist(cls, context: 'IconScoreContext', score_address: 'Address'):
+        """Prevent SCOREs in blacklist
+
+        :param context:
+        :param score_address:
+        """
+        if not score_address.is_contract:
+            raise ServerErrorException(f'Invalid SCORE address: {score_address}')
+
+        # Gets the governance SCORE
+        governance_score: 'Governance' = cls.get_icon_score(context, GOVERNANCE_SCORE_ADDRESS)
+        if governance_score is None:
+            raise ServerErrorException(f'governance_score is None')
+
+        if governance_score.isInScoreBlackList(score_address):
+            raise ServerErrorException(f'SCORE in blacklist: {score_address}')
+
+    @classmethod
+    def validate_deployer(cls, context: 'IconScoreContext', deployer: 'Address'):
+        """Check if a given deployer is allowed to deploy a SCORE
+
+        :param context:
+        :param deployer: EOA address to deploy a SCORE
+        """
+        # Gets the governance SCORE
+        governance_score: 'Governance' = cls.get_icon_score(context, GOVERNANCE_SCORE_ADDRESS)
+        if governance_score is None:
+            raise ServerErrorException(f'governance_score is None')
+
+        if not governance_score.isDeployer(deployer):
+            raise ServerErrorException(f'Invalid deployer: no permission (address: {deployer})')
+
+    @classmethod
+    def is_service_flag_on(cls, context: 'IconScoreContext', flag: 'IconServiceFlag'):
+        service_flag = cls._get_service_flag(context)
+        return cls._is_flag_on(service_flag, flag)
+
+    @staticmethod
+    def _is_flag_on(src_flag: int, dst_flag: int):
+        return src_flag & dst_flag == dst_flag
+
+    @classmethod
+    def _get_service_flag(cls, context: 'IconScoreContext') -> int:
+        governance_score: 'Governance' = cls.get_icon_score(context, GOVERNANCE_SCORE_ADDRESS)
+        if governance_score is None:
+            raise ServerErrorException(f'governance_score is None')
+
+        service_config = cls.icon_service_flag
+        try:
+            service_config = governance_score.service_config
+        except AttributeError:
+            pass
+        return service_config
+
+    @classmethod
+    def get_revision(cls, context: 'IconScoreContext') -> int:
+        try:
+            governance_score: 'Governance' = cls.get_icon_score(context, GOVERNANCE_SCORE_ADDRESS)
+            if governance_score is not None:
+                if hasattr(governance_score, 'revision_code'):
+                    return governance_score.revision_code
+        except:
+            pass
+
+        return 0
+
+    @classmethod
+    def get_tx_hashes_by_score_address(cls,
+                                       context: 'IconScoreContext',
+                                       score_address: 'Address') -> Tuple[Optional[bytes], Optional[bytes]]:
+        warnings.warn("legacy function don't use.", DeprecationWarning, stacklevel=2)
+        return cls.icon_score_deploy_engine.icon_deploy_storage.get_tx_hashes_by_score_address(context, score_address)
+
+    @classmethod
+    def get_score_address_by_tx_hash(cls,
+                                     context: 'IconScoreContext',
+                                     tx_hash: bytes) -> Optional['Address']:
+        warnings.warn("legacy function don't use.", DeprecationWarning, stacklevel=2)
+        return cls.icon_score_deploy_engine.icon_deploy_storage.get_score_address_by_tx_hash(context, tx_hash)
+
+    @classmethod
+    def enter_call(cls, context: 'IconScoreContext'):
+        """Start to call external function provided by other SCORE
+        """
+        if context.type != IconScoreContextType.INVOKE:
+            return
+
+        context.tx_batch.enter_call()
+
+        context.event_log_stack.append(context.event_logs)
+        context.event_logs = []
+
+    @classmethod
+    def revert_call(cls, context: 'IconScoreContext'):
+        """An exception happens during calling an external function provided by other SCORE
+        Revert the states changed by this function call
+        """
+        if context.type != IconScoreContextType.INVOKE:
+            return
+
+        context.tx_batch.revert_call()
+        context.event_logs.clear()
+
+    @classmethod
+    def leave_call(cls, context: 'IconScoreContext'):
+        """Finish to call external function provided by other SCORE
+        """
+        if context.type != IconScoreContextType.INVOKE:
+            return
+
+        context.tx_batch.leave_call()
+
+        prev_event_logs = context.event_log_stack.pop()
+        context.event_logs = prev_event_logs + context.event_logs

--- a/iconservice/iconscore/icon_score_context_util.py
+++ b/iconservice/iconscore/icon_score_context_util.py
@@ -13,8 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import warnings
 
+import warnings
 from typing import TYPE_CHECKING, Optional, Tuple
 
 from ..base.address import GOVERNANCE_SCORE_ADDRESS
@@ -22,57 +22,50 @@ from ..base.exception import ServerErrorException, InvalidParamsException
 from ..icon_constant import IconScoreContextType, DEFAULT_BYTE_SIZE, IconServiceFlag
 
 if TYPE_CHECKING:
-    from .icon_score_mapper import IconScoreMapper
-    from ..deploy.icon_score_deploy_engine import IconScoreDeployEngine
+    from .icon_score_context import IconScoreContext
     from .icon_score_base import IconScoreBase
     from ..base.address import Address
-    from .icon_score_context import IconScoreContext
+    from ..deploy.icon_score_deploy_storage import IconScoreDeployTXParams, IconScoreDeployInfo
 
 
 class IconScoreContextUtil(object):
     """Contains the useful information to process user's jsonrpc request
     """
-    icon_score_mapper: 'IconScoreMapper' = None
-    icon_score_deploy_engine: 'IconScoreDeployEngine'
-    icon_service_flag: int = 0
-    legacy_tbears_mode = False
 
-    @classmethod
-    def is_score_active(cls,
-                        context: Optional['IconScoreContext'],
-                        icon_score_address: 'Address') -> bool:
-        return cls.icon_score_deploy_engine.icon_deploy_storage.is_score_active(context, icon_score_address)
+    @staticmethod
+    def is_score_active(context: 'IconScoreContext', icon_score_address: 'Address') -> bool:
+        return context.icon_score_deploy_engine.icon_deploy_storage.is_score_active(context, icon_score_address)
 
-    @classmethod
-    def get_owner(cls,
-                  context: Optional['IconScoreContext'],
+    @staticmethod
+    def get_owner(context: 'IconScoreContext',
                   icon_score_address: 'Address') -> Optional['Address']:
-        return cls.icon_score_deploy_engine.icon_deploy_storage.get_score_owner(context, icon_score_address)
+        return context.icon_score_deploy_engine.icon_deploy_storage.get_score_owner(context, icon_score_address)
 
-    @classmethod
-    def deploy(cls, context: 'IconScoreContext', tx_hash: bytes) -> None:
-        cls.icon_score_deploy_engine.deploy(context, tx_hash)
+    @staticmethod
+    def deploy(context: 'IconScoreContext', tx_hash: bytes) -> None:
+        context.icon_score_deploy_engine.deploy(context, tx_hash)
 
-    @classmethod
-    def get_icon_score(cls, context: 'IconScoreContext', address: 'Address') -> Optional['IconScoreBase']:
+    @staticmethod
+    def get_icon_score(context: 'IconScoreContext', address: 'Address') -> Optional['IconScoreBase']:
         score = None
 
         if context.type == IconScoreContextType.INVOKE:
-            if context.new_icon_score_mapper is not None:
-                score = context.new_icon_score_mapper.get(address)
+            score_info = context.new_icon_score_mapper.get(address)
+            if score_info:
+                score = score_info.icon_score
         if score is None:
-            score = cls._get_icon_score(context, address)
+            score = IconScoreContextUtil._get_icon_score(context, address)
 
         return score
 
-    @classmethod
-    def _get_icon_score(cls, context: 'IconScoreContext', address: 'Address') -> Optional['IconScoreBase']:
-        is_score_active = cls.icon_score_deploy_engine.icon_deploy_storage.is_score_active(context, address)
+    @staticmethod
+    def _get_icon_score(context: 'IconScoreContext', address: 'Address') -> Optional['IconScoreBase']:
+        is_score_active = context.icon_score_deploy_engine.icon_deploy_storage.is_score_active(context, address)
 
         if not is_score_active:
             raise InvalidParamsException(f'SCORE is inactive: {address}')
 
-        deploy_info = cls.icon_score_deploy_engine.icon_deploy_storage.get_deploy_info(context, address)
+        deploy_info = context.icon_score_deploy_engine.icon_deploy_storage.get_deploy_info(context, address)
         if deploy_info is None:
             current_tx_hash = None
         else:
@@ -81,14 +74,14 @@ class IconScoreContextUtil(object):
         if current_tx_hash is None:
             current_tx_hash = bytes(DEFAULT_BYTE_SIZE)
 
-        return cls.icon_score_mapper.get_icon_score(address, current_tx_hash)
+        return context.icon_score_mapper.get_icon_score(address, current_tx_hash)
 
-    @classmethod
-    def try_score_package_validate(cls, address: 'Address', tx_hash: bytes):
-        cls.icon_score_mapper.try_score_package_validate(address, tx_hash)
+    @staticmethod
+    def try_score_package_validate(context: 'IconScoreContext', address: 'Address', tx_hash: bytes) -> None:
+        context.icon_score_mapper.try_score_package_validate(address, tx_hash)
 
-    @classmethod
-    def validate_score_blacklist(cls, context: 'IconScoreContext', score_address: 'Address'):
+    @staticmethod
+    def validate_score_blacklist(context: 'IconScoreContext', score_address: 'Address') -> None:
         """Prevent SCOREs in blacklist
 
         :param context:
@@ -98,54 +91,54 @@ class IconScoreContextUtil(object):
             raise ServerErrorException(f'Invalid SCORE address: {score_address}')
 
         # Gets the governance SCORE
-        governance_score: 'Governance' = cls.get_icon_score(context, GOVERNANCE_SCORE_ADDRESS)
+        governance_score: 'Governance' = IconScoreContextUtil.get_icon_score(context, GOVERNANCE_SCORE_ADDRESS)
         if governance_score is None:
             raise ServerErrorException(f'governance_score is None')
 
         if governance_score.isInScoreBlackList(score_address):
             raise ServerErrorException(f'SCORE in blacklist: {score_address}')
 
-    @classmethod
-    def validate_deployer(cls, context: 'IconScoreContext', deployer: 'Address'):
+    @staticmethod
+    def validate_deployer(context: 'IconScoreContext', deployer: 'Address') -> None:
         """Check if a given deployer is allowed to deploy a SCORE
 
         :param context:
         :param deployer: EOA address to deploy a SCORE
         """
         # Gets the governance SCORE
-        governance_score: 'Governance' = cls.get_icon_score(context, GOVERNANCE_SCORE_ADDRESS)
+        governance_score: 'Governance' = IconScoreContextUtil.get_icon_score(context, GOVERNANCE_SCORE_ADDRESS)
         if governance_score is None:
             raise ServerErrorException(f'governance_score is None')
 
         if not governance_score.isDeployer(deployer):
             raise ServerErrorException(f'Invalid deployer: no permission (address: {deployer})')
 
-    @classmethod
-    def is_service_flag_on(cls, context: 'IconScoreContext', flag: 'IconServiceFlag'):
-        service_flag = cls._get_service_flag(context)
-        return cls._is_flag_on(service_flag, flag)
+    @staticmethod
+    def is_service_flag_on(context: 'IconScoreContext', flag: 'IconServiceFlag') -> bool:
+        service_flag = IconScoreContextUtil._get_service_flag(context)
+        return IconScoreContextUtil._is_flag_on(service_flag, flag)
 
     @staticmethod
-    def _is_flag_on(src_flag: int, dst_flag: int):
+    def _is_flag_on(src_flag: int, dst_flag: int) -> bool:
         return src_flag & dst_flag == dst_flag
 
-    @classmethod
-    def _get_service_flag(cls, context: 'IconScoreContext') -> int:
-        governance_score: 'Governance' = cls.get_icon_score(context, GOVERNANCE_SCORE_ADDRESS)
+    @staticmethod
+    def _get_service_flag(context: 'IconScoreContext') -> int:
+        governance_score: 'Governance' = IconScoreContextUtil.get_icon_score(context, GOVERNANCE_SCORE_ADDRESS)
         if governance_score is None:
             raise ServerErrorException(f'governance_score is None')
 
-        service_config = cls.icon_service_flag
+        service_config = context.icon_service_flag
         try:
             service_config = governance_score.service_config
         except AttributeError:
             pass
         return service_config
 
-    @classmethod
-    def get_revision(cls, context: 'IconScoreContext') -> int:
+    @staticmethod
+    def get_revision(context: 'IconScoreContext') -> int:
         try:
-            governance_score: 'Governance' = cls.get_icon_score(context, GOVERNANCE_SCORE_ADDRESS)
+            governance_score: 'Governance' = IconScoreContextUtil.get_icon_score(context, GOVERNANCE_SCORE_ADDRESS)
             if governance_score is not None:
                 if hasattr(governance_score, 'revision_code'):
                     return governance_score.revision_code
@@ -154,22 +147,21 @@ class IconScoreContextUtil(object):
 
         return 0
 
-    @classmethod
-    def get_tx_hashes_by_score_address(cls,
-                                       context: 'IconScoreContext',
+    @staticmethod
+    def get_tx_hashes_by_score_address(context: 'IconScoreContext',
                                        score_address: 'Address') -> Tuple[Optional[bytes], Optional[bytes]]:
         warnings.warn("legacy function don't use.", DeprecationWarning, stacklevel=2)
-        return cls.icon_score_deploy_engine.icon_deploy_storage.get_tx_hashes_by_score_address(context, score_address)
+        return context.icon_score_deploy_engine.icon_deploy_storage.get_tx_hashes_by_score_address(context,
+                                                                                                   score_address)
 
-    @classmethod
-    def get_score_address_by_tx_hash(cls,
-                                     context: 'IconScoreContext',
+    @staticmethod
+    def get_score_address_by_tx_hash(context: 'IconScoreContext',
                                      tx_hash: bytes) -> Optional['Address']:
         warnings.warn("legacy function don't use.", DeprecationWarning, stacklevel=2)
-        return cls.icon_score_deploy_engine.icon_deploy_storage.get_score_address_by_tx_hash(context, tx_hash)
+        return context.icon_score_deploy_engine.icon_deploy_storage.get_score_address_by_tx_hash(context, tx_hash)
 
-    @classmethod
-    def enter_call(cls, context: 'IconScoreContext'):
+    @staticmethod
+    def enter_call(context: 'IconScoreContext') -> None:
         """Start to call external function provided by other SCORE
         """
         if context.type != IconScoreContextType.INVOKE:
@@ -180,8 +172,8 @@ class IconScoreContextUtil(object):
         context.event_log_stack.append(context.event_logs)
         context.event_logs = []
 
-    @classmethod
-    def revert_call(cls, context: 'IconScoreContext'):
+    @staticmethod
+    def revert_call(context: 'IconScoreContext') -> None:
         """An exception happens during calling an external function provided by other SCORE
         Revert the states changed by this function call
         """
@@ -191,8 +183,8 @@ class IconScoreContextUtil(object):
         context.tx_batch.revert_call()
         context.event_logs.clear()
 
-    @classmethod
-    def leave_call(cls, context: 'IconScoreContext'):
+    @staticmethod
+    def leave_call(context: 'IconScoreContext') -> None:
         """Finish to call external function provided by other SCORE
         """
         if context.type != IconScoreContextType.INVOKE:
@@ -202,3 +194,34 @@ class IconScoreContextUtil(object):
 
         prev_event_logs = context.event_log_stack.pop()
         context.event_logs = prev_event_logs + context.event_logs
+
+    @staticmethod
+    def load_score(context: 'IconScoreContext',
+                   address: 'Address',
+                   tx_hash: bytes) -> Optional['IconScoreBase']:
+        if context.type == IconScoreContextType.INVOKE:
+            return context.new_icon_score_mapper.load_score(address, tx_hash)
+        else:
+            return context.icon_score_mapper.load_score(address, tx_hash)
+
+    @staticmethod
+    def put_score_info(context: 'IconScoreContext',
+                       address: 'Address',
+                       icon_score: 'IconScoreBase',
+                       tx_hash: bytes) -> None:
+        if context.type == IconScoreContextType.INVOKE:
+            return context.new_icon_score_mapper.put_score_info(address, icon_score, tx_hash)
+        else:
+            return context.icon_score_mapper.put_score_info(address, icon_score, tx_hash)
+
+    @staticmethod
+    def get_deploy_tx_params(context: 'IconScoreContext', tx_hash: bytes) -> Optional['IconScoreDeployTXParams']:
+        return context.icon_score_deploy_engine.icon_deploy_storage.get_deploy_tx_params(context, tx_hash)
+
+    @staticmethod
+    def get_deploy_info(context: 'IconScoreContext', address: 'Address') -> Optional['IconScoreDeployInfo']:
+        return context.icon_score_deploy_engine.icon_deploy_storage.get_deploy_info(context, address)
+
+    @staticmethod
+    def get_score_root_path(context: 'IconScoreContext') -> str:
+        return context.icon_score_mapper.score_root_path

--- a/iconservice/iconscore/icon_score_engine.py
+++ b/iconservice/iconscore/icon_score_engine.py
@@ -18,6 +18,7 @@
 
 from typing import TYPE_CHECKING
 
+from iconservice.iconscore.icon_score_context_util import IconScoreContextUtil
 from .icon_score_context import IconScoreContext, IconScoreFuncType
 from .icon_score_mapper import IconScoreMapper
 from ..base.address import Address, ZERO_SCORE_ADDRESS
@@ -70,7 +71,7 @@ class IconScoreEngine(object):
                 not icon_score_address.is_contract:
             raise InvalidParamsException(f"invalid score address: ({icon_score_address})")
 
-        context.validate_score_blacklist(icon_score_address)
+        IconScoreContextUtil.validate_score_blacklist(context, icon_score_address)
 
         if data_type == 'call':
             self._call(context, icon_score_address, data)
@@ -91,7 +92,7 @@ class IconScoreEngine(object):
                 not icon_score_address.is_contract:
             raise InvalidParamsException(f"invalid score address: ({icon_score_address})")
 
-        context.validate_score_blacklist(icon_score_address)
+        IconScoreContextUtil.validate_score_blacklist(context, icon_score_address)
 
         if data_type == 'call':
             return self._call(context, icon_score_address, data)
@@ -161,7 +162,7 @@ class IconScoreEngine(object):
 
     @staticmethod
     def _get_icon_score(context: 'IconScoreContext', icon_score_address: 'Address'):
-        icon_score = context.get_icon_score(icon_score_address)
+        icon_score = IconScoreContextUtil.get_icon_score(context, icon_score_address)
         if icon_score is None:
             raise ServerErrorException(
                 f'SCORE not found: {icon_score_address}')

--- a/iconservice/iconscore/icon_score_engine.py
+++ b/iconservice/iconscore/icon_score_engine.py
@@ -18,7 +18,7 @@
 
 from typing import TYPE_CHECKING
 
-from iconservice.iconscore.icon_score_context_util import IconScoreContextUtil
+from .icon_score_context_util import IconScoreContextUtil
 from .icon_score_context import IconScoreContext, IconScoreFuncType
 from .icon_score_mapper import IconScoreMapper
 from ..base.address import Address, ZERO_SCORE_ADDRESS

--- a/iconservice/iconscore/icon_score_mapper.py
+++ b/iconservice/iconscore/icon_score_mapper.py
@@ -132,7 +132,7 @@ class IconScoreMapper(object):
     def put_score_info(self,
                        address: 'Address',
                        icon_score: 'IconScoreBase',
-                       tx_hash: bytes):
+                       tx_hash: bytes) -> None:
         self[address] = IconScoreInfo(icon_score, tx_hash)
 
     @staticmethod

--- a/iconservice/iconscore/icon_score_mapper_object.py
+++ b/iconservice/iconscore/icon_score_mapper_object.py
@@ -91,7 +91,7 @@ class IconScoreMapperObject(dict):
                 f'{address} is not an icon score address.')
 
     @staticmethod
-    def _check_value_type(info: IconScoreInfo) -> None:
+    def _check_value_type(info: 'IconScoreInfo') -> None:
         if not isinstance(info, IconScoreInfo):
             raise InvalidParamsException(
                 f'{info} is not IconScoreInfo type.')

--- a/iconservice/iconscore/icon_system_score_base.py
+++ b/iconservice/iconscore/icon_system_score_base.py
@@ -18,7 +18,7 @@ from abc import abstractmethod
 
 from typing import TYPE_CHECKING, Optional, Type
 
-from iconservice.iconscore.icon_score_context_util import IconScoreContextUtil
+from .icon_score_context_util import IconScoreContextUtil
 from ..base.exception import ScoreErrorException
 from ..iconscore.icon_score_base import IconScoreBase
 from ..utils import is_builtin_score as util_is_builtin_score
@@ -53,6 +53,7 @@ class IconSystemScoreBase(IconScoreBase):
     def is_builtin_score(self, score_address: 'Address') -> bool:
         return util_is_builtin_score(str(score_address))
 
+    # TODO remove after Update 0.0.6
     def get_icon_service_flag(self) -> int:
         return IconScoreContextUtil.icon_service_flag
 

--- a/iconservice/iconscore/icon_system_score_base.py
+++ b/iconservice/iconscore/icon_system_score_base.py
@@ -16,9 +16,9 @@
 
 from abc import abstractmethod
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Type
 
-
+from iconservice.iconscore.icon_score_context_util import IconScoreContextUtil
 from ..base.exception import ScoreErrorException
 from ..iconscore.icon_score_base import IconScoreBase
 from ..utils import is_builtin_score as util_is_builtin_score
@@ -53,11 +53,18 @@ class IconSystemScoreBase(IconScoreBase):
     def is_builtin_score(self, score_address: 'Address') -> bool:
         return util_is_builtin_score(str(score_address))
 
+    def get_icon_service_flag(self) -> int:
+        return IconScoreContextUtil.icon_service_flag
+
+    def get_icon_score_context_util(self) -> Type['IconScoreContextUtil']:
+        return IconScoreContextUtil
+
     def get_deploy_tx_params(self, tx_hash: bytes) -> Optional['IconScoreDeployTXParams']:
-        return self._context.icon_score_deploy_engine.icon_deploy_storage.get_deploy_tx_params(self._context, tx_hash)
+        return IconScoreContextUtil.icon_score_deploy_engine.icon_deploy_storage.get_deploy_tx_params(self._context,
+                                                                                                      tx_hash)
 
     def get_deploy_info(self, address: 'Address') -> Optional['IconScoreDeployInfo']:
-        return self._context.icon_score_deploy_engine.icon_deploy_storage.get_deploy_info(self._context, address)
+        return IconScoreContextUtil.icon_score_deploy_engine.icon_deploy_storage.get_deploy_info(self._context,
+                                                                                                 address)
 
-    def get_icon_service_flag(self) -> int:
-        return self._context.icon_service_flag
+

--- a/iconservice/iconscore/icon_system_score_base.py
+++ b/iconservice/iconscore/icon_system_score_base.py
@@ -55,17 +55,14 @@ class IconSystemScoreBase(IconScoreBase):
 
     # TODO remove after Update 0.0.6
     def get_icon_service_flag(self) -> int:
-        return IconScoreContextUtil.icon_service_flag
+        return self._context.icon_service_flag
 
-    def get_icon_score_context_util(self) -> Type['IconScoreContextUtil']:
-        return IconScoreContextUtil
+    # TODO remove after Update 0.0.6
+    def deploy(self, tx_hash: bytes) -> None:
+        return IconScoreContextUtil.deploy(self._context, tx_hash)
 
     def get_deploy_tx_params(self, tx_hash: bytes) -> Optional['IconScoreDeployTXParams']:
-        return IconScoreContextUtil.icon_score_deploy_engine.icon_deploy_storage.get_deploy_tx_params(self._context,
-                                                                                                      tx_hash)
+        return IconScoreContextUtil.get_deploy_tx_params(self._context, tx_hash)
 
     def get_deploy_info(self, address: 'Address') -> Optional['IconScoreDeployInfo']:
-        return IconScoreContextUtil.icon_score_deploy_engine.icon_deploy_storage.get_deploy_info(self._context,
-                                                                                                 address)
-
-
+        return IconScoreContextUtil.get_deploy_info(self._context, address)

--- a/iconservice/iconscore/internal_call.py
+++ b/iconservice/iconscore/internal_call.py
@@ -16,14 +16,14 @@
 
 from typing import TYPE_CHECKING, Optional, Any
 
-from iconservice.base.exception import InvalidRequestException
-from iconservice.iconscore.icon_score_context_util import IconScoreContextUtil
-from ..icon_constant import ICX_TRANSFER_EVENT_LOG, MAX_CALL_STACK_SIZE, IconScoreFuncType
+from .icon_score_context_util import IconScoreContextUtil
 from .icon_score_event_log import EventLogEmitter
 from .icon_score_step import StepType
 from .icon_score_trace import Trace, TraceType
 from ..base.address import Address
+from ..base.exception import InvalidRequestException
 from ..base.message import Message
+from ..icon_constant import ICX_TRANSFER_EVENT_LOG, MAX_CALL_STACK_SIZE, IconScoreFuncType
 
 if TYPE_CHECKING:
     from .icon_score_context import IconScoreContext

--- a/iconservice/iconscore/internal_call.py
+++ b/iconservice/iconscore/internal_call.py
@@ -17,6 +17,7 @@
 from typing import TYPE_CHECKING, Optional, Any
 
 from iconservice.base.exception import InvalidRequestException
+from iconservice.iconscore.icon_score_context_util import IconScoreContextUtil
 from ..icon_constant import ICX_TRANSFER_EVENT_LOG, MAX_CALL_STACK_SIZE, IconScoreFuncType
 from .icon_score_event_log import EventLogEmitter
 from .icon_score_step import StepType
@@ -65,7 +66,7 @@ class InternalCall(object):
               kw_params: dict,
               amount: int) -> Any:
 
-        self.__context.enter_call()
+        IconScoreContextUtil.enter_call(self.__context)
 
         try:
             self._make_trace(addr_from, addr_to, func_name, arg_params, kw_params, amount)
@@ -82,10 +83,10 @@ class InternalCall(object):
 
             return None
         except BaseException as e:
-            self.__context.revert_call()
+            IconScoreContextUtil.revert_call(self.__context)
             raise e
         finally:
-            self.__context.leave_call()
+            IconScoreContextUtil.leave_call(self.__context)
 
     def _make_trace(self,
                     _from: 'Address',
@@ -125,8 +126,7 @@ class InternalCall(object):
         :param amount:
         :return:
         """
-
-        self.__context.validate_score_blacklist(addr_to)
+        IconScoreContextUtil.validate_score_blacklist(self.__context, addr_to)
 
         if len(self.__context.msg_stack) == MAX_CALL_STACK_SIZE:
             raise InvalidRequestException('Max call stack size exceeded')
@@ -138,7 +138,7 @@ class InternalCall(object):
 
         prev_func_type = self.__context.func_type
         try:
-            icon_score = self.__context.get_icon_score(addr_to)
+            icon_score = IconScoreContextUtil.get_icon_score(self.__context, addr_to)
             is_func_readonly = getattr(icon_score, '_IconScoreBase__is_func_readonly')
             if func_name is not None and is_func_readonly(func_name):
                 self.__context.func_type = IconScoreFuncType.READONLY

--- a/tests/icon_score/test_external_payable_call_method.py
+++ b/tests/icon_score/test_external_payable_call_method.py
@@ -117,7 +117,7 @@ class ChildCallClass(BaseCallClass):
 class TestExternalPayableCall(unittest.TestCase):
 
     def setUp(self):
-        IconScoreContextUtil.icon_score_deploy_engine = Mock(spec=IconScoreDeployEngine)
+        IconScoreContext.icon_score_deploy_engine = Mock(spec=IconScoreDeployEngine)
         self.context = Mock(spec=IconScoreContext)
         self.context.attach_mock(Mock(spec=Transaction), "tx")
         self.context.attach_mock(Mock(spec=Block), "block")

--- a/tests/icon_score/test_external_payable_call_method.py
+++ b/tests/icon_score/test_external_payable_call_method.py
@@ -19,6 +19,8 @@ from unittest.mock import Mock
 
 from functools import wraps
 
+from iconservice.deploy.icon_score_deploy_engine import IconScoreDeployEngine
+
 from iconservice.base.block import Block
 from iconservice.base.exception import ExceptionCode
 from iconservice.base.transaction import Transaction
@@ -26,6 +28,7 @@ from iconservice.database.db import IconScoreDatabase
 from iconservice.iconscore.icon_score_base import IconScoreBase, external, payable
 from iconservice.iconscore.icon_score_context import IconScoreContextType, IconScoreFuncType
 from iconservice.iconscore.icon_score_context import Message, ContextContainer, IconScoreContext
+from iconservice.iconscore.icon_score_context_util import IconScoreContextUtil
 
 
 def decorator(func):
@@ -114,6 +117,7 @@ class ChildCallClass(BaseCallClass):
 class TestExternalPayableCall(unittest.TestCase):
 
     def setUp(self):
+        IconScoreContextUtil.icon_score_deploy_engine = Mock(spec=IconScoreDeployEngine)
         self.context = Mock(spec=IconScoreContext)
         self.context.attach_mock(Mock(spec=Transaction), "tx")
         self.context.attach_mock(Mock(spec=Block), "block")

--- a/tests/integrate_test/test_integrate_deploy_audit_install.py
+++ b/tests/integrate_test/test_integrate_deploy_audit_install.py
@@ -36,6 +36,16 @@ class TestIntegrateDeployAuditInstall(TestIntegrateBase):
     def _make_init_config(self) -> dict:
         return {ConfigKey.SERVICE: {ConfigKey.SERVICE_AUDIT: True}}
 
+    def _update_governance_0_0_5(self):
+        tx = self._make_deploy_tx("test_builtin",
+                                  "0_0_5/governance",
+                                  self._admin,
+                                  GOVERNANCE_SCORE_ADDRESS)
+        prev_block, tx_results = self._make_and_req_block([tx])
+        self._write_precommit_state(prev_block)
+        tx_hash1 = tx_results[0].tx_hash
+        self._accept_score(tx_hash1)
+
     def _update_governance(self):
         tx = self._make_deploy_tx("test_builtin",
                                   "latest_version/governance",
@@ -116,6 +126,7 @@ class TestIntegrateDeployAuditInstall(TestIntegrateBase):
         self._write_precommit_state(prev_block)
 
     def test_score(self):
+        # self._update_governance_0_0_5()
         self._update_governance()
 
         # 1. deploy (wait audit)
@@ -149,6 +160,37 @@ class TestIntegrateDeployAuditInstall(TestIntegrateBase):
         # 5. assert get value: value2
         self._assert_get_value(self._addr_array[0], score_addr1, "get_value", value2)
 
+    def test_accept_score_with_warning_message_update_0_0_5(self):
+        # inputting message when accepting score is available as of governance version 0.0.6
+        # previous version(below 0.0.5) raise error when trying this test
+        self._update_governance_0_0_5()
+
+        # 1. deploy (wait audit)
+        value1 = 1 * self._icx_factor
+        tx_result = self._deploy_score("install/test_score", value1)
+        self.assertEqual(tx_result.status, int(True))
+        tx_hash1 = tx_result.tx_hash
+
+        # 2. accept SCORE : tx_hash1
+        tx_result = self._accept_score(tx_hash1)
+        self.assertEqual(tx_result.status, int(True))
+
+        # check warning message(as not input warning argument when call acceptScore, "" should be recorded)
+        self.assertEqual(tx_result.event_logs[0].data, [])
+
+        # 1. deploy (wait audit)
+        value1 = 1 * self._icx_factor
+        tx_result = self._deploy_score("install/test_score", value1)
+        self.assertEqual(tx_result.status, int(True))
+        tx_hash1 = tx_result.tx_hash
+
+        # 2. accept SCORE with warning message: tx_hash1
+        expected_warning_message = "test_warning_message"
+        tx_result = self._accept_score(tx_hash1, expected_warning_message)
+        self.assertEqual(tx_result.status, int(False))
+        self.assertEqual(tx_result.failure.code, ExceptionCode.SERVER_ERROR)
+        self.assertEqual(tx_result.failure.message, "acceptScore() got an unexpected keyword argument 'warning'")
+
     def test_accept_score_with_warning_message(self):
         # inputting message when accepting score is available as of governance version 0.0.6
         # previous version(below 0.0.5) raise error when trying this test
@@ -179,6 +221,25 @@ class TestIntegrateDeployAuditInstall(TestIntegrateBase):
         tx_result = self._accept_score(tx_hash1, expected_warning_message)
         self.assertEqual(tx_result.status, int(True))
         self.assertEqual(tx_result.event_logs[0].data[0], expected_warning_message)
+
+    def test_accept_score_without_warning_message_update_0_0_5(self):
+        # inputting message when accepting score is available as of governance version 0.0.6
+        # previous version(below 0.0.5) raise error when trying this test
+        self._update_governance_0_0_5()
+
+        # 1. deploy (wait audit)
+        value1 = 1 * self._icx_factor
+        tx_result = self._deploy_score("install/test_score", value1)
+        self.assertEqual(tx_result.status, int(True))
+        tx_hash1 = tx_result.tx_hash
+
+        # 2. accept SCORE : tx_hash1
+        tx_result = self._accept_score(tx_hash1)
+        self.assertEqual(tx_result.status, int(True))
+
+        # check warning message(as not input warning argument when call acceptScore, "" should be recorded)
+        expected_warning_message = ""
+        self.assertEqual(tx_result.event_logs[0].data, [])
 
     def test_accept_score_without_warning_message(self):
         # inputting message when accepting score is available as of governance version 0.0.6

--- a/tests/integrate_test/test_integrate_deploy_audit_install.py
+++ b/tests/integrate_test/test_integrate_deploy_audit_install.py
@@ -126,7 +126,6 @@ class TestIntegrateDeployAuditInstall(TestIntegrateBase):
         self._write_precommit_state(prev_block)
 
     def test_score(self):
-        # self._update_governance_0_0_5()
         self._update_governance()
 
         # 1. deploy (wait audit)

--- a/tests/integrate_test/test_samples/test_builtin/0_0_5/governance/__init__.py
+++ b/tests/integrate_test/test_samples/test_builtin/0_0_5/governance/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 ICON Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/integrate_test/test_samples/test_builtin/0_0_5/governance/package.json
+++ b/tests/integrate_test/test_samples/test_builtin/0_0_5/governance/package.json
@@ -1,0 +1,5 @@
+{
+    "version": "0.0.5",
+    "main_file": "governance",
+    "main_score": "Governance"
+}

--- a/tests/integrate_test/test_samples/test_builtin/latest_version/governance/governance.py
+++ b/tests/integrate_test/test_samples/test_builtin/latest_version/governance/governance.py
@@ -381,7 +381,7 @@ class Governance(IconSystemScoreBase):
         tmp_sender = self.msg.sender
         self.msg.sender = owner
         try:
-            self.get_icon_score_context_util().deploy(self._context, tx_hash)
+            self.deploy(tx_hash)
         finally:
             self.msg.sender = tmp_sender
 
@@ -792,7 +792,7 @@ class Governance(IconSystemScoreBase):
                     self._import_white_list_keys[i] = top
 
     def _set_initial_service_config(self):
-        self._service_config.set(self.get_icon_score_context_util().icon_service_flag | 8)
+        self._service_config.set(self.get_icon_service_flag() | 8)
 
     @external
     def updateServiceConfig(self, serviceFlag: int):

--- a/tests/test_icon_score_engine.py
+++ b/tests/test_icon_score_engine.py
@@ -21,6 +21,7 @@
 import unittest
 import os
 
+from iconservice.iconscore.icon_score_context_util import IconScoreContextUtil
 from tests import rmtree, create_address
 from iconservice.base.address import AddressPrefix
 from iconservice.base.block import Block
@@ -84,7 +85,7 @@ class TestIconScoreEngine(unittest.TestCase):
         self._icon_score_address = create_address(AddressPrefix.CONTRACT)
 
         self.factory = IconScoreContextFactory(max_size=1)
-        IconScoreContext.icon_score_deploy_engine = deploy_engine
+        IconScoreContextUtil.icon_score_deploy_engine = deploy_engine
         self._context = self.factory.create(IconScoreContextType.DIRECT)
         self._context.msg = Message(self._from, 0)
         tx_hash = create_tx_hash()

--- a/tests/test_icon_score_engine.py
+++ b/tests/test_icon_score_engine.py
@@ -85,7 +85,7 @@ class TestIconScoreEngine(unittest.TestCase):
         self._icon_score_address = create_address(AddressPrefix.CONTRACT)
 
         self.factory = IconScoreContextFactory(max_size=1)
-        IconScoreContextUtil.icon_score_deploy_engine = deploy_engine
+        IconScoreContext.icon_score_deploy_engine = deploy_engine
         self._context = self.factory.create(IconScoreContextType.DIRECT)
         self._context.msg = Message(self._from, 0)
         tx_hash = create_tx_hash()

--- a/tests/test_icon_score_event.py
+++ b/tests/test_icon_score_event.py
@@ -20,6 +20,8 @@
 import unittest
 from unittest.mock import Mock
 
+from iconservice.deploy.icon_score_deploy_engine import IconScoreDeployEngine
+
 from iconservice.icon_service_engine import IconServiceEngine
 
 from iconservice.base.address import Address, AddressPrefix
@@ -29,6 +31,7 @@ from iconservice.icon_constant import DATA_BYTE_ORDER, ICX_TRANSFER_EVENT_LOG
 from iconservice.iconscore.icon_score_base import eventlog, IconScoreBase, IconScoreDatabase, external
 from iconservice.iconscore.icon_score_context import ContextContainer, \
     IconScoreContext, IconScoreContextType, IconScoreFuncType
+from iconservice.iconscore.icon_score_context_util import IconScoreContextUtil
 from iconservice.iconscore.icon_score_step import IconScoreStepCounter
 from iconservice.icx import IcxEngine
 from iconservice.utils import int_to_bytes
@@ -44,6 +47,7 @@ class TestEventlog(unittest.TestCase):
         traces = Mock(spec=list)
         step_counter = Mock(spec=IconScoreStepCounter)
 
+        IconScoreContextUtil.icon_score_deploy_engine = Mock(spec=IconScoreDeployEngine)
         context.type = IconScoreContextType.INVOKE
         context.func_type = IconScoreFuncType.WRITABLE
         context.tx_batch = TransactionBatch()

--- a/tests/test_icon_score_event.py
+++ b/tests/test_icon_score_event.py
@@ -47,7 +47,7 @@ class TestEventlog(unittest.TestCase):
         traces = Mock(spec=list)
         step_counter = Mock(spec=IconScoreStepCounter)
 
-        IconScoreContextUtil.icon_score_deploy_engine = Mock(spec=IconScoreDeployEngine)
+        IconScoreContext.icon_score_deploy_engine = Mock(spec=IconScoreDeployEngine)
         context.type = IconScoreContextType.INVOKE
         context.func_type = IconScoreFuncType.WRITABLE
         context.tx_batch = TransactionBatch()

--- a/tests/test_icon_score_loader.py
+++ b/tests/test_icon_score_loader.py
@@ -40,7 +40,7 @@ class TestIconScoreLoader(unittest.TestCase):
         self._loader = IconScoreLoader(self._score_path)
 
         self._factory = IconScoreContextFactory(max_size=1)
-        IconScoreContextUtil.icon_score_deploy_engine = Mock()
+        IconScoreContext.icon_score_deploy_engine = Mock()
         self._context = self._factory.create(IconScoreContextType.DIRECT)
         ContextContainer._push_context(self._context)
 

--- a/tests/test_icon_score_loader.py
+++ b/tests/test_icon_score_loader.py
@@ -25,6 +25,7 @@ from iconservice.iconscore.icon_score_base import IconScoreBase
 from iconservice.iconscore.icon_score_context import ContextContainer, \
     IconScoreContextFactory, IconScoreContextType
 from iconservice.iconscore.icon_score_context import IconScoreContext
+from iconservice.iconscore.icon_score_context_util import IconScoreContextUtil
 from iconservice.iconscore.icon_score_loader import IconScoreLoader
 from tests import create_address, create_tx_hash, rmtree
 
@@ -39,7 +40,7 @@ class TestIconScoreLoader(unittest.TestCase):
         self._loader = IconScoreLoader(self._score_path)
 
         self._factory = IconScoreContextFactory(max_size=1)
-        IconScoreContext.icon_score_deploy_engine = Mock()
+        IconScoreContextUtil.icon_score_deploy_engine = Mock()
         self._context = self._factory.create(IconScoreContextType.DIRECT)
         ContextContainer._push_context(self._context)
 

--- a/tests/test_icon_service_engine.py
+++ b/tests/test_icon_service_engine.py
@@ -38,6 +38,7 @@ from iconservice.icon_service_engine import IconServiceEngine
 from iconservice.iconscore.icon_score_context import IconScoreContext
 from iconservice.iconscore.icon_score_context import IconScoreContextFactory
 from iconservice.iconscore.icon_score_context import IconScoreContextType
+from iconservice.iconscore.icon_score_context_util import IconScoreContextUtil
 from iconservice.iconscore.icon_score_result import TransactionResult
 from iconservice.iconscore.icon_score_step import IconScoreStepCounter
 from iconservice.iconscore.icon_score_step import StepType
@@ -262,7 +263,7 @@ class TestIconServiceEngine(unittest.TestCase):
 
         step_price = self._engine._get_step_price()
 
-        if IconScoreContext._is_flag_on(IconScoreContext.icon_service_flag, IconServiceFlag.fee):
+        if IconScoreContextUtil._is_flag_on(IconScoreContextUtil.icon_service_flag, IconServiceFlag.fee):
             # step_price MUST BE 10**10 on protocol v2
             self.assertEqual(step_price, 10 ** 10)
         else:
@@ -443,7 +444,7 @@ class TestIconServiceEngine(unittest.TestCase):
         self.assertEqual(tx_result.step_used, step_unit)
 
         step_price = self._engine._get_step_price()
-        if IconScoreContext._is_flag_on(IconScoreContext.icon_service_flag, IconServiceFlag.fee):
+        if IconScoreContextUtil._is_flag_on(IconScoreContextUtil.icon_service_flag, IconServiceFlag.fee):
             # step_used MUST BE 10**10 on protocol v2
             self.assertEqual(step_price, 10 ** 10)
         else:
@@ -518,7 +519,7 @@ class TestIconServiceEngine(unittest.TestCase):
         self.assertEqual(tx_result.step_used, step_cost)
 
         step_price = self._engine._get_step_price()
-        if IconScoreContext._is_flag_on(IconScoreContext.icon_service_flag, IconServiceFlag.fee):
+        if IconScoreContextUtil._is_flag_on(IconScoreContextUtil.icon_service_flag, IconServiceFlag.fee):
             # step_price MUST BE 10**10 on protocol v2
             self.assertEqual(
                 step_price, self._engine._step_counter_factory.get_step_price())
@@ -600,7 +601,7 @@ class TestIconServiceEngine(unittest.TestCase):
         self.assertEqual(tx_result.step_used, step_unit)
 
         step_price = self._engine._get_step_price()
-        if IconScoreContext._is_flag_on(IconScoreContext.icon_service_flag, IconServiceFlag.fee):
+        if IconScoreContextUtil._is_flag_on(IconScoreContextUtil.icon_service_flag, IconServiceFlag.fee):
             # step_price MUST BE 10**10 on protocol v2
             self.assertEqual(
                 step_price, self._engine._step_counter_factory.get_step_price())

--- a/tests/test_icon_service_engine.py
+++ b/tests/test_icon_service_engine.py
@@ -182,8 +182,9 @@ class TestIconServiceEngine(unittest.TestCase):
         context.event_logs = []
         context.cumulative_step_used = Mock(spec=int)
         context.cumulative_step_used.attach_mock(Mock(), '__add__')
-        context.step_counter: IconScoreStepCounter = self._engine. \
-            _step_counter_factory.create(step_limit)
+        context.step_counter: IconScoreStepCounter = self._engine._step_counter_factory.create(step_limit)
+
+        IconScoreContextUtil._get_service_flag = Mock(return_value=IconScoreContext.icon_service_flag)
         self._engine._call(context, method, params)
 
         # from(genesis), to
@@ -263,7 +264,7 @@ class TestIconServiceEngine(unittest.TestCase):
 
         step_price = self._engine._get_step_price()
 
-        if IconScoreContextUtil._is_flag_on(IconScoreContextUtil.icon_service_flag, IconServiceFlag.fee):
+        if IconScoreContextUtil._is_flag_on(IconScoreContext.icon_service_flag, IconServiceFlag.fee):
             # step_price MUST BE 10**10 on protocol v2
             self.assertEqual(step_price, 10 ** 10)
         else:
@@ -444,7 +445,7 @@ class TestIconServiceEngine(unittest.TestCase):
         self.assertEqual(tx_result.step_used, step_unit)
 
         step_price = self._engine._get_step_price()
-        if IconScoreContextUtil._is_flag_on(IconScoreContextUtil.icon_service_flag, IconServiceFlag.fee):
+        if IconScoreContextUtil._is_flag_on(IconScoreContext.icon_service_flag, IconServiceFlag.fee):
             # step_used MUST BE 10**10 on protocol v2
             self.assertEqual(step_price, 10 ** 10)
         else:
@@ -519,7 +520,7 @@ class TestIconServiceEngine(unittest.TestCase):
         self.assertEqual(tx_result.step_used, step_cost)
 
         step_price = self._engine._get_step_price()
-        if IconScoreContextUtil._is_flag_on(IconScoreContextUtil.icon_service_flag, IconServiceFlag.fee):
+        if IconScoreContextUtil._is_flag_on(IconScoreContext.icon_service_flag, IconServiceFlag.fee):
             # step_price MUST BE 10**10 on protocol v2
             self.assertEqual(
                 step_price, self._engine._step_counter_factory.get_step_price())
@@ -601,7 +602,7 @@ class TestIconServiceEngine(unittest.TestCase):
         self.assertEqual(tx_result.step_used, step_unit)
 
         step_price = self._engine._get_step_price()
-        if IconScoreContextUtil._is_flag_on(IconScoreContextUtil.icon_service_flag, IconServiceFlag.fee):
+        if IconScoreContextUtil._is_flag_on(IconScoreContext.icon_service_flag, IconServiceFlag.fee):
             # step_price MUST BE 10**10 on protocol v2
             self.assertEqual(
                 step_price, self._engine._step_counter_factory.get_step_price())

--- a/tests/test_icon_zip_deploy.py
+++ b/tests/test_icon_zip_deploy.py
@@ -37,6 +37,7 @@ from iconservice.iconscore.icon_score_context import ContextContainer
 from iconservice.iconscore.icon_score_context import IconScoreContext
 from iconservice.iconscore.icon_score_context import IconScoreContextFactory
 from iconservice.iconscore.icon_score_context import IconScoreContextType
+from iconservice.iconscore.icon_score_context_util import IconScoreContextUtil
 from iconservice.iconscore.icon_score_mapper import IconScoreMapper
 from iconservice.iconscore.icon_score_loader import IconScoreLoader
 from iconservice.icx.icx_engine import IcxEngine
@@ -79,7 +80,11 @@ class TestIconZipDeploy(unittest.TestCase):
         IconScoreMapper.deploy_storage = self._icon_deploy_storage
         self._icon_score_mapper = IconScoreMapper()
 
-        IconScoreContext.get_owner = Mock()
+        IconScoreContextUtil.validate_score_blacklist = Mock()
+        IconScoreContextUtil.get_owner = Mock()
+        IconScoreContextUtil.get_icon_score = Mock()
+        IconScoreContextUtil.is_service_flag_on = Mock()
+        IconScoreContextUtil.get_revision = Mock(return_value=False)
 
         self._engine.open(
             score_root_path=score_path,


### PR DESCRIPTION
## Overview
currently IconScoreContext class is constituted data_struct and link system SCORE API (#8)

so someone who develop SCORE can accept API function which can't use
therefore I try to refactoring code about IconScoreContext Class

TODO. Divide that class to data class and API class

### Describe
IconScoreContext : Contains the useful information to process user's jsonrpc request like invoke and query, and have tools which can access governance api

prev)
IconScoreContext <- data struct + API

after)
IconContext <- data struct
IconContextUtil <- API

IconContextUtil only have static method for using context API