### PR TITLE
Fix the bug that has caused when changing constant names

### DIFF
--- a/iconservice/deploy/icon_score_deploy_engine.py
+++ b/iconservice/deploy/icon_score_deploy_engine.py
@@ -89,7 +89,7 @@ class IconScoreDeployEngine(object):
         try:
             IconScoreContextUtil.validate_score_blacklist(context, icon_score_address)
 
-            if IconScoreContextUtil.is_service_flag_on(context, IconServiceFlag.DEPLOYER_WHITELIST):
+            if IconScoreContextUtil.is_service_flag_on(context, IconServiceFlag.DEPLOYER_WHITE_LIST):
                 IconScoreContextUtil.validate_deployer(context, context.tx.origin)
 
             self.write_deploy_info_and_tx_params(context, deploy_type, icon_score_address, data)

--- a/iconservice/icon_config.py
+++ b/iconservice/icon_config.py
@@ -27,7 +27,7 @@ default_icon_config = {
     ConfigKey.SERVICE: {
         ConfigKey.SERVICE_FEE: False,
         ConfigKey.SERVICE_AUDIT: False,
-        ConfigKey.SERVICE_DEPLOYER_WHITELIST: False,
+        ConfigKey.SERVICE_DEPLOYER_WHITE_LIST: False,
         ConfigKey.SERVICE_SCORE_PACKAGE_VALIDATOR: False
     }
 }

--- a/iconservice/icon_constant.py
+++ b/iconservice/icon_constant.py
@@ -59,10 +59,10 @@ REVISION_3 = 3
 class ConfigKey:
     BUILTIN_SCORE_OWNER = 'builtinScoreOwner'
     SERVICE = 'service'
-    SERVICE_FEE = 'FEE'
-    SERVICE_AUDIT = 'AUDIT'
-    SERVICE_DEPLOYER_WHITELIST = 'DEPLOYER_WHITELIST'
-    SERVICE_SCORE_PACKAGE_VALIDATOR = 'SCORE_PACKAGE_VALIDATOR'
+    SERVICE_FEE = 'fee'
+    SERVICE_AUDIT = 'audit'
+    SERVICE_DEPLOYER_WHITE_LIST = 'deployerWhiteList'
+    SERVICE_SCORE_PACKAGE_VALIDATOR = 'scorePackageValidator'
     SCORE_ROOT_PATH = 'scoreRootPath'
     STATE_DB_ROOT_PATH = 'stateDbRootPath'
     CHANNEL = 'channel'
@@ -81,7 +81,7 @@ class EnableThreadFlag(IntFlag):
 class IconServiceFlag(IntFlag):
     FEE = 1
     AUDIT = 2
-    DEPLOYER_WHITELIST = 4
+    DEPLOYER_WHITE_LIST = 4
     SCORE_PACKAGE_VALIDATOR = 8
 
 

--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -55,6 +55,7 @@ from .utils import byte_length_of_int
 from .utils import is_lowercase_hex_string
 from .utils.bloom import BloomFilter
 from .utils import sha3_256, int_to_bytes
+from .utils import to_camel_case
 
 if TYPE_CHECKING:
     from .iconscore.icon_score_step import IconScoreStepCounter
@@ -156,7 +157,8 @@ class IconServiceEngine(ContextContainer):
     def _make_service_flag(flag_table: dict) -> int:
         make_flag = 0
         for flag in IconServiceFlag:
-            is_enable = flag_table.get(flag.name, False)
+            flag_name = to_camel_case(flag.name.lower())
+            is_enable = flag_table.get(flag_name, False)
             if is_enable:
                 make_flag |= flag
         return make_flag
@@ -601,7 +603,7 @@ class IconServiceEngine(ContextContainer):
 
         context: 'IconScoreContext' = self._context_factory.create(IconScoreContextType.QUERY)
         self._validate_score_blacklist(context, params)
-        if IconScoreContextUtil.is_service_flag_on(context, IconServiceFlag.DEPLOYER_WHITELIST):
+        if IconScoreContextUtil.is_service_flag_on(context, IconServiceFlag.DEPLOYER_WHITE_LIST):
             self._validate_deployer_whitelist(context, params)
         self._context_factory.destroy(context)
 

--- a/tests/integrate_test/test_integrate_base.py
+++ b/tests/integrate_test/test_integrate_base.py
@@ -63,7 +63,7 @@ class TestIntegrateBase(TestCase):
         config.update_conf({ConfigKey.BUILTIN_SCORE_OWNER: str(self._admin)})
         config.update_conf({ConfigKey.SERVICE: {ConfigKey.SERVICE_AUDIT: False,
                                                 ConfigKey.SERVICE_FEE: False,
-                                                ConfigKey.SERVICE_DEPLOYER_WHITELIST: False,
+                                                ConfigKey.SERVICE_DEPLOYER_WHITE_LIST: False,
                                                 ConfigKey.SERVICE_SCORE_PACKAGE_VALIDATOR: False}})
         config.update_conf({ConfigKey.SCORE_ROOT_PATH: self._score_root_path,
                             ConfigKey.STATE_DB_ROOT_PATH: self._state_db_root_path})

