### PR TITLE
Update version of packages in requirements.txt (fix #17)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-setproctitle
-hypothesis
-pytest
-plyvel
-secp256k1
+setproctitle==1.1.10
+plyvel==1.0.4
+secp256k1==0.13.2
+earlgrey>=0.0.4
+iconcommons>=1.0.5

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,8 @@ import os
 
 from setuptools import setup, find_packages
 
-requires = [
-    'earlgrey',
-    'iconcommons',
-    'plyvel',
-    'jsonpickle',
-    'setproctitle'
-]
+with open('requirements.txt') as requirements:
+    requires = list(requirements)
 
 version = os.environ.get('VERSION')
 


### PR DESCRIPTION
1. Fix package version
2. setup.py uses package list in requirements.txt as install_requires