### PR TITLE
Icon score engine refactoring

### DIFF
--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -139,8 +139,7 @@ class IconServiceEngine(ContextContainer):
         IconScoreContext.legacy_tbears_mode = self._conf.get(ConfigKey.TBEARS_MODE, False)
 
         self._icx_engine.open(self._icx_storage)
-        self._icon_score_engine.open(
-            self._icx_storage, self._icon_score_mapper)
+        self._icon_score_engine.open()
         self._icon_score_deploy_engine.open(
             score_root_path=score_root_path,
             icon_deploy_storage=icon_score_deploy_storage)

--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -78,7 +78,6 @@ class IconServiceEngine(ContextContainer):
         self._icx_storage = None
         self._icx_engine = None
         self._icon_score_mapper = None
-        self._icon_score_engine = None
         self._icon_score_deploy_engine = None
         self._step_counter_factory = None
         self._icon_pre_validator = None
@@ -117,7 +116,6 @@ class IconServiceEngine(ContextContainer):
         self._context_factory = IconScoreContextFactory(max_size=5)
 
         self._icx_engine = IcxEngine()
-        self._icon_score_engine = IconScoreEngine()
         self._icon_score_deploy_engine = IconScoreDeployEngine()
 
         self._icx_context_db = ContextDatabaseFactory.create_by_name(ICON_DEX_DB_NAME)
@@ -139,7 +137,6 @@ class IconServiceEngine(ContextContainer):
         IconScoreContext.legacy_tbears_mode = self._conf.get(ConfigKey.TBEARS_MODE, False)
 
         self._icx_engine.open(self._icx_storage)
-        self._icon_score_engine.open()
         self._icon_score_deploy_engine.open(
             score_root_path=score_root_path,
             icon_deploy_storage=icon_score_deploy_storage)
@@ -669,10 +666,10 @@ class IconServiceEngine(ContextContainer):
         data = params.get('data', None)
 
         context.step_counter.apply_step(StepType.CONTRACT_CALL, 1)
-        return self._icon_score_engine.query(context,
-                                             icon_score_address,
-                                             data_type,
-                                             data)
+        return IconScoreEngine.query(context,
+                                     icon_score_address,
+                                     data_type,
+                                     data)
 
     def _handle_icx_send_transaction(self,
                                      context: 'IconScoreContext',
@@ -727,8 +724,8 @@ class IconServiceEngine(ContextContainer):
         return tx_result
 
     def _handle_estimate_step(self,
-                             context: 'IconScoreContext',
-                             params: dict) -> int:
+                              context: 'IconScoreContext',
+                              params: dict) -> int:
         """
         Handles estimate step by execution of tx
 
@@ -917,7 +914,7 @@ class IconServiceEngine(ContextContainer):
             return score_address
         else:
             context.step_counter.apply_step(StepType.CONTRACT_CALL, 1)
-            self._icon_score_engine.invoke(context, to, data_type, data)
+            IconScoreEngine.invoke(context, to, data_type, data)
             return None
 
     @staticmethod
@@ -990,7 +987,7 @@ class IconServiceEngine(ContextContainer):
         :return:
         """
         icon_score_address: Address = params['address']
