### PR TITLE
IS-377: Reject non-string values of input data field on pre-validating

### DIFF
--- a/iconservice/iconscore/icon_pre_validator.py
+++ b/iconservice/iconscore/icon_pre_validator.py
@@ -126,7 +126,7 @@ class IconPreValidator:
             for v in data:
                 IconPreValidator._check_input_data_type(v)
         elif data is not None and not isinstance(data, str):
-            # the leaf value can only be None and str.
+            # The leaf value should be None or str.
             raise InvalidRequestException(f'Invalid data type')
 
     @staticmethod

--- a/iconservice/iconscore/icon_pre_validator.py
+++ b/iconservice/iconscore/icon_pre_validator.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from .icon_score_step import get_input_data_size
 from ..base.address import Address, ZERO_SCORE_ADDRESS, generate_score_address
@@ -58,10 +58,7 @@ class IconPreValidator:
         :param minimum_step: minimum step
         """
 
-        if 'message' == params.get('dataType', None):
-            self._check_message_data(params.get('data', None))
-
-        self._check_input_data_size(params)
+        self._check_input_data(params)
 
         value: int = params.get('value', 0)
         if value < 0:
@@ -86,9 +83,27 @@ class IconPreValidator:
             self._check_from_can_charge_fee_v3(context, params, step_price)
 
     @staticmethod
+    def _check_input_data(params):
+        """
+        Validates input data. It checks the input data type and the input data size.
+
+        :param params: params of icx_sendTransaction JSON-RPC request
+        :return:
+        """
+
+        input_data = params.get('data', None)
+        if 'message' == params.get('dataType', None):
+            IconPreValidator._check_message_data(input_data)
+        else:
+            IconPreValidator._check_input_data_type(input_data)
+
+        IconPreValidator._check_input_data_size(input_data)
+
+    @staticmethod
     def _check_message_data(data):
         """
         Check if the message data is a lowercase hex string
+
         :param data: input data of message type
         """
         if isinstance(data, str) \
@@ -100,7 +115,22 @@ class IconPreValidator:
         raise InvalidRequestException('Invalid message data')
 
     @staticmethod
-    def _check_input_data_size(params: dict):
+    def _check_input_data_type(data):
+        """
+        Validates transaction data types whether the leaf fields are str or None
+        """
+        if isinstance(data, dict):
+            for k, v in data.items():
+                IconPreValidator._check_input_data_type(v)
+        elif isinstance(data, list):
+            for v in data:
+                IconPreValidator._check_input_data_type(v)
+        elif data is not None and not isinstance(data, str):
+            # the leaf value can only be None and str.
+            raise InvalidRequestException(f'Invalid data type')
+
+    @staticmethod
+    def _check_input_data_size(input_data: Any):
         """
         Validates transaction data whether total bytes is less than MAX_DATA_SIZE
         If the property is a key-value object, counts key and value.
@@ -109,12 +139,11 @@ class IconPreValidator:
         to original format (string -> int, string -> Address, etc)
         But the field of 'data' has not been converted (TypeConvert marks it as LATER)
 
-        :param params: params of icx_sendTransaction JSON-RPC request
+        :param input_data: data field of icx_sendTransaction JSON-RPC request
         """
 
-        if 'data' in params:
-            data = params['data']
-            size = get_input_data_size(LATEST_REVISION, data)
+        if input_data is not None:
+            size = get_input_data_size(LATEST_REVISION, input_data)
 
             if size > MAX_DATA_SIZE:
                 raise InvalidRequestException(f'Invalid message length')

--- a/iconservice/iconscore/icon_pre_validator.py
+++ b/iconservice/iconscore/icon_pre_validator.py
@@ -120,7 +120,7 @@ class IconPreValidator:
         Validates transaction data types whether the leaf fields are str or None
         """
         if isinstance(data, dict):
-            for k, v in data.items():
+            for v in data.values():
                 IconPreValidator._check_input_data_type(v)
         elif isinstance(data, list):
             for v in data:

--- a/tests/icon_score/test_icon_pre_validator.py
+++ b/tests/icon_score/test_icon_pre_validator.py
@@ -111,6 +111,78 @@ class TestTransactionValidator(unittest.TestCase):
         self.validator.execute_to_check_out_of_balance(None, {"version": 3}, ANY)
         self.validator._check_from_can_charge_fee_v3.assert_called_once()
 
