### PR TITLE
IS-370: Unify revision3 and revision4 into revision3

### DIFF
--- a/iconservice/iconscore/icon_score_base.py
+++ b/iconservice/iconscore/icon_score_base.py
@@ -36,7 +36,7 @@ from ..base.address import Address, GOVERNANCE_SCORE_ADDRESS
 from ..base.exception import IconScoreException, IconTypeError, InterfaceException, PayableException, ExceptionCode, \
     EventLogException, ExternalException, ServerErrorException
 from ..database.db import IconScoreDatabase, DatabaseObserver
-from ..icon_constant import ICX_TRANSFER_EVENT_LOG, REVISION_4
+from ..icon_constant import ICX_TRANSFER_EVENT_LOG, REVISION_3
 from ..utils import get_main_type_from_annotations_type
 
 if TYPE_CHECKING:
@@ -406,7 +406,7 @@ class IconScoreBase(IconScoreObject, ContextGetter,
                kw_params: Optional[dict] = None) -> Any:
 
         if func_name == STR_FALLBACK:
-            if self._context.revision >= REVISION_4:
+            if self._context.revision >= REVISION_3:
                 if not self.__is_payable_method(func_name):
                     raise ExternalException(f"Method not found",
                                             func_name,

--- a/iconservice/iconscore/icon_score_mapper_object.py
+++ b/iconservice/iconscore/icon_score_mapper_object.py
@@ -17,7 +17,7 @@
 from ..base.address import Address, GOVERNANCE_SCORE_ADDRESS
 from ..base.exception import InvalidParamsException
 from ..database.db import IconScoreDatabase
-from ..icon_constant import REVISION_3
+from ..icon_constant import REVISION_2
 
 
 class IconScoreInfo(object):
@@ -62,7 +62,7 @@ class IconScoreInfo(object):
         :param revision:
         :return:
         """
-        if revision <= REVISION_3 or self.address == GOVERNANCE_SCORE_ADDRESS:
+        if revision <= REVISION_2 or self.address == GOVERNANCE_SCORE_ADDRESS:
             if self._score is None:
                 self._score = self.create_score()
 

--- a/tests/integrate_test/test_integrate_existent_scores.py
+++ b/tests/integrate_test/test_integrate_existent_scores.py
@@ -67,7 +67,7 @@ class TestIntegrateExistentScores(TestIntegrateBase):
         self.assertEqual(tx_results[0].status, int(True))
         return tx['params']['txHash']
 
-    def _set_revision(self, revision=4):
+    def _set_revision(self, revision):
         set_revision_tx = self._make_score_call_tx(self._admin, GOVERNANCE_SCORE_ADDRESS, 'setRevision',
                                                    {"code": hex(revision), "name": f"1.1.{revision}"})
         prev_block, tx_results = self._make_and_req_block([set_revision_tx])
@@ -143,7 +143,7 @@ class TestIntegrateExistentScores(TestIntegrateBase):
 
         # set revision to 4(revision4)
         self._update_governance('0_0_4')
-        self._set_revision()
+        self._set_revision(3)
 
         # deploy SCORE
         tx1 = self._deploy_score("test_deploy_scores/install", "sample_token", self._addr_array[0], ZERO_SCORE_ADDRESS,
@@ -205,7 +205,7 @@ class TestIntegrateExistentScores(TestIntegrateBase):
         self.assertEqual(tx_results[0].status, int(False))
 
         # set revision to 4
-        self._set_revision()
+        self._set_revision(3)
 
         # deploy(revision3 must be success)
         tx4 = self._deploy_score("test_deploy_scores/install", "sample_token", self._addr_array[0], ZERO_SCORE_ADDRESS,
@@ -219,7 +219,7 @@ class TestIntegrateExistentScores(TestIntegrateBase):
         self._setUp()
 
         # set revision to 3
-        self._set_revision()
+        self._set_revision(3)
         sample_score_init_params = {"value": hex(1000)}
 
         # deploy unnormal SCORE(not python)

--- a/tests/integrate_test/test_integrate_existent_scores_audit.py
+++ b/tests/integrate_test/test_integrate_existent_scores_audit.py
@@ -67,7 +67,7 @@ class TestIntegrateExistentScoresAudit(TestIntegrateBase):
         self.assertEqual(tx_results[0].status, int(True))
         return tx['params']['txHash']
 
-    def _set_revision(self, revision=4):
+    def _set_revision(self, revision):
         set_revision_tx = self._make_score_call_tx(self._admin, GOVERNANCE_SCORE_ADDRESS, 'setRevision',
                                                    {"code": hex(revision), "name": f"1.1.{revision}"})
         prev_block, tx_results = self._make_and_req_block([set_revision_tx])
@@ -145,7 +145,7 @@ class TestIntegrateExistentScoresAudit(TestIntegrateBase):
         # set revision to 4
         update_governance_tx = self._update_governance('0_0_4')
         self._accept_score(update_governance_tx)
-        self._set_revision()
+        self._set_revision(3)
 
         # deploy SCORE
         tx1 = self._deploy_score("test_deploy_scores/install", "sample_token", self._addr_array[0], ZERO_SCORE_ADDRESS,
@@ -215,7 +215,7 @@ class TestIntegrateExistentScoresAudit(TestIntegrateBase):
         self.assertEqual(accept_result[0].status, int(False))
 
         # set revision to 4
-        self._set_revision()
+        self._set_revision(3)
 
         # deploy (revision4 must be success)
         tx4 = self._deploy_score("test_deploy_scores/install", "sample_token", self._addr_array[0], ZERO_SCORE_ADDRESS,
@@ -232,7 +232,7 @@ class TestIntegrateExistentScoresAudit(TestIntegrateBase):
         # set revision to 3
         update_governance_tx = self._update_governance('0_0_4')
         self._accept_score(update_governance_tx)
-        self._set_revision()
+        self._set_revision(3)
         sample_score_params = {"value": hex(1000)}
 
         # deploy SCORE(not python)

--- a/tests/integrate_test/test_integrate_fallback_call.py
+++ b/tests/integrate_test/test_integrate_fallback_call.py
@@ -34,7 +34,7 @@ class TestIntegrateFallbackCall(TestIntegrateBase):
         self.assertEqual(tx_results[0].status, int(True))
         return tx['params']['txHash']
 
-    def _set_revision(self, revision=4):
+    def _set_revision(self, revision):
         set_revision_tx = self._make_score_call_tx(self._admin, GOVERNANCE_SCORE_ADDRESS, 'setRevision',
                                                    {"code": hex(revision), "name": f"1.1.{revision}"})
         prev_block, tx_results = self._make_and_req_block([set_revision_tx])
@@ -164,10 +164,10 @@ class TestIntegrateFallbackCall(TestIntegrateBase):
         response = self._query(query_request, 'icx_getBalance')
         self.assertEqual(response, 0)
 
-    def test_score_no_payable_revision_4(self):
+    def test_score_no_payable_revision_3(self):
         # update governance SCORE(revision4)
         self._update_governance('0_0_4')
-        self._set_revision()
+        self._set_revision(3)
 
         tx1 = self._make_deploy_tx("test_fallback_call_scores",
                                    "test_score_no_payable",
@@ -323,10 +323,10 @@ class TestIntegrateFallbackCall(TestIntegrateBase):
         response = self._query(query_request, 'icx_getBalance')
         self.assertEqual(response, 0)
 
-    def test_score_no_payable_link_transfer_revision_4(self):
+    def test_score_no_payable_link_transfer_revision_3(self):
         # update governance SCORE(revision4)
         self._update_governance('0_0_4')
-        self._set_revision()
+        self._set_revision(3)
 
         tx1 = self._make_deploy_tx("test_fallback_call_scores",
                                    "test_score_no_payable",
@@ -631,7 +631,7 @@ class TestIntegrateFallbackCall(TestIntegrateBase):
 
         # update governance SCORE(revision4)
         self._update_governance('0_0_4')
-        self._set_revision()
+        self._set_revision(3)
 
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
@@ -664,7 +664,7 @@ class TestIntegrateFallbackCall(TestIntegrateBase):
 
         # update governance SCORE(revision4)
         self._update_governance('0_0_4')
-        self._set_revision()
+        self._set_revision(3)
 
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
@@ -697,7 +697,7 @@ class TestIntegrateFallbackCall(TestIntegrateBase):
 
         # update governance SCORE(revision4)
         self._update_governance('0_0_4')
-        self._set_revision()
+        self._set_revision(3)
 
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)

--- a/tests/integrate_test/test_integrate_member_variable_score.py
+++ b/tests/integrate_test/test_integrate_member_variable_score.py
@@ -49,7 +49,7 @@ class TestScoreMemberVariable(TestIntegrateBase):
         self._write_precommit_state(prev_block)
         return tx_results[0]
 
-    def _set_revision(self, revision=3):
+    def _set_revision(self, revision):
         params = {
             "code": hex(revision),
             "name": f"1.1.{revision}"
@@ -87,7 +87,7 @@ class TestScoreMemberVariable(TestIntegrateBase):
 
     def test_use_every_time_created_score(self):
         self._update_governance()
-        self._set_revision(revision=4)
+        self._set_revision(3)
 
         _from: 'Address' = self._addr_array[0]
 


### PR DESCRIPTION
accoording to policy, change revision4 to revision3 about all logic

I think it should assign value explicitly .
remove default input param revision=3 in integration-test.