### PR TITLE
Remove iconscorecontextfactory

### DIFF
--- a/iconservice/iconscore/icon_score_context.py
+++ b/iconservice/iconscore/icon_score_context.py
@@ -173,32 +173,3 @@ class IconScoreContext(object):
     def deploy(self, tx_hash: bytes) -> None:
         warnings.warn("legacy function don't use.", DeprecationWarning, stacklevel=2)
         self.icon_score_deploy_engine.deploy(self, tx_hash)
-
-
-class IconScoreContextFactory(object):
-    """IconScoreContextFactory
-    """
-
-    def __init__(self, max_size: int) -> None:
-        """Constructor
-        """
-        self._lock = threading.Lock()
-        self._queue = []
-        self._max_size = max_size
-
-    def create(self,
-               context_type: 'IconScoreContextType') -> 'IconScoreContext':
-        with self._lock:
-            if len(self._queue) > 0:
-                context = self._queue.pop()
-                context.type = context_type
-            else:
-                context = IconScoreContext(context_type)
-
-        return context
-
-    def destroy(self, context: 'IconScoreContext') -> None:
-        with self._lock:
-            if len(self._queue) < self._max_size:
-                context.clear()
-                self._queue.append(context)

--- a/iconservice/iconscore/icon_score_context.py
+++ b/iconservice/iconscore/icon_score_context.py
@@ -18,7 +18,15 @@ import threading
 import warnings
 from typing import TYPE_CHECKING, Optional, List
 
+from .icon_score_event_log import EventLog
+from .icon_score_step import IconScoreStepCounter
+from .icon_score_trace import Trace
+from ..base.address import Address
+from ..base.block import Block
 from ..base.exception import ServerErrorException
+from ..base.message import Message
+from ..base.transaction import Transaction
+from ..database.batch import BlockBatch, TransactionBatch
 from ..icon_constant import IconScoreContextType, IconScoreFuncType
 
 if TYPE_CHECKING:
@@ -101,7 +109,17 @@ class IconScoreContext(object):
         self.type: IconScoreContextType = context_type
         # The type of external function which is called latest
         self.func_type: IconScoreFuncType = IconScoreFuncType.WRITABLE
+        self.block: 'Block' = None
+        self.tx: 'Transaction' = None
+        self.msg: 'Message' = None
+        self.current_address: 'Address' = None
+        self.block_batch: 'BlockBatch' = None
+        self.tx_batch: 'TransactionBatch' = None
+        self.new_icon_score_mapper: 'IconScoreMapper' = None
         self.cumulative_step_used: int = 0
+        self.step_counter: 'IconScoreStepCounter' = None
+        self.event_logs: List['EventLog'] = None
+        self.traces: List['Trace'] = None
 
         self.msg_stack = []
         self.event_log_stack = []

--- a/iconservice/iconscore/icon_score_context.py
+++ b/iconservice/iconscore/icon_score_context.py
@@ -18,19 +18,11 @@ import threading
 import warnings
 from typing import TYPE_CHECKING, Optional, List
 
-from .icon_score_trace import Trace
-from ..base.block import Block
 from ..base.exception import ServerErrorException
-from ..base.message import Message
-from ..base.transaction import Transaction
-from ..database.batch import BlockBatch, TransactionBatch
 from ..icon_constant import IconScoreContextType, IconScoreFuncType
 
 if TYPE_CHECKING:
     from .icon_score_mapper import IconScoreMapper
-    from .icon_score_step import IconScoreStepCounter
-    from .icon_score_event_log import EventLog
-    from ..base.address import Address
     from ..deploy.icon_score_deploy_engine import IconScoreDeployEngine
     from .icon_score_base import IconScoreBase
     from ..icx.icx_engine import IcxEngine
@@ -101,39 +93,15 @@ class IconScoreContext(object):
     """Contains the useful information to process user's jsonrpc request
     """
 