-        return self._icon_score_engine.get_score_api(
+        return IconScoreEngine.get_score_api(
             context, icon_score_address)
 
     def _handle_ise_get_status(self, context: 'IconScoreContext', params: dict) -> dict:

--- a/iconservice/iconscore/icon_score_engine.py
+++ b/iconservice/iconscore/icon_score_engine.py
@@ -40,19 +40,9 @@ class IconScoreEngine(object):
         """
         super().__init__()
 
-        self.__icx_storage = None
-        self.__icon_score_mapper = None
-
-    def open(self,
-             icx_storage: 'IcxStorage',
-             icon_score_mapper: 'IconScoreMapper') -> None:
+    def open(self) -> None:
         """open
-
-        :param icx_storage: Get IconScore owner info from icx_storage
-        :param icon_score_mapper:
         """
-        self.__icx_storage = icx_storage
-        self.__icon_score_mapper = icon_score_mapper
 
     def invoke(self,
                context: 'IconScoreContext',

--- a/tests/test_icon_score_engine.py
+++ b/tests/test_icon_score_engine.py
@@ -77,9 +77,7 @@ class TestIconScoreEngine(unittest.TestCase):
         self.icon_score_mapper = IconScoreMapper()
 
         self.engine = IconScoreEngine()
-        self.engine.open(
-            self.icx_storage,
-            self.icon_score_mapper)
+        self.engine.open()
 
         self._from = create_address(AddressPrefix.EOA)
         self._icon_score_address = create_address(AddressPrefix.CONTRACT)

--- a/tests/test_icon_score_engine.py
+++ b/tests/test_icon_score_engine.py
@@ -77,7 +77,6 @@ class TestIconScoreEngine(unittest.TestCase):
         self.icon_score_mapper = IconScoreMapper()
 
         self.engine = IconScoreEngine()
-        self.engine.open()
 
         self._from = create_address(AddressPrefix.EOA)
         self._icon_score_address = create_address(AddressPrefix.CONTRACT)

--- a/tests/test_icon_score_result.py
+++ b/tests/test_icon_score_result.py
@@ -49,9 +49,6 @@ class TestTransactionResult(unittest.TestCase):
         self._icon_service_engine._icon_score_deploy_engine = \
             Mock(spec=IconScoreDeployEngine)
 
-        self._icon_service_engine._icon_score_engine = \
-            Mock(spec=IconScoreEngine)
-
         self._icon_service_engine._charge_transaction_fee = \
             Mock(return_value=(0, 0))
 
@@ -93,6 +90,7 @@ class TestTransactionResult(unittest.TestCase):
             'timestamp': 1234567890,
             'nonce': 1
         }
+        self._icon_service_engine._process_transaction = Mock(return_value=None)
 
         tx_result = self._icon_service_engine._handle_icx_send_transaction(
             self._mock_context, params)
@@ -109,10 +107,7 @@ class TestTransactionResult(unittest.TestCase):
     def test_tx_failure(self):
         self._icon_service_engine._icon_score_deploy_engine.attach_mock(
             Mock(return_value=False), 'is_data_type_supported')
-
-        self._icon_service_engine._icon_score_engine. \
-            attach_mock(Mock(side_effect=IconServiceBaseException("error")),
-                        "invoke")
+        IconScoreEngine.invoke = Mock(side_effect=IconServiceBaseException("error"))
 
         from_ = Mock(spec=Address)
         to_ = Mock(spec=Address)
@@ -234,8 +229,7 @@ class TestTransactionResult(unittest.TestCase):
             address = create_address(AddressPrefix.EOA, b'address')
             score.SampleEvent(b'i_data', address, 10, b'data', 'text')
 
-        inner_task._icon_service_engine._icon_score_engine.invoke = \
-            Mock(side_effect=intercept_invoke)
+        IconScoreEngine.invoke = Mock(side_effect=intercept_invoke)
         inner_task._icon_service_engine._validate_score_blacklist = Mock()
 
         from_ = create_address(AddressPrefix.EOA, b'from')

--- a/tests/test_icon_score_step.py
+++ b/tests/test_icon_score_step.py
@@ -18,6 +18,8 @@ import unittest
 from typing import Optional
 from unittest.mock import Mock
 
+from iconservice.iconscore.icon_score_context_util import IconScoreContextUtil
+from iconservice.iconscore.icon_score_engine import IconScoreEngine
 from iconservice import VarDB
 from iconservice.base.address import AddressPrefix, Address
 from iconservice.builtin_scores.governance import governance
@@ -155,14 +157,13 @@ class TestIconScoreStepCounter(unittest.TestCase):
             score = SampleScore(IconScoreDatabase(to_, context_db))
             score.transfer()
 
-        score_engine_invoke = Mock(side_effect=intercept_invoke)
+        IconScoreContextUtil.validate_score_blacklist = Mock()
         self._inner_task._icon_service_engine._validate_score_blacklist = Mock()
-        self._inner_task._icon_service_engine. \
-            _icon_score_engine.invoke = score_engine_invoke
+        IconScoreEngine.invoke = Mock(side_effect=intercept_invoke)
 
         self._inner_task._icon_service_engine._icon_score_mapper.get_icon_score = Mock(return_value=None)
         result = self._inner_task_invoke(request)
-        score_engine_invoke.assert_called()
+        IconScoreEngine.invoke.assert_called()
 
         self.assertEqual(result['txResults'][tx_hash]['status'], '0x1')
 
@@ -194,10 +195,8 @@ class TestIconScoreStepCounter(unittest.TestCase):
             score = SampleScore(IconScoreDatabase(to_, context_db))
             score.set_db(100)
 
-        score_engine_invoke = Mock(side_effect=intercept_invoke)
         self._inner_task._icon_service_engine._validate_score_blacklist = Mock()
-        self._inner_task._icon_service_engine. \
-            _icon_score_engine.invoke = score_engine_invoke
+        IconScoreEngine.invoke = Mock(side_effect=intercept_invoke)
 
         self._inner_task._icon_service_engine._icon_score_mapper.get_icon_score = Mock(return_value=None)
         # for StepType.SET
@@ -206,7 +205,7 @@ class TestIconScoreStepCounter(unittest.TestCase):
         # for StepType.REPLACE
         result = self._inner_task_invoke(request)
         self.assertEqual(result['txResults'][tx_hash]['status'], '0x1')
-        score_engine_invoke.assert_called()
+        IconScoreEngine.invoke.assert_called()
 
         self.assertEqual(self.step_counter.apply_step.call_args_list[0][0],
                          (StepType.DEFAULT, 1))
@@ -250,14 +249,12 @@ class TestIconScoreStepCounter(unittest.TestCase):
             score = SampleScore(IconScoreDatabase(to_, context_db))
             score.get_db()
 
-        score_engine_invoke = Mock(side_effect=intercept_invoke)
         self._inner_task._icon_service_engine._validate_score_blacklist = Mock()
-        self._inner_task._icon_service_engine. \
-            _icon_score_engine.invoke = score_engine_invoke
+        IconScoreEngine.invoke = Mock(side_effect=intercept_invoke)
 
         self._inner_task._icon_service_engine._icon_score_mapper.get_icon_score = Mock(return_value=None)
         result = self._inner_task_invoke(request)
-        score_engine_invoke.assert_called()
+        IconScoreEngine.invoke.assert_called()
 
         self.assertEqual(result['txResults'][tx_hash]['status'], '0x1')
 
@@ -292,20 +289,18 @@ class TestIconScoreStepCounter(unittest.TestCase):
             _icx_context_db.get = Mock(return_value=b'1' * 100)
 
         # noinspection PyUnusedLocal
-        def intercept_invoke(*args, **kwargs):
+        def intercept_query(*args, **kwargs):
             ContextContainer._push_context(args[0])
             context_db = self._inner_task._icon_service_engine._icx_context_db
             score = SampleScore(IconScoreDatabase(to_, context_db))
             return score.query_db()
 
-        score_engine_invoke = Mock(side_effect=intercept_invoke)
         self._inner_task._icon_service_engine._validate_score_blacklist = Mock()
-        self._inner_task._icon_service_engine. \
-            _icon_score_engine.query = score_engine_invoke
+        IconScoreEngine.query = Mock(side_effect=intercept_query)
 
         self._inner_task._icon_service_engine._icon_score_mapper.get_icon_score = Mock(return_value=None)
         result = self._inner_task._query(request)
-        score_engine_invoke.assert_called()
+        IconScoreEngine.query.assert_called()
 
         self.assertIsNotNone(result)
 
@@ -332,14 +327,12 @@ class TestIconScoreStepCounter(unittest.TestCase):
             score = SampleScore(IconScoreDatabase(to_, context_db))
             score.remove_db()
 
-        score_engine_invoke = Mock(side_effect=intercept_invoke)
         self._inner_task._icon_service_engine._validate_score_blacklist = Mock()
-        self._inner_task._icon_service_engine. \
-            _icon_score_engine.invoke = score_engine_invoke
+        IconScoreEngine.invoke = Mock(side_effect=intercept_invoke)
 
         self._inner_task._icon_service_engine._icon_score_mapper.get_icon_score = Mock(return_value=None)
         result = self._inner_task_invoke(request)
-        score_engine_invoke.assert_called()
+        IconScoreEngine.invoke.assert_called()
 
         self.assertEqual(result['txResults'][tx_hash]['status'], '0x1')
 
@@ -385,14 +378,12 @@ class TestIconScoreStepCounter(unittest.TestCase):
                 len(data_param) + \
                 len(text_param.encode('utf-8'))
 
-        score_engine_invoke = Mock(side_effect=intercept_invoke)
-        self._inner_task._icon_service_engine. \
-            _icon_score_engine.invoke = score_engine_invoke
-
         self._inner_task._icon_service_engine._validate_score_blacklist = Mock()
+        IconScoreEngine.invoke = Mock(side_effect=intercept_invoke)
 
+        self._inner_task._icon_service_engine._icon_score_mapper.get_icon_score = Mock(return_value=None)
         result = self._inner_task_invoke(request)
-        score_engine_invoke.assert_called()
+        IconScoreEngine.invoke.assert_called()
 
         self.assertEqual(result['txResults'][tx_hash]['status'], '0x1')
 
@@ -429,14 +420,12 @@ class TestIconScoreStepCounter(unittest.TestCase):
             score = SampleScore(IconScoreDatabase(to_, context_db))
             score.hash_readonly(data_to_hash)
 
-        score_engine_invoke = Mock(side_effect=intercept_invoke)
         self._inner_task._icon_service_engine._validate_score_blacklist = Mock()
-        self._inner_task._icon_service_engine. \
-            _icon_score_engine.invoke = score_engine_invoke
+        IconScoreEngine.invoke = Mock(side_effect=intercept_invoke)
 
         self._inner_task._icon_service_engine._icon_score_mapper.get_icon_score = Mock(return_value=None)
         result = self._inner_task_invoke(request)
-        score_engine_invoke.assert_called()
+        IconScoreEngine.invoke.assert_called()
 
         self.assertEqual(result['txResults'][tx_hash]['status'], '0x1')
 
@@ -470,14 +459,12 @@ class TestIconScoreStepCounter(unittest.TestCase):
             score = SampleScore(IconScoreDatabase(to_, context_db))
             score.hash_writable(data_to_hash)
 
-        score_engine_invoke = Mock(side_effect=intercept_invoke)
         self._inner_task._icon_service_engine._validate_score_blacklist = Mock()
-        self._inner_task._icon_service_engine. \
-            _icon_score_engine.invoke = score_engine_invoke
+        IconScoreEngine.invoke = Mock(side_effect=intercept_invoke)
 
         self._inner_task._icon_service_engine._icon_score_mapper.get_icon_score = Mock(return_value=None)
         result = self._inner_task_invoke(request)
-        score_engine_invoke.assert_called()
+        IconScoreEngine.invoke.assert_called()
 
         self.assertEqual(result['txResults'][tx_hash]['status'], '0x1')
 
@@ -509,10 +496,8 @@ class TestIconScoreStepCounter(unittest.TestCase):
             score = SampleScore(IconScoreDatabase(to_, context_db))
             score.hash_writable(b'1234')
 
-        score_engine_invoke = Mock(side_effect=intercept_invoke)
         self._inner_task._icon_service_engine._validate_score_blacklist = Mock()
-        self._inner_task._icon_service_engine. \
-            _icon_score_engine.invoke = score_engine_invoke
+        IconScoreEngine.invoke = Mock(side_effect=intercept_invoke)
 
         raw_step_costs = {
             governance.STEP_TYPE_DEFAULT: 4000,

--- a/tests/test_icon_score_trace.py
+++ b/tests/test_icon_score_trace.py
@@ -142,8 +142,6 @@ class TestTrace(unittest.TestCase):
         self._icon_service_engine._icon_score_deploy_engine = \
             Mock(spec=IconScoreDeployEngine)
 
-        self._icon_service_engine._icon_score_engine = Mock(
-            spec=IconScoreEngine)
         self._icon_service_engine._icon_pre_validator = Mock(
             spec=IconPreValidator)
         context.tx_batch = TransactionBatch()
@@ -163,8 +161,7 @@ class TestTrace(unittest.TestCase):
         reason = Mock(spec=str)
         code = ExceptionCode.SCORE_ERROR
         mock_revert = Mock(side_effect=RevertException(reason))
-        self._icon_service_engine._icon_score_engine.attach_mock(
-            mock_revert, "invoke")
+        IconScoreEngine.invoke = Mock(side_effect=mock_revert)
 
         raise_exception_start_tag("test_revert")
         tx_result = self._icon_service_engine._handle_icx_send_transaction(
@@ -189,8 +186,6 @@ class TestTrace(unittest.TestCase):
         self._icon_service_engine._icon_score_deploy_engine = \
             Mock(spec=IconScoreDeployEngine)
 
-        self._icon_service_engine._icon_score_engine = Mock(
-            spec=IconScoreEngine)
         self._icon_service_engine._icon_pre_validator = Mock(
             spec=IconPreValidator)
         context.tx_batch = TransactionBatch()
@@ -210,8 +205,7 @@ class TestTrace(unittest.TestCase):
         error = Mock(spec=str)
         code = ExceptionCode.SCORE_ERROR
         mock_exception = Mock(side_effect=IconScoreException(error, code))
-        self._icon_service_engine._icon_score_engine.attach_mock(
-            mock_exception, "invoke")
+        IconScoreEngine.invoke = Mock(side_effect=mock_exception)
 
         raise_exception_start_tag("test_throw")
         tx_result = self._icon_service_engine._handle_icx_send_transaction(


### PR DESCRIPTION
1. Remove __icx_storage and __icon_score_mapper because of not being used anymore.
2. Make all icon score engine's functions as static. Detach Icon score engine from icon service engine. 
3. Modify unit tests which had been failed after refactoring icon_score_engine.