+    def test_check_input_data_type(self):
+        # flat data with string
+        self.validator._check_input_data_type("plain text")
+
+        # flat data with int
+        with self.assertRaises(InvalidRequestException) as e:
+            self.validator._check_input_data_type(10000)
+            self.assertEqual(e.exception.message, 'Invalid data type')
+
+        # flat data with bool
+        with self.assertRaises(InvalidRequestException) as e:
+            self.validator._check_input_data_type(False)
+            self.assertEqual(e.exception.message, 'Invalid data type')
+
+        # flat data with float
+        with self.assertRaises(InvalidRequestException) as e:
+            self.validator._check_input_data_type(10.1)
+            self.assertEqual(e.exception.message, 'Invalid data type')
+
+        params = {
+            "method": "transfer",
+            "params": {
+                "to": "hxab2d8215eab14bc6bdd8bfb2c8151257032ecd8b",
+                "value": "0x1"
+            }
+
+        }
+
+        # dict data with string
+        self.validator._check_input_data_type(params)
+
+        # dict data with int
+        with self.assertRaises(InvalidRequestException) as e:
+            params['params']['value'] = 10000
+            self.validator._check_input_data_type(params)
+            self.assertEqual(e.exception.message, 'Invalid data type')
+
+        # dict data with bool
+        with self.assertRaises(InvalidRequestException) as e:
+            params['params']['value'] = False
+            self.validator._check_input_data_type(params)
+            self.assertEqual(e.exception.message, 'Invalid data type')
+
+        # dict data with float
+        with self.assertRaises(InvalidRequestException) as e:
+            params['params']['value'] = 10.1
+            self.validator._check_input_data_type(params)
+            self.assertEqual(e.exception.message, 'Invalid data type')
+
+        params['params']['value'] = ['one', 'two']
+
+        # list data with string
+        self.validator._check_input_data_type(params)
+
+        # list data with int
+        with self.assertRaises(InvalidRequestException) as e:
+            params['params']['value'][1] = 2
+            self.validator._check_input_data_type(params)
+            self.assertEqual(e.exception.message, 'Invalid data type')
+
+        # list data with bool
+        with self.assertRaises(InvalidRequestException) as e:
+            params['params']['value'][1] = False
+            self.validator._check_input_data_type(params)
+            self.assertEqual(e.exception.message, 'Invalid data type')
+
+        # list data with float
+        with self.assertRaises(InvalidRequestException) as e:
+            params['params']['value'][1] = 10.1
+            self.validator._check_input_data_type(params)
+            self.assertEqual(e.exception.message, 'Invalid data type')
+
     def test_check_message_data(self):
         self.assert_message_input_raises(None)
         self.assert_message_input_raises({})

--- a/tests/integrate_test/test_integrate_base.py
+++ b/tests/integrate_test/test_integrate_base.py
@@ -133,7 +133,8 @@ class TestIntegrateBase(TestCase):
                         deploy_params: dict = None,
                         timestamp_us: int = None,
                         data: bytes = None,
-                        is_sys: bool = False):
+                        is_sys: bool = False,
+                        pre_validation_enabled: bool = True):
 
         if deploy_params is None:
             deploy_params = {}
@@ -175,7 +176,9 @@ class TestIntegrateBase(TestCase):
             'params': request_params
         }
 
-        self.icon_service_engine.validate_transaction(tx)
+        if pre_validation_enabled:
+            self.icon_service_engine.validate_transaction(tx)
+
         return tx
 
     def _make_score_call_tx(self,
@@ -183,7 +186,8 @@ class TestIntegrateBase(TestCase):
                             addr_to: 'Address',
                             method: str,
                             params: dict,
-                            value: int = 0):
+                            value: int = 0,
+                            pre_validation_enabled: bool = True):
 
         timestamp_us = create_timestamp()
         nonce = 0
@@ -212,7 +216,9 @@ class TestIntegrateBase(TestCase):
             'params': request_params
         }
 