-    def __init__(self,
-                 context_type: 'IconScoreContextType' = IconScoreContextType.QUERY,
-                 func_type: 'IconScoreFuncType' = IconScoreFuncType.WRITABLE,
-                 block: 'Block' = None,
-                 tx: 'Transaction' = None,
-                 msg: 'Message' = None,
-                 block_batch: 'BlockBatch' = None,
-                 tx_batch: 'TransactionBatch' = None,
-                 new_icon_score_mapper: 'IconScoreMapper' = None) -> None:
+    def __init__(self, context_type: 'IconScoreContextType' = IconScoreContextType.QUERY) -> None:
         """Constructor
 
         :param context_type: IconScoreContextType.GENESIS, INVOKE, QUERY
-        :param func_type: IconScoreFuncType (READONLY, WRITABLE)
-        :param block:
-        :param tx: initial transaction info
-        :param msg: message call info
-        :param block_batch:
-        :param tx_batch:
         """
         self.type: IconScoreContextType = context_type
         # The type of external function which is called latest
-        self.func_type: IconScoreFuncType = func_type
-        self.block = block
-        self.tx = tx
-        self.msg = msg
-        self.current_address: 'Address' = None
-        self.block_batch = block_batch
-        self.tx_batch = tx_batch
-        self.new_icon_score_mapper = new_icon_score_mapper
+        self.func_type: IconScoreFuncType = IconScoreFuncType.WRITABLE
         self.cumulative_step_used: int = 0
-        self.step_counter: 'IconScoreStepCounter' = None
-        self.event_logs: List['EventLog'] = None
-        self.traces: List['Trace'] = None
 
         self.msg_stack = []
         self.event_log_stack = []
@@ -142,25 +110,6 @@ class IconScoreContext(object):
     def readonly(self):
         return self.type == IconScoreContextType.QUERY or \
                self.func_type == IconScoreFuncType.READONLY
-
-    def clear(self) -> None:
-        """Set instance member variables to None
-        """
-        self.block = None
-        self.tx = None
-        self.msg = None
-        self.current_address: 'Address' = None
-        self.block_batch = None
-        self.tx_batch = None
-        self.new_icon_score_mapper = None
-        self.cumulative_step_used = 0
-        self.step_counter = None
-        self.event_logs = None
-        self.traces = None
-        self.func_type = IconScoreFuncType.WRITABLE
-
-        self.msg_stack.clear()
-        self.event_log_stack.clear()
 
     def set_func_type_by_icon_score(self, icon_score: 'IconScoreBase', func_name: str):
         is_func_readonly = getattr(icon_score, '_IconScoreBase__is_func_readonly')

--- a/iconservice/iconscore/icon_score_context.py
+++ b/iconservice/iconscore/icon_score_context.py
@@ -18,10 +18,7 @@ import threading
 import warnings
 from typing import TYPE_CHECKING, Optional, List
 
-from .icon_score_event_log import EventLog
-from .icon_score_step import IconScoreStepCounter
 from .icon_score_trace import Trace
-from ..base.address import Address
 from ..base.block import Block
 from ..base.exception import ServerErrorException
 from ..base.message import Message
@@ -31,10 +28,12 @@ from ..icon_constant import IconScoreContextType, IconScoreFuncType
 
 if TYPE_CHECKING:
     from .icon_score_mapper import IconScoreMapper
+    from .icon_score_event_log import EventLog
+    from .icon_score_step import IconScoreStepCounter
+    from ..base.address import Address
     from ..deploy.icon_score_deploy_engine import IconScoreDeployEngine
     from .icon_score_base import IconScoreBase
     from ..icx.icx_engine import IcxEngine
-
 
 _thread_local_data = threading.local()
 

--- a/tests/database/test_db_db.py
+++ b/tests/database/test_db_db.py
@@ -25,8 +25,7 @@ from iconservice.database.db import ContextDatabase
 from iconservice.database.db import IconScoreDatabase
 from iconservice.database.db import KeyValueDatabase
 from iconservice.icon_constant import DATA_BYTE_ORDER
