### PR TITLE
remove unused logic about system_score_base

### DIFF
--- a/iconservice/iconscore/icon_score_api_generator.py
+++ b/iconservice/iconscore/icon_score_api_generator.py
@@ -64,7 +64,9 @@ class ScoreApiGenerator:
             if param_name == 'self' or param_name == 'cls':
                 continue
             if param.kind != Parameter.VAR_KEYWORD:
-                ScoreApiGenerator.__generate_inputs(dict(sig_info.parameters))
+                ScoreApiGenerator.__generate_input([], param, False)
+            else:
+                raise InvalidParamsException("can't use keyward argument like **kwargs")
 
     @staticmethod
     def __generate_functions(src: list, score_funcs: list) -> None:

--- a/iconservice/iconscore/icon_score_api_generator.py
+++ b/iconservice/iconscore/icon_score_api_generator.py
@@ -66,7 +66,7 @@ class ScoreApiGenerator:
             if param.kind != Parameter.VAR_KEYWORD:
                 ScoreApiGenerator.__generate_input([], param, False)
             else:
-                raise InvalidParamsException("can't use keyward argument like **kwargs")
+                raise InvalidParamsException("Keyword arguments not allowed")
 
     @staticmethod
     def __generate_functions(src: list, score_funcs: list) -> None:

--- a/iconservice/iconscore/icon_score_base.py
+++ b/iconservice/iconscore/icon_score_base.py
@@ -295,7 +295,7 @@ class IconScoreObject(ABC):
 class IconScoreBaseMeta(ABCMeta):
 
     def __new__(mcs, name, bases, namespace, **kwargs):
-        if IconScoreObject in bases:
+        if IconScoreObject in bases or name == "IconSystemScoreBase":
             return super().__new__(mcs, name, bases, namespace, **kwargs)
 
         cls = super().__new__(mcs, name, bases, namespace, **kwargs)


### PR DESCRIPTION
we don't need to execute IconScoreBaseMeta's logic in systemSCORE
so I add filtering check logic for skip below logics

and
I add raise exception code to prevent keyword argument on deploy function like on_install and on_update 