-        self.icon_service_engine.validate_transaction(tx)
+        if pre_validation_enabled:
+            self.icon_service_engine.validate_transaction(tx)
+
         return tx
 
     def _make_icx_send_tx(self,

--- a/tests/integrate_test/test_integrate_deploy_install.py
+++ b/tests/integrate_test/test_integrate_deploy_install.py
@@ -310,7 +310,6 @@ class TestIntegrateDeployInstall(TestIntegrateBase):
             'params': request_params
         }
 
-        self.icon_service_engine.validate_transaction(tx)
         return tx
 
     def _query_revision(self):

--- a/tests/integrate_test/test_integrate_score_method_parameters_type.py
+++ b/tests/integrate_test/test_integrate_score_method_parameters_type.py
@@ -27,16 +27,15 @@ NUM0 = 0
 INT_VAL = '0x14'
 STRING_VAL = 'string value'
 BYTE_VAL = bytes.hex(b'byte string')
-ADDRESS_VAL = str(Address.from_string(f"hx{'abcd1234'*5}"))
+ADDRESS_VAL = str(Address.from_string(f"hx{'abcd1234' * 5}"))
 BOOL_VAL = hex(False)
-
-# 'asdf' '1' -> True, '2', int type에 'a'
 
 
 class TestIntegrateMethodParamters(TestIntegrateBase):
 
     def test_int_type_parameters_methods(self):
-        tx1 = self._make_deploy_tx("test_scores", "test_db_returns", self._addr_array[0], ZERO_SCORE_ADDRESS,
+        tx1 = self._make_deploy_tx("test_scores", "test_db_returns", self._addr_array[0],
+                                   ZERO_SCORE_ADDRESS,
                                    deploy_params={"value": str(self._addr_array[1]),
                                                   "value1": str(self._addr_array[1])})
 
@@ -57,52 +56,60 @@ class TestIntegrateMethodParamters(TestIntegrateBase):
             }
         }
         response = self._query(query_request)
-        self.assertEqual(response, 0) # original value: 0(int)
+        self.assertEqual(response, 0)  # original value: 0(int)
 
         # set value to '1' -> set 1
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value1', {"value": ONE})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value1',
+                                      {"value": ONE}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(True))
 
         # set value to '0' -> set 0
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value1', {"value": ZERO})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value1',
+                                      {"value": ZERO}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(True))
 
         # set value to '' -> fail
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value1', {"value": EMPTY_STR})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value1',
+                                      {"value": EMPTY_STR}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to b'' -> fail
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value1', {"value": EMPTY_BYTE})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value1',
+                                      {"value": EMPTY_BYTE}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to None -> fail
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value1', {"value": None})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value1',
+                                      {"value": None}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to 1 -> fail
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value1', {"value": NUM1})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value1',
+                                      {"value": NUM1}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to 0 -> fail
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value1', {"value": NUM0})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value1',
+                                      {"value": NUM0}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to '0x14' -> set 20
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value1', {"value": INT_VAL})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value1',
+                                      {"value": INT_VAL}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(True))
@@ -110,25 +117,29 @@ class TestIntegrateMethodParamters(TestIntegrateBase):
         self.assertEqual(response, 20)
 
         # set value to 'string value'' -> fail
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value1', {"value": STRING_VAL})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value1',
+                                      {"value": STRING_VAL}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to b'byte value' -> fail
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value1', {"value": BYTE_VAL})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value1',
+                                      {"value": BYTE_VAL}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to address value -> fail
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value1', {"value": ADDRESS_VAL})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value1',
+                                      {"value": ADDRESS_VAL}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to False -> 0
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value1', {"value": BOOL_VAL})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value1',
+                                      {"value": BOOL_VAL}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(True))
@@ -136,21 +147,25 @@ class TestIntegrateMethodParamters(TestIntegrateBase):
         self.assertEqual(response, 0)
 
         # set value to 'a' -> fail
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value1', {"value": 'a'})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value1',
+                                      {"value": 'a'})
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to 'A' -> fail
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value1', {"value": 'A'})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value1',
+                                      {"value": 'A'})
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
     def test_str_type_parameters_methods(self):
-        tx1 = self._make_deploy_tx("test_scores", "test_db_returns", self._addr_array[0], ZERO_SCORE_ADDRESS,
+        tx1 = self._make_deploy_tx("test_scores", "test_db_returns", self._addr_array[0],
+                                   ZERO_SCORE_ADDRESS,
                                    deploy_params={"value": str(self._addr_array[1]),
-                                                  "value1": str(self._addr_array[1])})
+                                                  "value1": str(self._addr_array[1])},
+                                   pre_validation_enabled=False)
 
         prev_block, tx_results = self._make_and_req_block([tx1])
         self._write_precommit_state(prev_block)