-from iconservice.iconscore.icon_score_context import IconScoreContextFactory
-from iconservice.iconscore.icon_score_context import IconScoreContextType
+from iconservice.iconscore.icon_score_context import IconScoreContextType, IconScoreContext
 from iconservice.iconscore.icon_score_context import IconScoreFuncType
 from tests import rmtree
 
@@ -75,16 +74,14 @@ class TestContextDatabaseOnWriteMode(unittest.TestCase):
         os.mkdir(state_db_root_path)
 
         address = Address.from_data(AddressPrefix.CONTRACT, b'score')
-        context_factory = IconScoreContextFactory(max_size=2)
 
-        context = context_factory.create(IconScoreContextType.INVOKE)
+        context = IconScoreContext(IconScoreContextType.INVOKE)
         context.block_batch = BlockBatch()
         context.tx_batch = TransactionBatch()
 
         db_path = os.path.join(state_db_root_path, 'db')
         context_db = ContextDatabase.from_path(db_path, True)
 
-        self.context_factory = context_factory
         self.context_db = context_db
         self.address = address
         self.context = context
@@ -92,7 +89,6 @@ class TestContextDatabaseOnWriteMode(unittest.TestCase):
     def tearDown(self):
         self.context.func_type = IconScoreFuncType.WRITABLE
         self.context_db.close(self.context)
-        self.context_factory.destroy(self.context)
         rmtree(self.state_db_root_path)
 
     def test_put_and_get(self):
@@ -215,14 +211,12 @@ class TestIconScoreDatabase(unittest.TestCase):
         os.mkdir(state_db_root_path)
 
         address = Address.from_data(AddressPrefix.CONTRACT, b'0')
-        context_factory = IconScoreContextFactory(max_size=2)
 
         db_path = os.path.join(state_db_root_path, 'db')
         context_db = ContextDatabase.from_path(db_path, True)
 
         self.db = IconScoreDatabase(address, context_db=context_db, prefix=b'')
         self.address = address
-        self.context_factory = context_factory
 
     def tearDown(self):
         self.db.close()

--- a/tests/icon_score/test_external_payable_call_method.py
+++ b/tests/icon_score/test_external_payable_call_method.py
@@ -15,20 +15,18 @@
 # limitations under the License.
 
 import unittest
-from unittest.mock import Mock
-
 from functools import wraps
-
-from iconservice.deploy.icon_score_deploy_engine import IconScoreDeployEngine
+from unittest.mock import Mock
 
 from iconservice.base.block import Block
 from iconservice.base.exception import ExceptionCode
+from iconservice.base.message import Message
 from iconservice.base.transaction import Transaction
 from iconservice.database.db import IconScoreDatabase
+from iconservice.deploy.icon_score_deploy_engine import IconScoreDeployEngine
 from iconservice.iconscore.icon_score_base import IconScoreBase, external, payable
+from iconservice.iconscore.icon_score_context import ContextContainer, IconScoreContext
 from iconservice.iconscore.icon_score_context import IconScoreContextType, IconScoreFuncType
-from iconservice.iconscore.icon_score_context import Message, ContextContainer, IconScoreContext
-from iconservice.iconscore.icon_score_context_util import IconScoreContextUtil
 
 
 def decorator(func):

--- a/tests/icon_score/test_icon_container_db.py
+++ b/tests/icon_score/test_icon_container_db.py
@@ -18,11 +18,11 @@ import unittest
 
 from iconservice import Address
 from iconservice.database.db import ContextDatabase, IconScoreDatabase
-from iconservice.iconscore.icon_score_context import IconScoreContextType
+from iconservice.iconscore.icon_score_context import IconScoreContextType, IconScoreContext
 from iconservice.base.address import AddressPrefix
 from iconservice.base.exception import ContainerDBException
 from iconservice.iconscore.icon_container_db import ContainerUtil, DictDB, ArrayDB, VarDB
