### PR TITLE
IS-270: Improve input data calculating rule

### DIFF
--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -855,23 +855,18 @@ class IconServiceEngine(ContextContainer):
 
     @staticmethod
     def _get_string_size_in_bytes(revision: int, data: 'str') -> int:
-        # If the value is a hex-string, it is calculated as bytes otherwise
-        # UTF-8 string
-        if revision >= REVISION_3:
-            # Revision 3 or after, Hex prefix can be '0x' or '-0x'
-            index_of_hex_body = 2 if data[:2] == '0x' else 3 if data[:3] == '-0x' else -1
-        else:
-            # Before revision 3, Hex prefix can be '0x' only
-            index_of_hex_body = 2 if data.startswith('0x') else 0
+        if revision < REVISION_3:
+            # If the value is hexstring, it is calculated as bytes otherwise
+            # string
+            data_body = data[2:] if data.startswith('0x') else data
+            if is_lowercase_hex_string(data_body):
+                data_body_length = len(data_body)
+                size = data_body_length // 2
+                if data_body_length % 2 == 1:
+                    size += 1
+                return size
 
-        if index_of_hex_body >= 0 and is_lowercase_hex_string(data[index_of_hex_body:]):
-            data_body_length = len(data) - index_of_hex_body
-            size = data_body_length // 2
-            if data_body_length % 2 == 1:
-                size += 1
-            return size
-        else:
-            return len(data.encode('utf-8'))
+        return len(data.encode('utf-8'))
 
     def _transfer_coin(self,
                        context: 'IconScoreContext',

--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -13,11 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import os
 from typing import TYPE_CHECKING, List, Any, Optional
 
 from iconcommons.logger import Logger
+
 from .base.address import Address, generate_score_address, generate_score_address_for_tbears
 from .base.address import ZERO_SCORE_ADDRESS, GOVERNANCE_SCORE_ADDRESS
 from .base.block import Block
@@ -30,7 +30,8 @@ from .database.factory import ContextDatabaseFactory
 from .deploy.icon_builtin_score_loader import IconBuiltinScoreLoader
 from .deploy.icon_score_deploy_engine import IconScoreDeployEngine
 from .deploy.icon_score_deploy_storage import IconScoreDeployStorage
-from .icon_constant import ICON_DEX_DB_NAME, ICON_SERVICE_LOG_TAG, IconServiceFlag, ConfigKey, REVISION_3
+from .icon_constant import ICON_DEX_DB_NAME, ICON_SERVICE_LOG_TAG, IconServiceFlag, ConfigKey, \
+    REVISION_3
 from .iconscore.icon_pre_validator import IconPreValidator
 from .iconscore.icon_score_class_loader import IconScoreClassLoader
 from .iconscore.icon_score_context import IconScoreContext, IconScoreFuncType, ContextContainer
@@ -40,14 +41,13 @@ from .iconscore.icon_score_engine import IconScoreEngine
 from .iconscore.icon_score_event_log import EventLogEmitter
 from .iconscore.icon_score_mapper import IconScoreMapper
 from .iconscore.icon_score_result import TransactionResult
-from .iconscore.icon_score_step import IconScoreStepCounterFactory, StepType
+from .iconscore.icon_score_step import IconScoreStepCounterFactory, StepType, get_input_data_size, \
+    get_deploy_content_size
 from .iconscore.icon_score_trace import Trace, TraceType
 from .icx.icx_account import AccountType
 from .icx.icx_engine import IcxEngine
 from .icx.icx_storage import IcxStorage
 from .precommit_data_manager import PrecommitData, PrecommitDataManager, PrecommitFlag
-from .utils import byte_length_of_int
-from .utils import is_lowercase_hex_string
 from .utils import sha3_256, int_to_bytes
 from .utils import to_camel_case
 from .utils.bloom import BloomFilter
@@ -488,11 +488,11 @@ class IconServiceEngine(ContextContainer):
 
         context.step_counter.apply_step(StepType.DEFAULT, 1)
 
-        input_size = self._get_data_size_in_bytes(context.revision, data)
+        input_size = get_input_data_size(context.revision, data)
         context.step_counter.apply_step(StepType.INPUT, input_size)
 
         if data_type == "deploy":
-            content_size = self._get_binary_hex_string_size_in_bytes(data.get('content', None))
+            content_size = get_deploy_content_size(context.revision, data.get('content', None))
             context.step_counter.apply_step(StepType.CONTRACT_SET, content_size)
             # When installing SCORE.
             if to == ZERO_SCORE_ADDRESS:
@@ -638,7 +638,7 @@ class IconServiceEngine(ContextContainer):
             # minimum_step is the sum of
             # default STEP cost and input STEP costs if data field exists
             data = params['data']
-            input_size = self._get_data_size_in_bytes(context.revision, data)
+            input_size = get_input_data_size(context.revision, data)
             minimum_step += input_size * self._step_counter_factory.get_step_cost(StepType.INPUT)
 
         self._icon_pre_validator.execute(context, params, step_price, minimum_step)
@@ -818,7 +818,7 @@ class IconServiceEngine(ContextContainer):
         # Every send_transaction are calculated DEFAULT STEP at first
         context.step_counter.apply_step(StepType.DEFAULT, 1)
 
-        input_size = self._get_data_size_in_bytes(context.revision, params.get('data', None))
+        input_size = get_input_data_size(context.revision, params.get('data', None))
         context.step_counter.apply_step(StepType.INPUT, input_size)
 
         self._transfer_coin(context, params)
@@ -828,59 +828,6 @@ class IconServiceEngine(ContextContainer):
             score_address = self._handle_score_invoke(context, to, params)
 
         return score_address
-
-    def _get_data_size_in_bytes(self, revision: int, data) -> int:
-        size = 0
-        if isinstance(data, dict):
-            size = self._get_dict_size_in_bytes(revision, data)
-        elif isinstance(data, list):
-            for v in data:
-                size += self._get_data_size_in_bytes(revision, v)
-        elif isinstance(data, str):
-            size = self._get_string_size_in_bytes(revision, data)
-        else:
-            # int and bool
-            if isinstance(data, int):
-                size = byte_length_of_int(data)
-        return size
-
-    def _get_dict_size_in_bytes(self, revision: int, data: 'dict') -> int:
-        size = 0
-        for k, v in data.items():
-            if revision >= REVISION_3:
-                # Revision 3 or after, counts keys of dict also
-                size += len(k.encode('utf-8'))
-            size += self._get_data_size_in_bytes(revision, v)
-        return size
-
-    @staticmethod
-    def _get_string_size_in_bytes(revision: int, data: 'str') -> int:
-        if revision < REVISION_3:
-            # Before revision 3, If the str value is regarded as a hex string,
-            # it is calculated as bytes otherwise string
-            return IconServiceEngine._get_binary_hex_string_size_in_bytes(data)
-
-        return len(data.encode('utf-8'))
-
-    @staticmethod
-    def _get_binary_hex_string_size_in_bytes(data: 'str') -> int:
-        """
-        Gets the binary size of the hex string data,
-        If the data can not be parse as hex, returns utf-8 encoded string size in bytes.
-        """
-
-        # hex string can have '0x' prefix or not
-        data_body = data[2:] if data.startswith('0x') else data
-
-        # hex string must only have lowercase hex digits otherwise it is string
-        if is_lowercase_hex_string(data_body):
-            data_body_length = len(data_body)
-            size = data_body_length // 2
-            if data_body_length % 2 == 1:
-                size += 1
-            return size
-
-        return len(data.encode('utf-8'))
 
     def _transfer_coin(self,
                        context: 'IconScoreContext',
@@ -984,8 +931,8 @@ class IconServiceEngine(ContextContainer):
                 score_address = to
                 context.step_counter.apply_step(StepType.CONTRACT_UPDATE, 1)
 
-            data_size = self._get_binary_hex_string_size_in_bytes(data.get('content', None))
-            context.step_counter.apply_step(StepType.CONTRACT_SET, data_size)
+            content_size = get_deploy_content_size(context.revision, data.get('content', None))
+            context.step_counter.apply_step(StepType.CONTRACT_SET, content_size)
 
             self._icon_score_deploy_engine.invoke(
                 context=context,

--- a/iconservice/iconscore/icon_pre_validator.py
+++ b/iconservice/iconscore/icon_pre_validator.py
@@ -16,7 +16,7 @@
 
 from typing import TYPE_CHECKING
 
-from iconservice.iconscore.icon_score_step import get_input_data_size
+from .icon_score_step import get_input_data_size
 from ..base.address import Address, ZERO_SCORE_ADDRESS, generate_score_address
 from ..base.exception import InvalidRequestException, InvalidParamsException
 from ..deploy import DeployState

--- a/iconservice/iconscore/icon_pre_validator.py
+++ b/iconservice/iconscore/icon_pre_validator.py
@@ -16,11 +16,11 @@
 
 from typing import TYPE_CHECKING
 
-from iconservice.utils import is_lowercase_hex_string
 from ..base.address import Address, ZERO_SCORE_ADDRESS, generate_score_address
 from ..base.exception import InvalidRequestException, InvalidParamsException
 from ..deploy import DeployState
 from ..icon_constant import FIXED_FEE, MAX_DATA_SIZE, DEFAULT_BYTE_SIZE, DATA_BYTE_ORDER
+from ..utils import is_lowercase_hex_string
 
 if TYPE_CHECKING:
     from ..deploy.icon_score_deploy_storage import IconScoreDeployStorage, IconScoreDeployInfo

--- a/iconservice/iconscore/icon_pre_validator.py
+++ b/iconservice/iconscore/icon_pre_validator.py
@@ -89,12 +89,14 @@ class IconPreValidator:
         Check if the message data is a lowercase hex string
         :param data: input data of message type
         """
+        if isinstance(data, str) \
+                and data.startswith('0x') \
+                and is_lowercase_hex_string(data[2:]) \
+                and len(data) % 2 == 0:
+            return
 
-        if not isinstance(data, str) or \
-                data[:2] != '0x' or \
-                (not is_lowercase_hex_string(data[2:]) and len(data) % 2 == 0):
-            raise InvalidRequestException(
-                'The message data should be a lowercase hex string')
+        raise InvalidRequestException(
+            'The message data should be a lowercase hex string')
 
     def _check_input_size(self, params: dict):
         """

--- a/iconservice/iconscore/icon_score_step.py
+++ b/iconservice/iconscore/icon_score_step.py
@@ -18,8 +18,8 @@ from enum import Enum, auto
 from threading import Lock
 from typing import TYPE_CHECKING, Any
 
-from iconservice.icon_constant import MAX_EXTERNAL_CALL_COUNT, REVISION_3
-from iconservice.utils import to_camel_case, is_lowercase_hex_string, byte_length_of_int
+from ..icon_constant import MAX_EXTERNAL_CALL_COUNT, REVISION_3
+from ..utils import to_camel_case, is_lowercase_hex_string, byte_length_of_int
 from ..base.exception import IconServiceBaseException, ExceptionCode, InvalidRequestException
 
 if TYPE_CHECKING:

--- a/iconservice/iconscore/icon_score_step.py
+++ b/iconservice/iconscore/icon_score_step.py
@@ -13,16 +13,89 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 from enum import Enum, auto
 from threading import Lock
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
-from iconservice.icon_constant import MAX_EXTERNAL_CALL_COUNT
-from iconservice.utils import to_camel_case
+from iconservice.icon_constant import MAX_EXTERNAL_CALL_COUNT, REVISION_3
+from iconservice.utils import to_camel_case, is_lowercase_hex_string, byte_length_of_int
 from ..base.exception import IconServiceBaseException, ExceptionCode, InvalidRequestException
 
 if TYPE_CHECKING:
     from iconservice.iconscore.icon_score_context import IconScoreContextType
+
+
+def get_input_data_size(revision: int, input_data: Any) -> int:
+    """
+    Returns size of input data of a transaction
+
+    :param revision: current revision
+    :param input_data: input data of transaction
+    :return: size of input data
+    """
+    if revision < REVISION_3:
+        return get_data_size_recursively(input_data)
+
+    data = json.dumps(input_data, ensure_ascii=False, separators=(',', ':'))
+    return len(data.encode())
+
+
+def get_deploy_content_size(revision: int, content: str) -> int:
+    """
+    Returns size of deploying content.
+
+    If the content is not binary hex string, it raises an exception.
+
+    :param revision: current revision
+    :param content: deploying content of transaction
+    :return: size of input content
+    """
+    if revision < REVISION_3:
+        return get_data_size_recursively(content)
+
+    if isinstance(content, str) \
+            and content.startswith('0x') \
+            and is_lowercase_hex_string(content[2:]) \
+            and len(content) % 2 == 0:
+
+        return len(content[2:]) // 2
+    else:
+        raise InvalidRequestException('Invalid content data')
+
+
+def get_data_size_recursively(data) -> int:
+    """
+    Deprecated (Only for revision 2 and below).
+    Returns size of data(input data or deploying content) by recursive traversal
+
+    :param data: input data or deploying content
+    :return: size of data
+    """
+    size = 0
+    if data:
+        if isinstance(data, dict):
+            for v in data.values():
+                size += get_data_size_recursively(v)
+        elif isinstance(data, list):
+            for v in data:
+                size += get_data_size_recursively(v)
+        elif isinstance(data, str):
+            # If the value is hexstring, it is calculated as bytes otherwise
+            # string
+            data_body = data[2:] if data.startswith('0x') else data
+            if is_lowercase_hex_string(data_body):
+                data_body_length = len(data_body)
+                size = data_body_length // 2
+                if data_body_length % 2 == 1:
+                    size += 1
+            else:
+                size = len(data.encode('utf-8'))
+        else:
+            # int and bool
+            if isinstance(data, int):
+                size = byte_length_of_int(data)
+    return size
 
 
 class AutoValueEnum(Enum):

--- a/tests/base/test_type_converter_func.py
+++ b/tests/base/test_type_converter_func.py
@@ -66,12 +66,48 @@ class TestTypeConverterFunc(unittest.TestCase):
         TypeConverter.convert_data_params(annotations, params)
         self.assertEqual(value, self.test_score.func_param_address2(**params))
 
+    def test_func_param_int_none(self):
+        value = None
+        params = {"value": value}
+        annotations = TypeConverter.make_annotations_from_method(self.test_score.func_param_int)
+        TypeConverter.convert_data_params(annotations, params)
+        self.assertEqual(value, self.test_score.func_param_int(**params))
+
+    def test_func_param_str_none(self):
+        value = None
+        params = {"value": value}
+        annotations = TypeConverter.make_annotations_from_method(self.test_score.func_param_str)
+        TypeConverter.convert_data_params(annotations, params)
+        self.assertEqual(value, self.test_score.func_param_str(**params))
+
+    def test_func_param_bytes_none(self):
+        value = None
+        params = {"value": value}
+        annotations = TypeConverter.make_annotations_from_method(self.test_score.func_param_bytes)
+        TypeConverter.convert_data_params(annotations, params)
+        self.assertEqual(value, self.test_score.func_param_bytes(**params))
+
+    def test_func_param_bool_none(self):
+        value = None
+        params = {"value": value}
+        annotations = TypeConverter.make_annotations_from_method(self.test_score.func_param_bool)
+        TypeConverter.convert_data_params(annotations, params)
+        self.assertEqual(value, self.test_score.func_param_bool(**params))
+
+    def test_func_param_address_none(self):
+        value = None
+        params = {"value": value}
+        annotations = TypeConverter.make_annotations_from_method(self.test_score.func_param_address1)
+        TypeConverter.convert_data_params(annotations, params)
+        self.assertEqual(value, self.test_score.func_param_address1(**params))
+
 
 class TestScore:
     def func_param_int(self, value: int) -> int:
         return value
 
     def func_param_str(self, value: str) -> str:
+        print(value)
         return value
 
     def func_param_bytes(self, value: bytes) -> bytes:

--- a/tests/integrate_test/test_integrate_deploy_install.py
+++ b/tests/integrate_test/test_integrate_deploy_install.py
@@ -21,7 +21,8 @@ import unittest
 
 from iconservice.base.address import ZERO_SCORE_ADDRESS, GOVERNANCE_SCORE_ADDRESS
 from iconservice.base.exception import ExceptionCode
-from tests import raise_exception_start_tag, raise_exception_end_tag
+from tests import raise_exception_start_tag, raise_exception_end_tag, create_tx_hash
+from tests.integrate_test import create_timestamp
 from tests.integrate_test.test_integrate_base import TestIntegrateBase
 
 from typing import TYPE_CHECKING, Any
@@ -210,6 +211,120 @@ class TestIntegrateDeployInstall(TestIntegrateBase):
 
         # 4. assert get value: 2 * value2
         self._assert_get_value(self._addr_array[0], score_addr1, "get_value", value2)
+
+    def test_deploy_invalid_content(self):
+        self._update_governance()
+
+        # Update revision
+        prev_block, tx_results = self._make_and_req_block([
+            self._make_score_call_tx(
+                self._admin,
+                GOVERNANCE_SCORE_ADDRESS,
+                'setRevision',
+                {"code": hex(3), "name": "1.1.1"},
+            )
+        ])
+        self._write_precommit_state(prev_block)
+        self.assertEqual(3, self._query_revision())
+
+        # 1. deploy with str content
+        tx1 = self._make_invalid_deploy_tx(
+                                   self._addr_array[0],
+                                   ZERO_SCORE_ADDRESS,
+                                   'invalid')
+
+        raise_exception_start_tag("test_score_no_zip")
+        prev_block, tx_results = self._make_and_req_block([tx1])
+        raise_exception_end_tag("test_score_no_zip")
+        self._write_precommit_state(prev_block)
+        self.assertEqual(tx_results[0].status, int(False))
+        self.assertEqual(tx_results[0].failure.message, f'Invalid content data')
+
+        # 2. deploy with int content
+        tx1 = self._make_invalid_deploy_tx(
+            self._addr_array[0],
+            ZERO_SCORE_ADDRESS,
+            1000)
+
+        raise_exception_start_tag("test_score_no_zip")
+        prev_block, tx_results = self._make_and_req_block([tx1])
+        raise_exception_end_tag("test_score_no_zip")
+        self._write_precommit_state(prev_block)
+        self.assertEqual(tx_results[0].status, int(False))
+        self.assertEqual(tx_results[0].failure.message, f'Invalid content data')
+
+        # 3. deploy content with hex(no prefix)
+        tx1 = self._make_invalid_deploy_tx(
+            self._addr_array[0],
+            ZERO_SCORE_ADDRESS,
+            '1a2c3b')
+
+        raise_exception_start_tag("test_score_no_zip")
+        prev_block, tx_results = self._make_and_req_block([tx1])
+        raise_exception_end_tag("test_score_no_zip")
+        self._write_precommit_state(prev_block)
+        self.assertEqual(tx_results[0].status, int(False))
+        self.assertEqual(tx_results[0].failure.message, f'Invalid content data')
+
+        # 3. deploy content with hex(upper case)
+        tx1 = self._make_invalid_deploy_tx(
+            self._addr_array[0],
+            ZERO_SCORE_ADDRESS,
+            '0x1A2c3b')
+
+        raise_exception_start_tag("test_score_no_zip")
+        prev_block, tx_results = self._make_and_req_block([tx1])
+        raise_exception_end_tag("test_score_no_zip")
+        self._write_precommit_state(prev_block)
+        self.assertEqual(tx_results[0].status, int(False))
+        self.assertEqual(tx_results[0].failure.message, f'Invalid content data')
+
+    def _make_invalid_deploy_tx(self,
+                        addr_from: 'Address',
+                        addr_to: 'Address',
+                        content: Any = None):
+
+        deploy_params = {}
+        deploy_data = {'contentType': 'application/zip', 'content': content, 'params': deploy_params}
+
+        timestamp_us = create_timestamp()
+        nonce = 0
+
+        request_params = {
+            "version": self._version,
+            "from": addr_from,
+            "to": addr_to,
+            "stepLimit": self._step_limit,
+            "timestamp": timestamp_us,
+            "nonce": nonce,
+            "signature": self._signature,
+            "dataType": "deploy",
+            "data": deploy_data
+        }
+
+        method = 'icx_sendTransaction'
+        # Insert txHash into request params
+        request_params['txHash'] = create_tx_hash()
+        tx = {
+            'method': method,
+            'params': request_params
+        }
+
+        self.icon_service_engine.validate_transaction(tx)
+        return tx
+
+    def _query_revision(self):
+        query_request = {
+            "version": self._version,
+            "from": self._addr_array[0],
+            "to": GOVERNANCE_SCORE_ADDRESS,
+            "dataType": "call",
+            "data": {
+                "method": "getRevision",
+                "params": {}
+            }
+        }
+        return self._query(query_request)['code']
 
     def test_score_no_zip(self):
         self._update_governance()

--- a/tests/integrate_test/test_integrate_estimate_step.py
+++ b/tests/integrate_test/test_integrate_estimate_step.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from math import ceil
 
 from tests.integrate_test.test_integrate_base import TestIntegrateBase
 from iconservice.base.address import ZERO_SCORE_ADDRESS, GOVERNANCE_SCORE_ADDRESS
@@ -358,6 +359,161 @@ class TestIntegrateEstimateStep(TestIntegrateBase):
         self.assertEqual(tx_results[0].status, int(True))
         self.assertEqual(estimate, tx_results[0].step_used)
 
+    def test_migration_input_step(self):
+        self._update_governance_0_0_4()
+        self.assertEqual(2, self._query_revision())
 
+        step_costs = self._query_step_costs()
 
+        key_content_type = 'contentType'
+        key_content = 'content'
+        key_data_params = 'params'
+        content_type = 'application/zip'
+        content = '0xabcde12345'
 
+        data_param_keys = ['upper_case_hex',
+                           'lower_case_hex',
+                           'no_prefix_hex',
+                           'korean',
+                           'negative_integer']
+
+        data_param_values = ['0xabcDe12345',
+                             '0xabcde12345',
+                             'abcde12345',
+                             '한국어',
+                             '-0x1a2b3c']
+
+        estimated_steps = self.icon_service_engine.estimate_step(
+            self.generate_mock_request(
+                key_content, content,
+                key_content_type, content_type,
+                key_data_params,
+                data_param_keys, data_param_values)
+        )
+
+        content_size = self._get_bin_size(content)
+
+        input_size_rev2 = \
+            self._get_str_size(content_type) + \
+            content_size + \
+            self._get_str_size(data_param_values[0]) + \
+            self._get_bin_size(data_param_values[1]) + \
+            self._get_bin_size(data_param_values[2]) + \
+            self._get_str_size(data_param_values[3]) + \
+            self._get_str_size(data_param_values[4])
+
+        expected_steps = self._get_expected_step_count(step_costs, input_size_rev2, content_size)
+        self.assertEqual(expected_steps, estimated_steps)
+
+        # Update revision
+        prev_block, tx_results = self._make_and_req_block([
+            self._make_score_call_tx(
+                self._admin,
+                GOVERNANCE_SCORE_ADDRESS,
+                'setRevision',
+                {"code": hex(3), "name": "1.1.1"},
+            )
+        ])
+        self._write_precommit_state(prev_block)
+        self.assertEqual(3, self._query_revision())
+
+        estimated_steps = self.icon_service_engine.estimate_step(
+            self.generate_mock_request(
+                key_content, content,
+                key_content_type, content_type,
+                key_data_params,
+                data_param_keys, data_param_values)
+        )
+
+        input_size_rev3 = \
+            self._get_str_size(key_content_type) + self._get_str_size(content_type) + \
+            self._get_str_size(key_content) + content_size + \
+            self._get_str_size(key_data_params) + \
+            self._get_str_size(data_param_keys[0]) + self._get_str_size(data_param_values[0]) + \
+            self._get_str_size(data_param_keys[1]) + self._get_bin_size(data_param_values[1]) + \
+            self._get_str_size(data_param_keys[2]) + self._get_str_size(data_param_values[2]) + \
+            self._get_str_size(data_param_keys[3]) + self._get_str_size(data_param_values[3]) + \
+            self._get_str_size(data_param_keys[4]) + self._get_bin_size(data_param_values[4])
+
+        expected_steps = self._get_expected_step_count(step_costs, input_size_rev3, content_size)
+        self.assertEqual(expected_steps, estimated_steps)
+
+    def generate_mock_request(self,
+                              key_content, content,
+                              key_content_type, content_type,
+                              key_data_params,
+                              data_param_keys, data_param_values):
+        return {
+            'method': 'icx_sendTransaction',
+            'params': {
+                'version': 3,
+                'from': self._genesis,
+                'to': ZERO_SCORE_ADDRESS,
+                'stepLimit': 1000000000000,
+                'timestamp': 1541753667870296,
+                'nonce': 0,
+                'dataType': 'deploy',
+                'data': {
+                    key_content_type: content_type,
+                    key_content: content,
+                    key_data_params: {
+                        data_param_keys[0]: data_param_values[0],
+                        data_param_keys[1]: data_param_values[1],
+                        data_param_keys[2]: data_param_values[2],
+                        data_param_keys[3]: data_param_values[3],
+                        data_param_keys[4]: data_param_values[4]
+                    }
+                }
+            }
+        }
+
+    def _update_governance_0_0_4(self):
+        tx = self._make_deploy_tx("test_builtin",
+                                  "0_0_4/governance",
+                                  self._admin,
+                                  GOVERNANCE_SCORE_ADDRESS)
+        prev_block, tx_results = self._make_and_req_block([tx])
+        self._write_precommit_state(prev_block)
+        self.assertEqual(tx_results[0].status, int(True))
+
+    def _query_revision(self):
+        query_request = {
+            "version": self._version,
+            "from": self._addr_array[0],
+            "to": GOVERNANCE_SCORE_ADDRESS,
+            "dataType": "call",
+            "data": {
+                "method": "getRevision",
+                "params": {}
+            }
+        }
+        return self._query(query_request)['code']
+
+    def _query_step_costs(self):
+        query_request = {
+            "version": self._version,
+            "from": self._addr_array[0],
+            "to": GOVERNANCE_SCORE_ADDRESS,
+            "dataType": "call",
+            "data": {
+                "method": "getStepCosts",
+                "params": {}
+            }
+        }
+        return self._query(query_request)
+
+    @staticmethod
+    def _get_expected_step_count(step_costs, input_size, content_size):
+        return step_costs['default'] + \
+               step_costs['input'] * input_size + \
+               step_costs['contractSet'] * content_size + \
+               step_costs['contractCreate']
+
+    @staticmethod
+    def _get_str_size(data):
+        return len(data.encode('utf-8'))
+
+    @staticmethod
+    def _get_bin_size(data):
+        index_of_hex_body = 2 if data[:2] == '0x' else 3 if data[:3] == '-0x' else 0
+        return ceil(len(data[index_of_hex_body:]) / 2)

--- a/tests/integrate_test/test_integrate_estimate_step.py
+++ b/tests/integrate_test/test_integrate_estimate_step.py
@@ -383,13 +383,13 @@ class TestIntegrateEstimateStep(TestIntegrateBase):
                              '한국어',
                              '-0x1a2b3c']
 
-        estimated_steps = self.icon_service_engine.estimate_step(
-            self.generate_mock_request(
-                key_content, content,
-                key_content_type, content_type,
-                key_data_params,
-                data_param_keys, data_param_values)
-        )
+        request = self.generate_mock_request(
+            key_content, content,
+            key_content_type, content_type,
+            key_data_params,
+            data_param_keys, data_param_values)
+
+        estimated_steps = self.icon_service_engine.estimate_step(request)
 
         content_size = self._get_bin_size(content)
 
@@ -417,23 +417,21 @@ class TestIntegrateEstimateStep(TestIntegrateBase):
         self._write_precommit_state(prev_block)
         self.assertEqual(3, self._query_revision())
 
-        estimated_steps = self.icon_service_engine.estimate_step(
-            self.generate_mock_request(
-                key_content, content,
-                key_content_type, content_type,
-                key_data_params,
-                data_param_keys, data_param_values)
-        )
+        estimated_steps = self.icon_service_engine.estimate_step(request)
 
-        input_size_rev3 = \
-            self._get_str_size(key_content_type) + self._get_str_size(content_type) + \
-            self._get_str_size(key_content) + self._get_str_size(content) + \
-            self._get_str_size(key_data_params) + \
-            self._get_str_size(data_param_keys[0]) + self._get_str_size(data_param_values[0]) + \
-            self._get_str_size(data_param_keys[1]) + self._get_str_size(data_param_values[1]) + \
-            self._get_str_size(data_param_keys[2]) + self._get_str_size(data_param_values[2]) + \
-            self._get_str_size(data_param_keys[3]) + self._get_str_size(data_param_values[3]) + \
-            self._get_str_size(data_param_keys[4]) + self._get_str_size(data_param_values[4])
+        input_size_rev3 = len(
+            '{'
+                f'"{key_content_type}":"{content_type}",'
+                f'"{key_content}":"{content}",'
+                f'"{key_data_params}":'
+                '{'
+                    f'"{data_param_keys[0]}":"{data_param_values[0]}",'
+                    f'"{data_param_keys[1]}":"{data_param_values[1]}",'
+                    f'"{data_param_keys[2]}":"{data_param_values[2]}",'
+                    f'"{data_param_keys[3]}":"{data_param_values[3]}",'
+                    f'"{data_param_keys[4]}":"{data_param_values[4]}"'
+                '}'
+            '}'.encode())
 
         expected_steps = self._get_expected_step_count(step_costs, input_size_rev3, content_size)
         self.assertEqual(expected_steps, estimated_steps)

--- a/tests/integrate_test/test_integrate_estimate_step.py
+++ b/tests/integrate_test/test_integrate_estimate_step.py
@@ -395,7 +395,7 @@ class TestIntegrateEstimateStep(TestIntegrateBase):
 
         input_size_rev2 = \
             self._get_str_size(content_type) + \
-            content_size + \
+            self._get_bin_size(content) + \
             self._get_str_size(data_param_values[0]) + \
             self._get_bin_size(data_param_values[1]) + \
             self._get_bin_size(data_param_values[2]) + \
@@ -427,13 +427,13 @@ class TestIntegrateEstimateStep(TestIntegrateBase):
 
         input_size_rev3 = \
             self._get_str_size(key_content_type) + self._get_str_size(content_type) + \
-            self._get_str_size(key_content) + content_size + \
+            self._get_str_size(key_content) + self._get_str_size(content) + \
             self._get_str_size(key_data_params) + \
             self._get_str_size(data_param_keys[0]) + self._get_str_size(data_param_values[0]) + \
-            self._get_str_size(data_param_keys[1]) + self._get_bin_size(data_param_values[1]) + \
+            self._get_str_size(data_param_keys[1]) + self._get_str_size(data_param_values[1]) + \
             self._get_str_size(data_param_keys[2]) + self._get_str_size(data_param_values[2]) + \
             self._get_str_size(data_param_keys[3]) + self._get_str_size(data_param_values[3]) + \
-            self._get_str_size(data_param_keys[4]) + self._get_bin_size(data_param_values[4])
+            self._get_str_size(data_param_keys[4]) + self._get_str_size(data_param_values[4])
 
         expected_steps = self._get_expected_step_count(step_costs, input_size_rev3, content_size)
         self.assertEqual(expected_steps, estimated_steps)

--- a/tests/test_icon_score_step.py
+++ b/tests/test_icon_score_step.py
@@ -116,6 +116,34 @@ class TestIconScoreStepCounter(unittest.TestCase):
         # check SCORE update stepUsed value
         self._assert_step_used(step_used_update, request2, tx_hash2)
 
+    def test_message_step(self):
+        self._inner_task._icon_service_engine._validate_score_blacklist = Mock()
+
+        tx_hash1 = bytes.hex(create_tx_hash())
+        from_ = create_address(AddressPrefix.EOA)
+        to_ = from_
+        # data size 25
+        data = '0x01234abcde01234abcde01234abcde01234abcde01234abcde'
+
+        request = create_request([
+            ReqData(tx_hash1, from_, to_, 'message', data),
+        ])
+
+        result = self._inner_task_invoke(request)
+        self.assertEqual(result['txResults'][tx_hash1]['status'], '0x1')
+
+        input_length = 25
+
+        self.assertEqual(self.step_counter.apply_step.call_args_list[0][0],
+                         (StepType.DEFAULT, 1))
+        self.assertEqual(self.step_counter.apply_step.call_args_list[1][0],
+                         (StepType.INPUT, input_length))
+        self.assertEqual(len(self.step_counter.apply_step.call_args_list), 2)
+
+        step_used = self._calc_step_used(0, 2)
+
+        self._assert_step_used(step_used, request, tx_hash1)
+
     def test_transfer_step(self):
         tx_hash = bytes.hex(create_tx_hash())
         from_ = create_address(AddressPrefix.EOA)


### PR DESCRIPTION
- basic rule
  - Calculating strings
    : Counts UTF-8 encoded byte length
  ~- Calculating binaries (0x prefixed lowercase hex-string)~
    ~: Counts real byte length~
  ~- 0x prefixed hex-string which included uppercases is not a binary~
- when pre-validating
  - Counts key and value as a string
  - Reject non-binary data on message type transaction
- when input STEP counting
  - Counts key and value
  - Counts key as a string
  ~- If the value is 0x prefixed lowercase hex-string, counts as a binary~
  ~- If the value is a negative integer(e.g. -0x1a2b3c), counts as a binary with removing a sign.~
  ~- Otherwise, counts as a string~
  - Counts value as a string
- when content(deploying) STEP counting
  - Calculating as a binary