### PR TITLE
IS-403: Fix memory leak for IconScoreContext

### DIFF
--- a/iconservice/icon_inner_service.py
+++ b/iconservice/icon_inner_service.py
@@ -118,6 +118,7 @@ class IconScoreInnerTask(object):
             response = MakeResponse.make_error_response(ExceptionCode.SERVER_ERROR, str(e))
         finally:
             Logger.info(f'invoke response with {response}', ICON_INNER_LOG_TAG)
+            self._icon_service_engine.clear_context_stack()
             return response
 
     @message_queue_task
@@ -154,6 +155,7 @@ class IconScoreInnerTask(object):
             response = MakeResponse.make_error_response(ExceptionCode.SERVER_ERROR, str(e))
         finally:
             Logger.info(f'query response with {response}', ICON_INNER_LOG_TAG)
+            self._icon_service_engine.clear_context_stack()
             return response
 
     @message_queue_task
@@ -237,6 +239,7 @@ class IconScoreInnerTask(object):
             response = MakeResponse.make_error_response(ExceptionCode.SERVER_ERROR, str(e))
         finally:
             Logger.info(f'pre_validate_check response with {response}', ICON_INNER_LOG_TAG)
+            self._icon_service_engine.clear_context_stack()
             return response
 
     @message_queue_task

--- a/iconservice/iconscore/icon_score_context.py
+++ b/iconservice/iconscore/icon_score_context.py
@@ -79,6 +79,11 @@ class ContextContainer(object):
     def _clear_context() -> None:
         setattr(_thread_local_data, 'context_stack', None)
 
+    @staticmethod
+    def _get_context_stack_size() -> int:
+        context_stack: List['IconScoreContext'] = getattr(_thread_local_data, 'context_stack', None)
+        return 0 if context_stack is None else len(context_stack)
+
 
 class ContextGetter(object):
     """The class which refers to IconScoreContext should inherit ContextGetter

--- a/tests/test_icon_score_result.py
+++ b/tests/test_icon_score_result.py
@@ -222,6 +222,7 @@ class TestTransactionResult(unittest.TestCase):
         # noinspection PyUnusedLocal
         def intercept_invoke(*args, **kwargs):
             ContextContainer._push_context(args[0])
+
             context_db = inner_task._icon_service_engine._icx_context_db
 
             score_address = create_address(AddressPrefix.CONTRACT, b'address')
@@ -229,6 +230,8 @@ class TestTransactionResult(unittest.TestCase):
 
             address = create_address(AddressPrefix.EOA, b'address')
             score.SampleEvent(b'i_data', address, 10, b'data', 'text')
+
+            ContextContainer._pop_context()
 
         IconScoreEngine.invoke = Mock(side_effect=intercept_invoke)
 

--- a/tests/test_icon_score_step.py
+++ b/tests/test_icon_score_step.py
@@ -176,6 +176,7 @@ class TestIconScoreStepCounter(unittest.TestCase):
             context_db = self._inner_task._icon_service_engine._icx_context_db
             score = SampleScore(IconScoreDatabase(to_, context_db))
             score.transfer()
+            ContextContainer._pop_context()
 
         IconScoreEngine.invoke = Mock(side_effect=intercept_invoke)
 
@@ -212,6 +213,7 @@ class TestIconScoreStepCounter(unittest.TestCase):
             context_db = self._inner_task._icon_service_engine._icx_context_db
             score = SampleScore(IconScoreDatabase(to_, context_db))
             score.set_db(100)
+            ContextContainer._pop_context()
 
         IconScoreEngine.invoke = Mock(side_effect=intercept_invoke)
 
@@ -255,9 +257,12 @@ class TestIconScoreStepCounter(unittest.TestCase):
         # noinspection PyUnusedLocal
         def intercept_invoke(*args, **kwargs):
             ContextContainer._push_context(args[0])
+
             context_db = self._inner_task._icon_service_engine._icx_context_db
             score = SampleScore(IconScoreDatabase(to_, context_db))
             score.get_db()
+
+            ContextContainer._pop_context()
 
         IconScoreEngine.invoke = Mock(side_effect=intercept_invoke)
 
@@ -299,7 +304,9 @@ class TestIconScoreStepCounter(unittest.TestCase):
             ContextContainer._push_context(args[0])
             context_db = self._inner_task._icon_service_engine._icx_context_db
             score = SampleScore(IconScoreDatabase(to_, context_db))
-            return score.query_db()
+            ret = score.query_db()
+            ContextContainer._pop_context()
+            return ret
 
         IconScoreEngine.query = Mock(side_effect=intercept_query)
 
@@ -331,6 +338,7 @@ class TestIconScoreStepCounter(unittest.TestCase):
             context_db = self._inner_task._icon_service_engine._icx_context_db
             score = SampleScore(IconScoreDatabase(to_, context_db))
             score.remove_db()
+            ContextContainer._pop_context()
 
         IconScoreEngine.invoke = Mock(side_effect=intercept_invoke)
 
@@ -378,6 +386,7 @@ class TestIconScoreStepCounter(unittest.TestCase):
                 len(address.body) + \
                 len(data_param) + \
                 len(text_param.encode('utf-8'))
+            ContextContainer._pop_context()
 
         IconScoreEngine.invoke = Mock(side_effect=intercept_invoke)
 
@@ -412,6 +421,7 @@ class TestIconScoreStepCounter(unittest.TestCase):
         def intercept_invoke(*args, **kwargs):
             args[0].revision = REVISION_3
             ContextContainer._push_context(args[0])
+
             context_db = self._inner_task._icon_service_engine._icx_context_db
             address = create_address(AddressPrefix.EOA)
             score = SampleScore(IconScoreDatabase(address, context_db))
@@ -426,6 +436,8 @@ class TestIconScoreStepCounter(unittest.TestCase):
                 ICON_CONTRACT_ADDRESS_BYTES_SIZE + \
                 len(data_param) + \
                 len(text_param.encode('utf-8'))
+
+            ContextContainer._pop_context()
 
         IconScoreEngine.invoke = Mock(side_effect=intercept_invoke)
 
@@ -461,9 +473,12 @@ class TestIconScoreStepCounter(unittest.TestCase):
         # noinspection PyUnusedLocal
         def intercept_invoke(*args, **kwargs):
             ContextContainer._push_context(args[0])
+
             context_db = self._inner_task._icon_service_engine._icx_context_db
             score = SampleScore(IconScoreDatabase(to_, context_db))
             score.hash_readonly(data_to_hash)
+
+            ContextContainer._pop_context()
 
         IconScoreEngine.invoke = Mock(side_effect=intercept_invoke)
 
@@ -502,6 +517,7 @@ class TestIconScoreStepCounter(unittest.TestCase):
             context_db = self._inner_task._icon_service_engine._icx_context_db
             score = SampleScore(IconScoreDatabase(to_, context_db))
             score.hash_writable(data_to_hash)
+            ContextContainer._pop_context()
 
         IconScoreEngine.invoke = Mock(side_effect=intercept_invoke)
 


### PR DESCRIPTION
Add missed ContextContainer._pop_context() call
Clear context stack in IconInnerService
Fix missed pop_context() bug in unittest