-from iconservice.iconscore.icon_score_context import ContextContainer, IconScoreContextFactory
+from iconservice.iconscore.icon_score_context import ContextContainer
 from tests import create_address
 from tests.mock_db import MockKeyValueDatabase
 
@@ -31,8 +31,7 @@ class TestIconContainerDB(unittest.TestCase):
 
     def setUp(self):
         self.db = self.create_db()
-        self._factory = IconScoreContextFactory(max_size=1)
-        self._context = self._factory.create(IconScoreContextType.DIRECT)
+        self._context = IconScoreContext(IconScoreContextType.DIRECT)
 
         ContextContainer._push_context(self._context)
         pass

--- a/tests/icx/test_icx_engine.py
+++ b/tests/icx/test_icx_engine.py
@@ -20,8 +20,7 @@ import unittest
 
 from iconservice.base.address import Address, MalformedAddress
 from iconservice.database.db import ContextDatabase
-from iconservice.iconscore.icon_score_context import ContextContainer
-from iconservice.iconscore.icon_score_context import IconScoreContextFactory
+from iconservice.iconscore.icon_score_context import ContextContainer, IconScoreContext
 from iconservice.iconscore.icon_score_context import IconScoreContextType
 from iconservice.icx.icx_account import AccountType
 from iconservice.icx.icx_engine import IcxEngine
@@ -40,8 +39,7 @@ class TestIcxEngine(unittest.TestCase, ContextContainer):
         self.fee_treasury_address = Address.from_string('hx' + '1' * 40)
         self.total_supply = 10 ** 20  # 100 icx
 
-        self.factory = IconScoreContextFactory(max_size=1)
-        self.context = self.factory.create(IconScoreContextType.DIRECT)
+        self.context = IconScoreContext(IconScoreContextType.DIRECT)
 
         icx_storage = IcxStorage(db)
         self.engine.open(icx_storage)
@@ -56,7 +54,6 @@ class TestIcxEngine(unittest.TestCase, ContextContainer):
     def tearDown(self):
         self._clear_context()
         self.engine.close()
-        self.factory.destroy(self.context)
 
         # Remove a state db for test
         shutil.rmtree(self.db_name)
@@ -119,8 +116,7 @@ class TestIcxEngineForMalformedAddress(unittest.TestCase, ContextContainer):
         self.fee_treasury_address = Address.from_string('hx' + '1' * 40)
         self.total_supply = 10 ** 20  # 100 icx
 
-        self.factory = IconScoreContextFactory(max_size=1)
-        self.context = self.factory.create(IconScoreContextType.DIRECT)
+        self.context = IconScoreContext(IconScoreContextType.DIRECT)
 
         icx_storage = IcxStorage(db)
         self.engine.open(icx_storage)
@@ -135,7 +131,6 @@ class TestIcxEngineForMalformedAddress(unittest.TestCase, ContextContainer):
     def tearDown(self):
         self.engine.close()
         self.engine = None
-        self.factory.destroy(self.context)
 
         # Remove a state db for test
         shutil.rmtree(self.db_name)

--- a/tests/icx/test_icx_storage.py
+++ b/tests/icx/test_icx_storage.py
@@ -22,8 +22,7 @@ import unittest
 from iconservice.base.address import AddressPrefix, MalformedAddress
 from iconservice.database.batch import BlockBatch, TransactionBatch
 from iconservice.database.db import ContextDatabase
-from iconservice.iconscore.icon_score_context import IconScoreContextFactory
-from iconservice.iconscore.icon_score_context import IconScoreContextType
+from iconservice.iconscore.icon_score_context import IconScoreContextType, IconScoreContext
 from iconservice.icx.icx_account import Account
 from iconservice.icx.icx_storage import IcxStorage
 from tests import create_address