@@ -167,10 +182,11 @@ class TestIntegrateMethodParamters(TestIntegrateBase):
             }
         }
         response = self._query(query_request)
-        self.assertEqual(response, "") # original value: 0(int)
+        self.assertEqual(response, "")  # original value: 0(int)
 
         # set value to '1' -> set '1'
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value2', {"value": ONE})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value2',
+                                      {"value": ONE}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(True))
@@ -178,7 +194,8 @@ class TestIntegrateMethodParamters(TestIntegrateBase):
         self.assertEqual(response, ONE)
 
         # set value to '0' -> set '0'
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value2', {"value": ZERO})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value2',
+                                      {"value": ZERO}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(True))
@@ -186,7 +203,8 @@ class TestIntegrateMethodParamters(TestIntegrateBase):
         self.assertEqual(response, ZERO)
 
         # set value to '' -> set ''
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value2', {"value": EMPTY_STR})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value2',
+                                      {"value": EMPTY_STR}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(True))
@@ -194,7 +212,8 @@ class TestIntegrateMethodParamters(TestIntegrateBase):
         self.assertEqual(response, EMPTY_STR)
 
         # set value to b'' -> set ''
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value2', {"value": EMPTY_BYTE})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value2',
+                                      {"value": EMPTY_BYTE}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(True))
@@ -202,25 +221,29 @@ class TestIntegrateMethodParamters(TestIntegrateBase):
         self.assertEqual(response, '')
 
         # set value to None -> fail
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value2', {"value": None})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value2',
+                                      {"value": None}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to 1 -> fail
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value2', {"value": NUM1})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value2',
+                                      {"value": NUM1}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to 0 -> fail
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value2', {"value": NUM0})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value2',
+                                      {"value": NUM0}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to '0x14' -> '0x14'
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value2', {"value": INT_VAL})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value2',
+                                      {"value": INT_VAL}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(True))
@@ -228,7 +251,8 @@ class TestIntegrateMethodParamters(TestIntegrateBase):
         self.assertEqual(response, '0x14')
 
         # set value to 'string value' -> 'string value'
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value2', {"value": STRING_VAL})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value2',
+                                      {"value": STRING_VAL}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(True))
@@ -236,7 +260,8 @@ class TestIntegrateMethodParamters(TestIntegrateBase):
         self.assertEqual(response, STRING_VAL)
 
         # set value to b'byte value' -> b'byte value'
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value2', {"value": BYTE_VAL})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value2',
+                                      {"value": BYTE_VAL}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(True))
@@ -244,7 +269,8 @@ class TestIntegrateMethodParamters(TestIntegrateBase):
         self.assertEqual(response, BYTE_VAL)
 
         # set value to address value -> address string
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value2', {"value": ADDRESS_VAL})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value2',
+                                      {"value": ADDRESS_VAL}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(True))
@@ -252,7 +278,8 @@ class TestIntegrateMethodParamters(TestIntegrateBase):
         self.assertEqual(response, ADDRESS_VAL)
 
         # set value to False -> '0x0'
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value2', {"value": BOOL_VAL})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value2',
+                                      {"value": BOOL_VAL}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(True))
@@ -260,9 +287,11 @@ class TestIntegrateMethodParamters(TestIntegrateBase):
         self.assertEqual(response, hex(False))
 
     def test_byte_type_parameters_methods(self):
-        tx1 = self._make_deploy_tx("test_scores", "test_db_returns", self._addr_array[0], ZERO_SCORE_ADDRESS,
+        tx1 = self._make_deploy_tx("test_scores", "test_db_returns", self._addr_array[0],
+                                   ZERO_SCORE_ADDRESS,
                                    deploy_params={"value": str(self._addr_array[1]),
-                                                  "value1": str(self._addr_array[1])})
+                                                  "value1": str(self._addr_array[1])},
+                                   pre_validation_enabled=False)
 
         prev_block, tx_results = self._make_and_req_block([tx1])
 
