### PR TITLE
Implement isAuditor and getImportWhiteList read-only method to governance SCORE

### DIFF
--- a/tests/integrate_test/test_samples/test_builtin/latest_version/governance/governance.py
+++ b/tests/integrate_test/test_samples/test_builtin/latest_version/governance/governance.py
@@ -761,12 +761,9 @@ class Governance(IconSystemScoreBase):
     @external(readonly=True)
     def getImportWhiteList(self) -> list:
         formatted_white_list = []
-
         white_list: dict = self._get_import_white_list()
-
         for key, value in white_list.items():
             formatted_white_list.append({"package": key, "objects": value})
-
         return formatted_white_list
 
     @staticmethod

--- a/tests/integrate_test/test_samples/test_builtin/latest_version/governance/governance.py
+++ b/tests/integrate_test/test_samples/test_builtin/latest_version/governance/governance.py
@@ -411,6 +411,10 @@ class Governance(IconSystemScoreBase):
 
         self.Rejected('0x' + txHash.hex(), reason)
 
+    @external(readonly=True)
+    def isAuditor(self, address: Address) -> bool:
+        return address in self._auditor_list
+
     @external
     def addAuditor(self, address: Address):
         if address.is_contract:
@@ -753,6 +757,17 @@ class Governance(IconSystemScoreBase):
         if DEBUG is True:
             Logger.debug(f'({importStmt}) is in import white list')
         return True
+
+    @external(readonly=True)
+    def getImportWhiteList(self) -> list:
+        formatted_white_list = []
+
+        white_list: dict = self._get_import_white_list()
+
+        for key, value in white_list.items():
+            formatted_white_list.append({"package": key, "objects": value})
+
+        return formatted_white_list
 
     @staticmethod
     def _check_import_stmt(import_stmt: str) -> dict:

--- a/tests/integrate_test/test_samples/test_builtin/latest_version/governance/governance.py
+++ b/tests/integrate_test/test_samples/test_builtin/latest_version/governance/governance.py
@@ -411,10 +411,6 @@ class Governance(IconSystemScoreBase):
 
         self.Rejected('0x' + txHash.hex(), reason)
 
-    @external(readonly=True)
-    def isAuditor(self, address: Address) -> bool:
-        return address in self._auditor_list
-
     @external
     def addAuditor(self, address: Address):
         if address.is_contract:
@@ -447,6 +443,10 @@ class Governance(IconSystemScoreBase):
                     self._auditor_list[i] = top
         if DEBUG is True:
             self._print_auditor_list('removeAuditor')
+
+    @external(readonly=True)
+    def isAuditor(self, address: Address) -> bool:
+        return address in self._auditor_list
 
     def _print_auditor_list(self, header: str):
         Logger.debug(f'{header}: list len = {len(self._auditor_list)}', TAG)


### PR DESCRIPTION
isAuditor: check if the address is Auditor or not and return boolean data
getImportWhiteList: return the whole list of package which has been allowed to import

if this PR pass, these changes will be applied to governance repo.
* these changes will be applied governance version 0.0.6