@@ -38,8 +37,7 @@ class TestIcxStorage(unittest.TestCase):
 
         self.storage = IcxStorage(db)
 
-        self.factory = IconScoreContextFactory(max_size=1)
-        context = self.factory.create(IconScoreContextType.DIRECT)
+        context = IconScoreContext(IconScoreContextType.DIRECT)
         context.tx_batch = TransactionBatch()
         context.block_batch = BlockBatch()
         self.context = context
@@ -97,8 +95,7 @@ class TestIcxStorageForMalformedAddress(unittest.TestCase):
 
         self.storage = IcxStorage(db)
 
-        self.factory = IconScoreContextFactory(max_size=1)
-        context = self.factory.create(IconScoreContextType.DIRECT)
+        context = IconScoreContext(IconScoreContextType.DIRECT)
         self.context = context
 
     def tearDown(self):

--- a/tests/test_icon_score_context.py
+++ b/tests/test_icon_score_context.py
@@ -19,35 +19,19 @@ import unittest
 
 from iconservice.iconscore.icon_score_context import IconScoreContext
 from iconservice.iconscore.icon_score_context import IconScoreContextType
-from iconservice.iconscore.icon_score_context import IconScoreContextFactory
 
 
 class TestIconScoreContextFactory(unittest.TestCase):
-    def setUp(self):
-        self.factory = IconScoreContextFactory(max_size=2)
-
-    def tearDown(self):
-        self.factory = None
 
     def test_create_and_destroy(self):
-        factory = self.factory
-        self.assertEqual(0, len(factory._queue))
 
         for _ in range(3):
-            context = factory.create(IconScoreContextType.QUERY)
+            context = IconScoreContext(IconScoreContextType.QUERY)
             self.assertTrue(isinstance(context, IconScoreContext))
-            self.assertEqual(0, len(factory._queue))
             self.assertTrue(context.readonly)
-            factory.destroy(context)
 
-        self.assertEqual(1, len(factory._queue))
-
-        context = factory.create(IconScoreContextType.INVOKE)
-        self.assertEqual(0, len(factory._queue))
+        context = IconScoreContext(IconScoreContextType.INVOKE)
         self.assertEqual(IconScoreContextType.INVOKE, context.type)
-        self.factory.destroy(context)
 
-        context = factory.create(IconScoreContextType.DIRECT)
-        self.assertEqual(0, len(factory._queue))
+        context = IconScoreContext(IconScoreContextType.DIRECT)
         self.assertEqual(IconScoreContextType.DIRECT, context.type)
-        self.factory.destroy(context)

--- a/tests/test_icon_score_deploy_engine.py
+++ b/tests/test_icon_score_deploy_engine.py
@@ -25,10 +25,9 @@ from iconservice.base.transaction import Transaction
 from iconservice.database.factory import ContextDatabaseFactory
 from iconservice.deploy.icon_score_deploy_engine import IconScoreDeployEngine
 from iconservice.deploy.icon_score_deploy_storage import IconScoreDeployStorage
-from iconservice.iconscore.icon_score_context import IconScoreContextFactory
-from iconservice.iconscore.icon_score_context import IconScoreContextType
-from iconservice.iconscore.icon_score_mapper import IconScoreMapper
+from iconservice.iconscore.icon_score_context import IconScoreContextType, IconScoreContext
 from iconservice.iconscore.icon_score_loader import IconScoreLoader
+from iconservice.iconscore.icon_score_mapper import IconScoreMapper
 from iconservice.iconscore.icon_score_step import IconScoreStepCounter
 from iconservice.iconscore.icon_score_step import IconScoreStepCounterFactory
 from iconservice.icx.icx_engine import IcxEngine
@@ -82,13 +81,11 @@ class TestScoreDeployEngine(unittest.TestCase):
             score_root_path=score_path,
             icon_deploy_storage=self._deploy_storage)
 
-        self._factory = IconScoreContextFactory(max_size=1)
         self.make_context()
 
     def tearDown(self):
         try:
-            self._context = self._factory.create(IconScoreContextType.DIRECT)
-            self._factory.destroy(self._context)
+            self._context = IconScoreContext(IconScoreContextType.DIRECT)
             self._icx_storage.close(self._context)
         finally:
             remove_path = os.path.join(TEST_ROOT_PATH, self._ROOT_SCORE_PATH)
@@ -98,7 +95,7 @@ class TestScoreDeployEngine(unittest.TestCase):
 
     def make_context(self):
         self._tx_index += 1
-        self._context = self._factory.create(IconScoreContextType.DIRECT)
+        self._context = IconScoreContext(IconScoreContextType.DIRECT)
         self._context.msg = Message(self._addr1, 0)
 
         self._context.tx = Transaction(

--- a/tests/test_icon_score_engine.py
+++ b/tests/test_icon_score_engine.py
@@ -18,28 +18,26 @@
 """
 
 
-import unittest
 import os
+import unittest
 
-from iconservice.iconscore.icon_score_context_util import IconScoreContextUtil
-from tests import rmtree, create_address
 from iconservice.base.address import AddressPrefix
 from iconservice.base.block import Block
 from iconservice.base.exception import ExceptionCode, InvalidParamsException
 from iconservice.base.message import Message
 from iconservice.base.transaction import Transaction
 from iconservice.database.factory import ContextDatabaseFactory
-from iconservice.iconscore.icon_score_context import IconScoreContextFactory, IconScoreContext
+from iconservice.deploy.icon_score_deploy_engine import IconScoreDeployEngine
+from iconservice.deploy.icon_score_deploy_storage import IconScoreDeployStorage
+from iconservice.deploy.icon_score_deployer import IconScoreDeployer
+from iconservice.iconscore.icon_score_context import IconScoreContext
 from iconservice.iconscore.icon_score_context import IconScoreContextType
 from iconservice.iconscore.icon_score_engine import IconScoreEngine
-from iconservice.iconscore.icon_score_mapper import IconScoreMapper
 from iconservice.iconscore.icon_score_loader import IconScoreLoader
-from iconservice.deploy.icon_score_deploy_engine import IconScoreDeployEngine
-from iconservice.deploy.icon_score_deployer import IconScoreDeployer
-from iconservice.deploy.icon_score_deploy_storage import IconScoreDeployStorage
+from iconservice.iconscore.icon_score_mapper import IconScoreMapper
 from iconservice.icx.icx_storage import IcxStorage
 from tests import create_tx_hash, create_block_hash
-
+from tests import rmtree, create_address
 
 TEST_ROOT_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '../'))
 
@@ -81,9 +79,8 @@ class TestIconScoreEngine(unittest.TestCase):
         self._from = create_address(AddressPrefix.EOA)
         self._icon_score_address = create_address(AddressPrefix.CONTRACT)
 
-        self.factory = IconScoreContextFactory(max_size=1)
         IconScoreContext.icon_score_deploy_engine = deploy_engine
-        self._context = self.factory.create(IconScoreContextType.DIRECT)
+        self._context = IconScoreContext(IconScoreContextType.DIRECT)
         self._context.msg = Message(self._from, 0)
         tx_hash = create_tx_hash()
         self._context.tx = Transaction(
@@ -94,7 +91,6 @@ class TestIconScoreEngine(unittest.TestCase):
     def tearDown(self):
         self.engine = None
         self.icx_storage.close(self._context)
-        self.factory.destroy(self._context)
         ContextDatabaseFactory.close()
 
         remove_path = os.path.join(TEST_ROOT_PATH, self._ROOT_SCORE_PATH)
@@ -144,7 +140,7 @@ class TestIconScoreEngine(unittest.TestCase):
         # self._engine.invoke(
         #     self._context, self._icon_score_address, 'install', install_data)
         # self._engine.commit(self._context)
-        context = self.factory.create(IconScoreContextType.QUERY)
+        context = IconScoreContext(IconScoreContextType.QUERY)
 
         with self.assertRaises(InvalidParamsException) as cm:
             self.engine.query(
@@ -153,5 +149,3 @@ class TestIconScoreEngine(unittest.TestCase):
         e = cm.exception
         self.assertEqual(ExceptionCode.INVALID_PARAMS, e.code)
         print(e)
-
-        self.factory.destroy(context)

--- a/tests/test_icon_score_loader.py
+++ b/tests/test_icon_score_loader.py
@@ -18,14 +18,12 @@
 import inspect
 import unittest
 from os import path, makedirs, symlink
-
 from unittest.mock import Mock
 
 from iconservice.iconscore.icon_score_base import IconScoreBase
 from iconservice.iconscore.icon_score_context import ContextContainer, \
-    IconScoreContextFactory, IconScoreContextType
+    IconScoreContextType
 from iconservice.iconscore.icon_score_context import IconScoreContext
-from iconservice.iconscore.icon_score_context_util import IconScoreContextUtil
 from iconservice.iconscore.icon_score_loader import IconScoreLoader
 from tests import create_address, create_tx_hash, rmtree
 
@@ -39,9 +37,8 @@ class TestIconScoreLoader(unittest.TestCase):
         self._score_path = self._ROOT_SCORE_PATH
         self._loader = IconScoreLoader(self._score_path)
 
-        self._factory = IconScoreContextFactory(max_size=1)
         IconScoreContext.icon_score_deploy_engine = Mock()
-        self._context = self._factory.create(IconScoreContextType.DIRECT)
+        self._context = IconScoreContext(IconScoreContextType.DIRECT)
         ContextContainer._push_context(self._context)
 
     def tearDown(self):

--- a/tests/test_icon_service_engine.py
+++ b/tests/test_icon_service_engine.py
@@ -18,25 +18,25 @@
 """
 import hashlib
 import os
-import unittest
 import time
+import unittest
 from unittest.mock import Mock
 
 from iconcommons.icon_config import IconConfig
+
 from iconservice.base.address import Address, AddressPrefix, MalformedAddress
 from iconservice.base.block import Block
-from iconservice.base.type_converter import TypeConverter
-from iconservice.base.type_converter_templates import ParamType
 from iconservice.base.exception import ExceptionCode, ServerErrorException, \
     RevertException
 from iconservice.base.message import Message
 from iconservice.base.transaction import Transaction
+from iconservice.base.type_converter import TypeConverter
+from iconservice.base.type_converter_templates import ParamType
 from iconservice.database.batch import BlockBatch, TransactionBatch
 from iconservice.icon_config import default_icon_config
 from iconservice.icon_constant import IconServiceFlag, ConfigKey
 from iconservice.icon_service_engine import IconServiceEngine
 from iconservice.iconscore.icon_score_context import IconScoreContext
-from iconservice.iconscore.icon_score_context import IconScoreContextFactory
 from iconservice.iconscore.icon_score_context import IconScoreContextType
 from iconservice.iconscore.icon_score_context_util import IconScoreContextUtil
 from iconservice.iconscore.icon_score_result import TransactionResult
@@ -45,12 +45,11 @@ from iconservice.iconscore.icon_score_step import StepType
 from tests import create_block_hash, create_address, rmtree, create_tx_hash, \
     raise_exception_start_tag, raise_exception_end_tag
 
-context_factory = IconScoreContextFactory(max_size=1)
 TEST_ROOT_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '../'))
 
 
 def _create_context(context_type: IconScoreContextType) -> IconScoreContext:
-    context = context_factory.create(context_type)
+    context = IconScoreContext(context_type)
 
     if context.type == IconScoreContextType.INVOKE:
         context.block_batch = BlockBatch()
@@ -138,7 +137,7 @@ class TestIconServiceEngine(unittest.TestCase):
         self.assertEqual(self._total_supply, balance)
 
     def test_call_on_query(self):
-        context = context_factory.create(IconScoreContextType.QUERY)
+        context = IconScoreContext(IconScoreContextType.QUERY)
 
         method = 'icx_getBalance'
         params = {'address': self.from_}
@@ -146,8 +145,6 @@ class TestIconServiceEngine(unittest.TestCase):
         balance = self._engine._call(context, method, params)
         self.assertTrue(isinstance(balance, int))
         self.assertEqual(self._total_supply, balance)
-
-        context_factory.destroy(context)
 
     def test_call_on_invoke(self):
         context = _create_context(IconScoreContextType.INVOKE)
@@ -191,8 +188,6 @@ class TestIconServiceEngine(unittest.TestCase):
         # no transfer to fee_treasury because fee charging is disabled
         tx_batch = context.tx_batch
         self.assertEqual(2, len(tx_batch))
-
-        context_factory.destroy(context)
 
     def test_invoke(self):
         block_height = 1
