### PR TITLE
fix bug in check_rabbitmq

### DIFF
--- a/iconservice/icon_service.py
+++ b/iconservice/icon_service.py
@@ -127,7 +127,7 @@ def main():
     Logger.load_config(conf)
     Logger.print_config(conf, ICON_SERVICE_CLI)
 
-    _run_async(_check_rabbitmq())
+    _run_async(_check_rabbitmq(conf[ConfigKey.AMQP_TARGET]))
     icon_service = IconService()
     icon_service.serve(config=conf)
     Logger.info(f'==========IconService Done==========', ICON_SERVICE_CLI)
@@ -144,12 +144,12 @@ def _run_async(async_func):
     return loop.run_until_complete(async_func)
 
 
-async def _check_rabbitmq():
+async def _check_rabbitmq(amqp_target: str):
     connection = None
     try:
         amqp_user_name = os.getenv("AMQP_USERNAME", "guest")
         amqp_password = os.getenv("AMQP_PASSWORD", "guest")
-        connection = await aio_pika.connect(login=amqp_user_name, password=amqp_password)
+        connection = await aio_pika.connect(host=amqp_target, login=amqp_user_name, password=amqp_password)
         connection.connect()
     except ConnectionRefusedError:
         Logger.error("rabbitmq-service disable", ICON_SERVICE_CLI)

--- a/iconservice/icon_service.py
+++ b/iconservice/icon_service.py
@@ -134,7 +134,7 @@ def main():
 
 
 def run_in_foreground(conf: 'IconConfig'):
-    _run_async(_check_rabbitmq())
+    _run_async(_check_rabbitmq(conf[ConfigKey.AMQP_TARGET]))
     icon_service = IconService()
     icon_service.serve(config=conf)
 


### PR DESCRIPTION
I want to apply to add amqp_target in check_rabbitmq function.
because of we can't do when we want to connect external host like "1.1.1.1"
also we are going to fix rpcserver like this.