### PR TITLE
fix internal_call_refactoring

### DIFF
--- a/iconservice/iconscore/icx.py
+++ b/iconservice/iconscore/icx.py
@@ -16,7 +16,7 @@
 
 from typing import TYPE_CHECKING
 
-from iconservice.iconscore.icon_score_constant import STR_FALLBACK
+from .icon_score_constant import STR_FALLBACK
 from .icon_score_context_util import IconScoreContextUtil
 from .internal_call import InternalCall
 from ..base.address import Address, GOVERNANCE_SCORE_ADDRESS

--- a/iconservice/iconscore/internal_call.py
+++ b/iconservice/iconscore/internal_call.py
@@ -16,6 +16,7 @@
 
 from typing import TYPE_CHECKING, Optional, Any
 
+from .icon_score_constant import STR_FALLBACK
 from .icon_score_context_util import IconScoreContextUtil
 from .icon_score_event_log import EventLogEmitter
 from .icon_score_step import StepType
@@ -40,9 +41,11 @@ class InternalCall(object):
                             addr_from: 'Address',
                             addr_to: 'Address',
                             amount: int,
-                            func_name: str,
+                            func_name: Optional[str],
                             arg_params: Optional[tuple] = None,
                             kw_params: Optional[dict] = None) -> Any:
+        if func_name is None:
+            func_name = STR_FALLBACK
         return InternalCall._call(context, addr_from, addr_to, amount, func_name, arg_params, kw_params)
 
     @staticmethod


### PR DESCRIPTION
I found db sync bug when I tried to sync testnetDB at 33,756 BH.
this bug is occur by internal_call codes.

I fixed that none -> "fallback" already. but about "fallback" I can't edit SCORE db's info.
but multisigwallet SCORE already saved some tx's info to call this SCORE external function before. 
even transfer icx. so I fixed like this.