@@ -664,8 +659,6 @@ class TestIconServiceEngine(unittest.TestCase):
         self.assertEqual(tx_hash, tx_result.tx_hash)
         self.assertIsNone(tx_result.score_address)
         context.traces.append.assert_called()
-
-        context_factory.destroy(context)
 
     def test_score_invoke_failure_by_readonly_external_call(self):
         block_height = 1

--- a/tests/test_icon_zip_deploy.py
+++ b/tests/test_icon_zip_deploy.py
@@ -20,7 +20,6 @@
 
 import os
 import unittest
-
 from unittest.mock import Mock
 
 from iconservice.base.address import AddressPrefix, ZERO_SCORE_ADDRESS
@@ -35,11 +34,10 @@ from iconservice.deploy.icon_score_deployer import IconScoreDeployer
 from iconservice.icon_constant import DEFAULT_BYTE_SIZE
 from iconservice.iconscore.icon_score_context import ContextContainer
 from iconservice.iconscore.icon_score_context import IconScoreContext
-from iconservice.iconscore.icon_score_context import IconScoreContextFactory
 from iconservice.iconscore.icon_score_context import IconScoreContextType
 from iconservice.iconscore.icon_score_context_util import IconScoreContextUtil
-from iconservice.iconscore.icon_score_mapper import IconScoreMapper
 from iconservice.iconscore.icon_score_loader import IconScoreLoader
+from iconservice.iconscore.icon_score_mapper import IconScoreMapper
 from iconservice.icx.icx_engine import IcxEngine
 from iconservice.icx.icx_storage import IcxStorage
 from tests import create_address, create_block_hash, create_tx_hash
@@ -94,7 +92,6 @@ class TestIconZipDeploy(unittest.TestCase):
 
         self.sample_token_address = create_address(AddressPrefix.CONTRACT)
 
-        self._factory = IconScoreContextFactory(max_size=1)
         self.make_context()
 
         self._one_icx = 1 * 10 ** 18
@@ -102,7 +99,7 @@ class TestIconZipDeploy(unittest.TestCase):
 
     def make_context(self):
         self._tx_index += 1
-        self._context = self._factory.create(IconScoreContextType.DIRECT)
+        self._context = IconScoreContext(IconScoreContextType.DIRECT)
         self._context.msg = Message(self.from_address, 0)
 
         tx_hash = create_tx_hash()
@@ -121,7 +118,6 @@ class TestIconZipDeploy(unittest.TestCase):
         self._engine = None
         ContextContainer._pop_context()
         self._icon_score_mapper.close()
-        self._factory.destroy(self._context)
 
         remove_path = os.path.join(TEST_ROOT_PATH, 'tests')
         IconScoreDeployer.remove_existing_score(remove_path)


### PR DESCRIPTION
1. Create IconScoreContext using its constructor rather than IconScoreContextFactory.create method
2. Remove IconScoreContextFactory
3. Modify context related unittests