@@ -281,22 +310,25 @@ class TestIntegrateMethodParamters(TestIntegrateBase):
             }
         }
         response = self._query(query_request)
-        self.assertEqual(response, None) # original value: 0(int)
+        self.assertEqual(response, None)  # original value: 0(int)
 
         # set value to '1' -> fail
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value3', {"value": ONE})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value3',
+                                      {"value": ONE}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to '0' -> fail
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value3', {"value": ZERO})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value3',
+                                      {"value": ZERO}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to '' fail -> None
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value3', {"value": EMPTY_STR})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value3',
+                                      {"value": EMPTY_STR}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(True))
@@ -304,7 +336,8 @@ class TestIntegrateMethodParamters(TestIntegrateBase):
         self.assertEqual(response, None)
 
         # set value to b'' -> None
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value3', {"value": EMPTY_BYTE})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value3',
+                                      {"value": EMPTY_BYTE}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(True))
@@ -312,25 +345,29 @@ class TestIntegrateMethodParamters(TestIntegrateBase):
         self.assertEqual(response, None)
 
         # set value to None -> fail
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value3', {"value": None})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value3',
+                                      {"value": None}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to 1 -> fail
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value3', {"value": NUM1})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value3',
+                                      {"value": NUM1}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to 0 -> fail
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value3', {"value": NUM0})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value3',
+                                      {"value": NUM0}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to '0x14' -> b'\x14'
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value3', {"value": INT_VAL})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value3',
+                                      {"value": INT_VAL}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(True))
@@ -338,13 +375,15 @@ class TestIntegrateMethodParamters(TestIntegrateBase):
         self.assertEqual(response, bytes.fromhex('14'))
 
         # set value to 'string value' -> fail
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value3', {"value": STRING_VAL})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value3',
+                                      {"value": STRING_VAL}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to b'byte value' -> byte value
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value3', {"value": BYTE_VAL})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value3',
+                                      {"value": BYTE_VAL}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(True))
@@ -352,20 +391,22 @@ class TestIntegrateMethodParamters(TestIntegrateBase):
         self.assertEqual(response, int.to_bytes(int(BYTE_VAL, 16), 11, 'big'))
 
         # set value to address value -> fail
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value3', {"value": ADDRESS_VAL})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value3',
+                                      {"value": ADDRESS_VAL}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to False -> fail
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value3', {"value": BOOL_VAL})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value3',
+                                      {"value": BOOL_VAL}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
     def test_address_type_parameters_methods(self):
-
-        tx1 = self._make_deploy_tx("test_scores", "test_db_returns", self._addr_array[0], ZERO_SCORE_ADDRESS,
+        tx1 = self._make_deploy_tx("test_scores", "test_db_returns", self._addr_array[0],
+                                   ZERO_SCORE_ADDRESS,
                                    deploy_params={"value": str(self._addr_array[1]),
                                                   "value1": str(self._addr_array[1])})
 
@@ -383,71 +424,82 @@ class TestIntegrateMethodParamters(TestIntegrateBase):
             }
         }
         response = self._query(query_request)
-        self.assertEqual(response, self._addr_array[1]) # original value: 0(int)
+        self.assertEqual(response, self._addr_array[1])  # original value: 0(int)
 
         # set value to '1' -> fail
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value4', {"value": ONE})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value4',
+                                      {"value": ONE}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to '0' -> fail
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value4', {"value": ZERO})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value4',
+                                      {"value": ZERO}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to '' fail
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value4', {"value": EMPTY_STR})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value4',
+                                      {"value": EMPTY_STR}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to b'' fail
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value4', {"value": EMPTY_BYTE})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value4',
+                                      {"value": EMPTY_BYTE}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to None -> fail
 
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value4', {"value": None})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value4',
+                                      {"value": None}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to 1 -> fail
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value4', {"value": NUM1})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value4',
+                                      {"value": NUM1}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to 0 -> fail
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value4', {"value": NUM0})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value4',
+                                      {"value": NUM0}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to '0x14'
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value4', {"value": INT_VAL})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value4',
+                                      {"value": INT_VAL}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to 'string value''
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value4', {"value": STRING_VAL})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value4',
+                                      {"value": STRING_VAL}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to b'byte value'
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value4', {"value": BYTE_VAL})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value4',
+                                      {"value": BYTE_VAL}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to address value
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value4', {"value": ADDRESS_VAL})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value4',
+                                      {"value": ADDRESS_VAL}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(True))
@@ -455,14 +507,15 @@ class TestIntegrateMethodParamters(TestIntegrateBase):
         self.assertEqual(response, Address.from_string(ADDRESS_VAL))
 
         # set value to False
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value4', {"value": BOOL_VAL})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value4',
+                                      {"value": BOOL_VAL}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
     def test_bool_type_parameters_methods(self):