--- a/tests/integrate_test/test_integrate_deploy_whitelist.py
+++ b/tests/integrate_test/test_integrate_deploy_whitelist.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 class TestIntegrateDeployWhiteList(TestIntegrateBase):
 
     def _make_init_config(self) -> dict:
-        return {ConfigKey.SERVICE: {ConfigKey.SERVICE_DEPLOYER_WHITELIST: True}}
+        return {ConfigKey.SERVICE: {ConfigKey.SERVICE_DEPLOYER_WHITE_LIST: True}}
 
     def _update_governance(self):
         tx = self._make_deploy_tx("test_builtin",

--- a/tests/integrate_test/test_integrate_existent_scores.py
+++ b/tests/integrate_test/test_integrate_existent_scores.py
@@ -53,7 +53,7 @@ class TestIntegrateExistentScores(TestIntegrateBase):
     def _setUp(self):
         self.config.update_conf({ConfigKey.SERVICE: {ConfigKey.SERVICE_AUDIT: False,
                                                      ConfigKey.SERVICE_FEE: False,
-                                                     ConfigKey.SERVICE_DEPLOYER_WHITELIST: False,
+                                                     ConfigKey.SERVICE_DEPLOYER_WHITE_LIST: False,
                                                      ConfigKey.SERVICE_SCORE_PACKAGE_VALIDATOR: False}})
         self.icon_service_engine = IconServiceEngine()
         self.icon_service_engine.open(self.config)

--- a/tests/integrate_test/test_integrate_existent_scores_audit.py
+++ b/tests/integrate_test/test_integrate_existent_scores_audit.py
@@ -53,7 +53,7 @@ class TestIntegrateExistentScoresAudit(TestIntegrateBase):
     def _setUp_audit(self):
         self.config.update_conf({ConfigKey.SERVICE: {ConfigKey.SERVICE_AUDIT: True,
                                                      ConfigKey.SERVICE_FEE: False,
-                                                     ConfigKey.SERVICE_DEPLOYER_WHITELIST: False,
+                                                     ConfigKey.SERVICE_DEPLOYER_WHITE_LIST: False,
                                                      ConfigKey.SERVICE_SCORE_PACKAGE_VALIDATOR: False}})
         self.icon_service_engine = IconServiceEngine()
         self.icon_service_engine.open(self.config)

--- a/tests/integrate_test/test_integrate_service_configuration_initial.py
+++ b/tests/integrate_test/test_integrate_service_configuration_initial.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 ICON Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""IconScoreEngine testcase
+"""
+from iconservice.icon_config import default_icon_config
+from iconcommons import IconConfig
+from iconservice.icon_constant import ConfigKey, IconScoreContextType
+from iconservice.icon_service_engine import IconServiceEngine
+from iconservice.icon_constant import IconServiceFlag
+from tests.integrate_test.test_integrate_base import TestIntegrateBase
+
+
+class TestIntegrateServiceConfigurationInitial(TestIntegrateBase):
+    def setUp(self):
+        self._block_height = 0
+        self._prev_block_hash = None
+        self.config = IconConfig("", default_icon_config)
+        self.config.load()
+
+        self.config.update_conf({ConfigKey.BUILTIN_SCORE_OWNER: str(self._admin)})
+        self.config.update_conf({ConfigKey.SERVICE: {ConfigKey.SERVICE_AUDIT: False,
+                                                     ConfigKey.SERVICE_FEE: False,
+                                                     ConfigKey.SERVICE_DEPLOYER_WHITE_LIST: False,
+                                                     ConfigKey.SERVICE_SCORE_PACKAGE_VALIDATOR: False}})
+        self.config.update_conf({ConfigKey.SCORE_ROOT_PATH: self._score_root_path,
+                                 ConfigKey.STATE_DB_ROOT_PATH: self._state_db_root_path})
+
+    def test_service_configuration_fee_setting(self):
+        self.config.update_conf({ConfigKey.SERVICE: {ConfigKey.SERVICE_FEE: True}})
+        self.icon_service_engine = IconServiceEngine()
+        self.icon_service_engine.open(self.config)
+
+        context = self.icon_service_engine._context_factory.create(IconScoreContextType.INVOKE)
+        self.assertEqual(context.icon_service_flag, IconServiceFlag.FEE)
+
+    def test_service_configuration_audit_setting(self):
+        self.config.update_conf({ConfigKey.SERVICE: {ConfigKey.SERVICE_AUDIT: True}})
+        self.icon_service_engine = IconServiceEngine()
+        self.icon_service_engine.open(self.config)
+
+        context = self.icon_service_engine._context_factory.create(IconScoreContextType.INVOKE)
+        self.assertEqual(context.icon_service_flag, IconServiceFlag.AUDIT)
+
+    def test_service_configuration_deployer_white_list_setting(self):
+        self.config.update_conf({ConfigKey.SERVICE: {ConfigKey.SERVICE_DEPLOYER_WHITE_LIST: True}})
+        self.icon_service_engine = IconServiceEngine()
+        self.icon_service_engine.open(self.config)
+
+        context = self.icon_service_engine._context_factory.create(IconScoreContextType.INVOKE)
+        self.assertEqual(context.icon_service_flag, IconServiceFlag.DEPLOYER_WHITE_LIST)
+
+    def test_service_configuration_score_package_validiator_setting(self):
+        self.config.update_conf({ConfigKey.SERVICE: {ConfigKey.SERVICE_SCORE_PACKAGE_VALIDATOR: True}})
+        self.icon_service_engine = IconServiceEngine()
+        self.icon_service_engine.open(self.config)
+
+        context = self.icon_service_engine._context_factory.create(IconScoreContextType.INVOKE)
+        self.assertEqual(context.icon_service_flag, IconServiceFlag.SCORE_PACKAGE_VALIDATOR)
+
+    def test_service_configuration_multiple_setting(self):
+        multiple_config = {ConfigKey.SERVICE: {ConfigKey.SERVICE_AUDIT: True,
+                                               ConfigKey.SERVICE_FEE: True,
+                                               ConfigKey.SERVICE_DEPLOYER_WHITE_LIST: True,
+                                               ConfigKey.SERVICE_SCORE_PACKAGE_VALIDATOR: True}}
+        self.config.update_conf(multiple_config)
+        self.icon_service_engine = IconServiceEngine()
+        self.icon_service_engine.open(self.config)
+
+        context = self.icon_service_engine._context_factory.create(IconScoreContextType.INVOKE)
+        expected_flag = IconServiceFlag.FEE | IconServiceFlag.AUDIT | \
+                        IconServiceFlag.SCORE_PACKAGE_VALIDATOR | IconServiceFlag.DEPLOYER_WHITE_LIST
+        self.assertEqual(context.icon_service_flag, expected_flag)

--- a/tests/test_icon_service_engine.py
+++ b/tests/test_icon_service_engine.py
@@ -124,7 +124,7 @@ class TestIconServiceEngine(unittest.TestCase):
     def test_make_flag(self):
         table = {ConfigKey.SERVICE_FEE: True,
                  ConfigKey.SERVICE_AUDIT: False,
-                 ConfigKey.SERVICE_DEPLOYER_WHITELIST: False,
+                 ConfigKey.SERVICE_DEPLOYER_WHITE_LIST: False,
                  ConfigKey.SERVICE_SCORE_PACKAGE_VALIDATOR: False}
         flag = self._engine._make_service_flag(table)
         self.assertEqual(flag, IconServiceFlag.FEE)
@@ -465,7 +465,7 @@ class TestIconServiceEngine(unittest.TestCase):
 
         table = {ConfigKey.SERVICE_FEE: True,
                  ConfigKey.SERVICE_AUDIT: False,
-                 ConfigKey.SERVICE_DEPLOYER_WHITELIST: False,
+                 ConfigKey.SERVICE_DEPLOYER_WHITE_LIST: False,
                  ConfigKey.SERVICE_SCORE_PACKAGE_VALIDATOR: False}
         # TODO: must apply the service flags to the engine
         # self._engine._flag = self._engine._make_service_flag(table)
@@ -542,7 +542,7 @@ class TestIconServiceEngine(unittest.TestCase):
 
         table = {ConfigKey.SERVICE_FEE: True,
                  ConfigKey.SERVICE_AUDIT: False,
-                 ConfigKey.SERVICE_DEPLOYER_WHITELIST: False,
+                 ConfigKey.SERVICE_DEPLOYER_WHITE_LIST: False,
                  ConfigKey.SERVICE_SCORE_PACKAGE_VALIDATOR: False}
         # TODO: must apply the service flags to the engine
         # self._engine._flag = self._engine._make_service_flag(table)


### PR DESCRIPTION
When open the icon service engine(open()), receives the config information(JSON format) and proceed config setting. When setting service config, inconsistency between camel case config name and the constant config name occurs(e.g. deployerWhiteList != DEPLOYER_WHITE_LIST), so config cannot be set properly. So solved the problem and added a unit test.