-
-        tx1 = self._make_deploy_tx("test_scores", "test_db_returns", self._addr_array[0], ZERO_SCORE_ADDRESS,
+        tx1 = self._make_deploy_tx("test_scores", "test_db_returns", self._addr_array[0],
+                                   ZERO_SCORE_ADDRESS,
                                    deploy_params={"value": str(self._addr_array[1]),
                                                   "value1": str(self._addr_array[1])})
 
@@ -480,10 +533,11 @@ class TestIntegrateMethodParamters(TestIntegrateBase):
             }
         }
         response = self._query(query_request)
-        self.assertEqual(response, False) # original value: 0(int)
+        self.assertEqual(response, False)  # original value: 0(int)
 
         # set value to '1' -> True
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value5', {"value": ONE})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value5',
+                                      {"value": ONE}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(True))
@@ -491,7 +545,8 @@ class TestIntegrateMethodParamters(TestIntegrateBase):
         self.assertEqual(response, True)
 
         # set value to '0' -> False
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value5', {"value": ZERO})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value5',
+                                      {"value": ZERO}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(True))
@@ -499,37 +554,48 @@ class TestIntegrateMethodParamters(TestIntegrateBase):
         self.assertEqual(response, False)
 
         # set value to '' -> fail
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value5', {"value": EMPTY_STR})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value5',
+                                      {"value": EMPTY_STR}, pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to b'' -> fail
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value5', {"value": EMPTY_BYTE})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value5',
+                                      {"value": EMPTY_BYTE},
+                                      pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to None -> fail
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value5', {"value": None})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value5',
+                                      {"value": None},
+                                      pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to 1 -> fail
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value5', {"value": NUM1})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value5',
+                                      {"value": NUM1},
+                                      pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to 0 -> fail
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value5', {"value": NUM0})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value5',
+                                      {"value": NUM0},
+                                      pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to '0x14' -> True
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value5', {"value": INT_VAL})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value5',
+                                      {"value": INT_VAL},
+                                      pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(True))
@@ -537,25 +603,33 @@ class TestIntegrateMethodParamters(TestIntegrateBase):
         self.assertEqual(response, True)
 
         # set value to 'string value' -> fail
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value5', {"value": STRING_VAL})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value5',
+                                      {"value": STRING_VAL},
+                                      pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to b'byte value' -> fail
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value5', {"value": BYTE_VAL})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value5',
+                                      {"value": BYTE_VAL},
+                                      pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to address value -> fail
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value5', {"value": ADDRESS_VAL})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value5',
+                                      {"value": ADDRESS_VAL},
+                                      pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(False))
 
         # set value to False -> False
-        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value5', {"value": BOOL_VAL})
+        tx = self._make_score_call_tx(self._addr_array[0], score_addr1, 'set_value5',
+                                      {"value": BOOL_VAL},
+                                      pre_validation_enabled=False)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
         self.assertEqual(tx_results[0].status, int(True))

--- a/tests/integrate_test/test_integrate_service_configuration.py
+++ b/tests/integrate_test/test_integrate_service_configuration.py
@@ -48,7 +48,8 @@ class TestIntegrateServiceConfiguration(TestIntegrateBase):
         tx = self._make_score_call_tx(self._admin,
                                       GOVERNANCE_SCORE_ADDRESS,
                                       'updateServiceConfig',
-                                      params=params)
+                                      params=params,
+                                      pre_validation_enabled=False)
 
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)


### PR DESCRIPTION
Validates whether the leaf fields of transaction data are str or None on pre-validating

```json
{
  ...
  "data": {
    "method": "myMethod",
    "params": { 
      "a": 10000, 
      "b": false, 
      "d": 10.1 
    }
  }
  ...
}
```