### PR TITLE
IS-494: Replace instant block hash with confirmed block hash

### DIFF
--- a/iconservice/base/block.py
+++ b/iconservice/base/block.py
@@ -54,6 +54,9 @@ class Block(object):
     def hash(self) -> bytes:
         return self._hash
 
+    def set_hash(self, block_hash: bytes):
+        self._hash = block_hash
+
     @property
     def timestamp(self) -> int:
         return self._timestamp

--- a/iconservice/base/block.py
+++ b/iconservice/base/block.py
@@ -54,9 +54,6 @@ class Block(object):
     def hash(self) -> bytes:
         return self._hash
 
-    def set_hash(self, block_hash: bytes):
-        self._hash = block_hash
-
     @property
     def timestamp(self) -> int:
         return self._timestamp

--- a/iconservice/base/type_converter_templates.py
+++ b/iconservice/base/type_converter_templates.py
@@ -81,6 +81,8 @@ KEY_CONVERTER = 'KEY_CONVERTER'
 class ConstantKeys:
     BLOCK_HEIGHT = "blockHeight"
     BLOCK_HASH = "blockHash"
+    OLD_BLOCK_HASH = "oldBlockHash"
+    NEW_BLOCK_HASH = "newBlockHash"
     TIMESTAMP = "timestamp"
     PREV_BLOCK_HASH = "prevBlockHash"
 
@@ -242,8 +244,11 @@ type_convert_templates[ParamType.QUERY] = {
 
 type_convert_templates[ParamType.WRITE_PRECOMMIT] = {
     ConstantKeys.BLOCK_HEIGHT: ValueType.INT,
-    ConstantKeys.BLOCK_HASH: ValueType.BYTES
+    ConstantKeys.BLOCK_HASH: ValueType.BYTES,
+    ConstantKeys.OLD_BLOCK_HASH: ValueType.BYTES,
+    ConstantKeys.NEW_BLOCK_HASH: ValueType.BYTES
 }
+
 type_convert_templates[ParamType.REMOVE_PRECOMMIT] = type_convert_templates[ParamType.WRITE_PRECOMMIT]
 
 type_convert_templates[ParamType.VALIDATE_TRANSACTION] = {

--- a/iconservice/icon_inner_service.py
+++ b/iconservice/icon_inner_service.py
@@ -23,6 +23,7 @@ from iconservice.base.address import Address
 from iconservice.base.block import Block
 from iconservice.base.exception import ExceptionCode, IconServiceBaseException
 from iconservice.base.type_converter import TypeConverter, ParamType
+from iconservice.base.type_converter_templates import ConstantKeys
 from iconservice.icon_constant import ICON_INNER_LOG_TAG, ICON_SERVICE_LOG_TAG, \
     EnableThreadFlag, ENABLE_THREAD_FLAG
 from iconservice.icon_service_engine import IconServiceEngine
@@ -168,13 +169,26 @@ class IconScoreInnerTask(object):
         else:
             return self._write_precommit_state(request)
 
+    @staticmethod
+    def _get_block_info_for_precommit_state(converted_block_params: dict):
+        block_height = converted_block_params[ConstantKeys.BLOCK_HEIGHT]
+        block_hash = None
+        if ConstantKeys.BLOCK_HASH in converted_block_params:
+            instant_block_hash = converted_block_params[ConstantKeys.BLOCK_HASH]
+        else:
+            instant_block_hash = converted_block_params[ConstantKeys.OLD_BLOCK_HASH]
+            block_hash = converted_block_params[ConstantKeys.NEW_BLOCK_HASH]
+
+        return block_height, block_hash, instant_block_hash
+
     def _write_precommit_state(self, request: dict):
         response = None
         try:
             converted_block_params = TypeConverter.convert(request, ParamType.WRITE_PRECOMMIT)
-            block = Block.from_dict(converted_block_params)
+            block_height, block_hash, instant_block_hash = \
+                self._get_block_info_for_precommit_state(converted_block_params)
 
-            self._icon_service_engine.commit(block)
+            self._icon_service_engine.commit(block_height, instant_block_hash, block_hash)
             response = MakeResponse.make_response(ExceptionCode.OK)
         except IconServiceBaseException as icon_e:
             self._log_exception(icon_e, ICON_SERVICE_LOG_TAG)
@@ -200,9 +214,10 @@ class IconScoreInnerTask(object):
         response = None
         try:
             converted_block_params = TypeConverter.convert(request, ParamType.WRITE_PRECOMMIT)
-            block = Block.from_dict(converted_block_params)
+            _, _, instant_block_hash = \
+                self._get_block_info_for_precommit_state(converted_block_params)
 
-            self._icon_service_engine.rollback(block)
+            self._icon_service_engine.rollback(instant_block_hash)
             response = MakeResponse.make_response(ExceptionCode.OK)
         except IconServiceBaseException as icon_e:
             self._log_exception(icon_e, ICON_SERVICE_LOG_TAG)

--- a/iconservice/icon_inner_service.py
+++ b/iconservice/icon_inner_service.py
@@ -171,6 +171,7 @@ class IconScoreInnerTask(object):
 
     @staticmethod
     def _get_block_info_for_precommit_state(converted_block_params: dict):
+        # todo: implement unit tests
         block_height = converted_block_params[ConstantKeys.BLOCK_HEIGHT]
         block_hash = None
         if ConstantKeys.BLOCK_HASH in converted_block_params:

--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -1092,18 +1092,21 @@ class IconServiceEngine(ContextContainer):
         prev_block_hash = block_hash
         return Block(block_height, block_hash, timestamp, prev_block_hash)
 
-    def commit(self, block: 'Block') -> None:
+    def commit(self, block_height: int, instant_block_hash: bytes, block_hash: Optional[bytes]) -> None:
         """Write updated states in a context.block_batch to StateDB
         when the candidate block has been confirmed
         """
         # Check for block validation before commit
-        self._precommit_data_manager.validate_precommit_block(block)
+        self._precommit_data_manager.validate_precommit_block(instant_block_hash)
 
         context = IconScoreContext(IconScoreContextType.DIRECT)
 
         precommit_data: 'PrecommitData' = \
-            self._precommit_data_manager.get(block.hash)
+            self._precommit_data_manager.get(instant_block_hash)
         block_batch = precommit_data.block_batch
+        if block_hash:
+            block_batch.block.set_hash(block_hash)
+
         new_icon_score_mapper = precommit_data.score_mapper
         if new_icon_score_mapper:
             context.icon_score_mapper.update(new_icon_score_mapper)
@@ -1117,13 +1120,13 @@ class IconServiceEngine(ContextContainer):
         if precommit_data.precommit_flag & PrecommitFlag.STEP_ALL_CHANGED != PrecommitFlag.NONE:
             self._init_global_value_by_governance_score()
 
-    def rollback(self, block: 'Block') -> None:
+    def rollback(self, instant_block_hash: bytes) -> None:
         """Throw away a precommit state
         in context.block_batch and IconScoreEngine
         """
         # Check for block validation before rollback
-        self._precommit_data_manager.validate_precommit_block(block)
-        self._precommit_data_manager.rollback(block)
+        self._precommit_data_manager.validate_precommit_block(instant_block_hash)
+        self._precommit_data_manager.rollback(instant_block_hash)
 
     def clear_context_stack(self):
         """Clear IconScoreContext stacks

--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -1095,6 +1095,9 @@ class IconServiceEngine(ContextContainer):
     def commit(self, block_height: int, instant_block_hash: bytes, block_hash: Optional[bytes]) -> None:
         """Write updated states in a context.block_batch to StateDB
         when the candidate block has been confirmed
+        :param block_height: height of block being committed
+        :param instant_block_hash: instant hash of block being committed
+        :param block_hash: hash of block being committed
         """
         # Check for block validation before commit
         self._precommit_data_manager.validate_precommit_block(instant_block_hash)
@@ -1105,7 +1108,10 @@ class IconServiceEngine(ContextContainer):
             self._precommit_data_manager.get(instant_block_hash)
         block_batch = precommit_data.block_batch
         if block_hash:
-            block_batch.block.set_hash(block_hash)
+            block_batch.block = Block(block_height=block_batch.block.height,
+                                      block_hash=block_hash,
+                                      timestamp=block_batch.block.timestamp,
+                                      prev_hash=block_batch.block.prev_hash)
 
         new_icon_score_mapper = precommit_data.score_mapper
         if new_icon_score_mapper:
@@ -1120,9 +1126,11 @@ class IconServiceEngine(ContextContainer):
         if precommit_data.precommit_flag & PrecommitFlag.STEP_ALL_CHANGED != PrecommitFlag.NONE:
             self._init_global_value_by_governance_score()
 
-    def rollback(self, instant_block_hash: bytes) -> None:
+    def rollback(self,block_height: int, instant_block_hash: bytes) -> None:
         """Throw away a precommit state
         in context.block_batch and IconScoreEngine
+        :param block_height: height of block which is needed to be removed from the pre-commit data manager
+        :param instant_block_hash: hash of block which is needed to be removed from the pre-commit data manager
         """
         # Check for block validation before rollback
         self._precommit_data_manager.validate_precommit_block(instant_block_hash)

--- a/iconservice/iconscore/icon_score_result.py
+++ b/iconservice/iconscore/icon_score_result.py
@@ -74,7 +74,6 @@ class TransactionResult(object):
         """
         self.tx_hash = tx.hash
         self.block_height = block.height
-        self.block_hash = block.hash
         self.tx_index = tx.index
         self.to = to
         self.score_address = score_address

--- a/iconservice/precommit_data_manager.py
+++ b/iconservice/precommit_data_manager.py
@@ -133,9 +133,9 @@ class PrecommitDataManager(object):
         """Check block validation
         before write_precommit_state() or remove_precommit_state()
 
-        :param instant_block_hash:
+        :param instant_block_hash: hash data which is used for retrieving block instance from the pre-commit data mapper
         """
-        # assert isinstance(precommit_block, Block)
+        assert isinstance(instant_block_hash, bytes)
 
         precommit_data = self._precommit_data_mapper.get(instant_block_hash)
         if precommit_data is None:

--- a/iconservice/precommit_data_manager.py
+++ b/iconservice/precommit_data_manager.py
@@ -98,9 +98,9 @@ class PrecommitDataManager(object):
         # Clear remaining precommit data which have the same block height
         self._precommit_data_mapper.clear()
 
-    def rollback(self, block: 'Block'):
-        if block.hash in self._precommit_data_mapper:
-            del self._precommit_data_mapper[block.hash]
+    def rollback(self, instant_block_hash: bytes):
+        if instant_block_hash in self._precommit_data_mapper:
+            del self._precommit_data_mapper[instant_block_hash]
 
     def empty(self) -> bool:
         return len(self._precommit_data_mapper) == 0
@@ -129,18 +129,18 @@ class PrecommitDataManager(object):
             f'last_block({self._last_block}) '
             f'block_to_invoke({block})')
 
-    def validate_precommit_block(self, precommit_block: 'Block'):
+    def validate_precommit_block(self, instant_block_hash: bytes):
         """Check block validation
         before write_precommit_state() or remove_precommit_state()
 
-        :param precommit_block:
+        :param instant_block_hash:
         """
-        assert isinstance(precommit_block, Block)
+        # assert isinstance(precommit_block, Block)
 
-        precommit_data = self._precommit_data_mapper.get(precommit_block.hash)
+        precommit_data = self._precommit_data_mapper.get(instant_block_hash)
         if precommit_data is None:
             raise InvalidParamsException(
-                f'No precommit data: precommit_block({precommit_block})')
+                f'No precommit data: block hash: ({instant_block_hash})')
 
         if self._last_block is None:
             return

--- a/tests/base/test_type_converter.py
+++ b/tests/base/test_type_converter.py
@@ -651,6 +651,24 @@ class TestTypeConverter(unittest.TestCase):
         self.assertEqual(block_height, ret_params[ConstantKeys.BLOCK_HEIGHT])
         self.assertEqual(block_hash, ret_params[ConstantKeys.BLOCK_HASH])
 
+    def test_write_precommit_convert_new_format(self):
+        # newly defined interface (jira issue LC-306)
+        block_height = 1001
+        old_block_hash = create_block_hash()
+        new_block_hash = create_block_hash()
+
+        request = {
+            ConstantKeys.BLOCK_HEIGHT: hex(block_height),
+            ConstantKeys.OLD_BLOCK_HASH: bytes.hex(old_block_hash),
+            ConstantKeys.NEW_BLOCK_HASH: bytes.hex(new_block_hash)
+        }
+
+        ret_params = TypeConverter.convert(request, ParamType.WRITE_PRECOMMIT)
+
+        self.assertEqual(block_height, ret_params[ConstantKeys.BLOCK_HEIGHT])
+        self.assertEqual(old_block_hash, ret_params[ConstantKeys.OLD_BLOCK_HASH])
+        self.assertEqual(new_block_hash, ret_params[ConstantKeys.NEW_BLOCK_HASH])
+
     def test_remove_precommit_convert(self):
         block_height = 1001
         block_hash = create_block_hash()

--- a/tests/integrate_test/test_integrate_base.py
+++ b/tests/integrate_test/test_integrate_base.py
@@ -120,7 +120,7 @@ class TestIntegrateBase(TestCase):
             block,
             [tx]
         )
-        self.icon_service_engine.commit(block)
+        self.icon_service_engine.commit(block.height, block.hash, None)
         self._block_height += 1
         self._prev_block_hash = block_hash
 
@@ -273,7 +273,7 @@ class TestIntegrateBase(TestCase):
         return block, invoke_response
 
     def _write_precommit_state(self, block: 'Block') -> None:
-        self.icon_service_engine.commit(block)
+        self.icon_service_engine.commit(block.height, block.hash, None)
         self._block_height += 1
         self._prev_block_hash = block.hash
 

--- a/tests/integrate_test/test_integrate_base.py
+++ b/tests/integrate_test/test_integrate_base.py
@@ -277,8 +277,8 @@ class TestIntegrateBase(TestCase):
         self._block_height += 1
         self._prev_block_hash = block.hash
 
-    def _remove_precommit_state(self, block: 'Block') -> None:
-        self.icon_service_engine.rollback(block)
+    def _remove_precommit_state(self, instant_block_hash: bytes) -> None:
+        self.icon_service_engine.rollback(instant_block_hash)
 
     def _query(self, request: dict, method: str = 'icx_call') -> Any:
         response = self.icon_service_engine.query(method, request)

--- a/tests/test_icon_inner_service.py
+++ b/tests/test_icon_inner_service.py
@@ -37,7 +37,7 @@ class TestIconInnerService(unittest.TestCase):
 
         self.assertEqual(block_height, actual_block_height)
         self.assertEqual(instant_block_hash, actual_instant_block_hash)
-        self.assertIsNone(None, actual_block_hash)
+        self.assertIsNone(actual_block_hash)
 
         # success case: when input new write-pre-commit data format, block_hash should be hash
         new_precommit_data_format = {

--- a/tests/test_icon_inner_service.py
+++ b/tests/test_icon_inner_service.py
@@ -37,7 +37,7 @@ class TestIconInnerService(unittest.TestCase):
 
         self.assertEqual(block_height, actual_block_height)
         self.assertEqual(instant_block_hash, actual_instant_block_hash)
-        self.assertEqual(None, actual_block_hash)
+        self.assertIsNone(None, actual_block_hash)
 
         # success case: when input new write-pre-commit data format, block_hash should be hash
         new_precommit_data_format = {
@@ -57,4 +57,6 @@ class TestIconInnerService(unittest.TestCase):
             ConstantKeys.BLOCK_HEIGHT: block_height,
             ConstantKeys.OLD_BLOCK_HASH: instant_block_hash,
         }
-        self.assertRaises(KeyError, IconScoreInnerTask._get_block_info_for_precommit_state, invalid_precommit_data_format)
+        self.assertRaises(KeyError,
+                          IconScoreInnerTask._get_block_info_for_precommit_state,
+                          invalid_precommit_data_format)

--- a/tests/test_icon_inner_service.py
+++ b/tests/test_icon_inner_service.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019 ICON Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from iconservice.base.type_converter_templates import ConstantKeys
+from iconservice.icon_inner_service import IconScoreInnerTask
+from tests import create_block_hash
+
+
+class TestIconInnerService(unittest.TestCase):
+    def test_get_block_info_for_precommit_state(self):
+        block_height = 10
+        instant_block_hash = create_block_hash()
+        block_hash = create_block_hash()
+
+        # success case: when input prev write pre-commit data format, block_hash should be None
+        prev_precommit_data_format = {
+            ConstantKeys.BLOCK_HEIGHT: block_height,
+            ConstantKeys.BLOCK_HASH: instant_block_hash
+        }
+        actual_block_height, actual_instant_block_hash, actual_block_hash = \
+            IconScoreInnerTask._get_block_info_for_precommit_state(prev_precommit_data_format)
+
+        self.assertEqual(block_height, actual_block_height)
+        self.assertEqual(instant_block_hash, actual_instant_block_hash)
+        self.assertEqual(None, actual_block_hash)
+
+        # success case: when input new write-pre-commit data format, block_hash should be hash
+        new_precommit_data_format = {
+            ConstantKeys.BLOCK_HEIGHT: block_height,
+            ConstantKeys.OLD_BLOCK_HASH: instant_block_hash,
+            ConstantKeys.NEW_BLOCK_HASH: block_hash
+        }
+        actual_block_height, actual_instant_block_hash, actual_block_hash = \
+            IconScoreInnerTask._get_block_info_for_precommit_state(new_precommit_data_format)
+
+        self.assertEqual(block_height, actual_block_height)
+        self.assertEqual(instant_block_hash, actual_instant_block_hash)
+        self.assertEqual(block_hash, actual_block_hash)
+
+        # failure case: when input invalid data format, should raise key error
+        invalid_precommit_data_format = {
+            ConstantKeys.BLOCK_HEIGHT: block_height,
+            ConstantKeys.OLD_BLOCK_HASH: instant_block_hash,
+        }
+        self.assertRaises(KeyError, IconScoreInnerTask._get_block_info_for_precommit_state, invalid_precommit_data_format)

--- a/tests/test_icon_score_result.py
+++ b/tests/test_icon_score_result.py
@@ -254,7 +254,6 @@ class TestTransactionResult(unittest.TestCase):
             self.assertIn('txHash', result)
             self.assertIn('txIndex', result)
             self.assertIn('blockHeight', result)
-            self.assertIn('blockHash', result)
             self.assertIn('cumulativeStepUsed', result)
             self.assertIn('stepUsed', result)
             self.assertEqual(1, len(result['eventLogs']))

--- a/tests/test_icon_service_engine.py
+++ b/tests/test_icon_service_engine.py
@@ -110,7 +110,7 @@ class TestIconServiceEngine(unittest.TestCase):
         tx_lists = [tx]
 
         self._engine.invoke(block, tx_lists)
-        self._engine.commit(block)
+        self._engine.commit(block.height, block.hash, None)
         self.genesis_block = block
 
     def tearDown(self):
@@ -267,7 +267,7 @@ class TestIconServiceEngine(unittest.TestCase):
             self.assertEqual(step_price, 0)
         self.assertEqual(tx_result.step_price, step_price)
 
-        self._engine.commit(block)
+        self._engine.commit(block.height, block_hash, None)
 
         # Check whether fee charging works well
         from_balance: int = \
@@ -326,7 +326,7 @@ class TestIconServiceEngine(unittest.TestCase):
         self.assertEqual(tx_result.step_price, step_price)
 
         # Write updated states to levelDB
-        self._engine.commit(block)
+        self._engine.commit(block.height, block.hash, None)
 
         # Check whether fee charging works well
         from_balance: int = self._engine._icx_engine.get_balance(
@@ -382,7 +382,7 @@ class TestIconServiceEngine(unittest.TestCase):
         self.assertEqual(tx_result.step_price, step_price)
 
         # Write updated states to levelDB
-        self._engine.commit(block)
+        self._engine.commit(block.height, block.hash, None)
 
         # Check whether fee charging works well
         from_balance: int = self._engine._icx_engine.get_balance(
@@ -448,7 +448,7 @@ class TestIconServiceEngine(unittest.TestCase):
             self.assertEqual(step_price, 0)
         self.assertEqual(tx_result.step_price, step_price)
 
-        self._engine.commit(block)
+        self._engine.commit(block.height, block.hash, None)
 
         # Check whether fee charging works well
         from_balance: int = \
@@ -525,7 +525,7 @@ class TestIconServiceEngine(unittest.TestCase):
             self.assertEqual(step_price, 0)
         self.assertEqual(tx_result.step_price, step_price)
 
-        self._engine.commit(block)
+        self._engine.commit(block.height, block.hash, None)
 
         # Check whether fee charging works well
         after_from_balance: int = \
@@ -607,7 +607,7 @@ class TestIconServiceEngine(unittest.TestCase):
             self.assertEqual(step_price, 0)
         self.assertEqual(tx_result.step_price, step_price)
 
-        self._engine.commit(block)
+        self._engine.commit(block.height, block.hash, None)
 
         # Check whether fee charging works well
         after_from_balance: int = \
@@ -719,7 +719,7 @@ class TestIconServiceEngine(unittest.TestCase):
             prev_hash=create_block_hash())
 
         with self.assertRaises(InvalidParamsException) as cm:
-            self._engine.commit(block)
+            self._engine.commit(block.height, block.hash, None)
         e = cm.exception
         self.assertEqual(ExceptionCode.INVALID_PARAMETER, e.code)
         self.assertTrue(e.message.startswith('No precommit data'))
@@ -735,7 +735,7 @@ class TestIconServiceEngine(unittest.TestCase):
         self.assertIsInstance(block_result, list)
         self.assertEqual(state_root_hash, hashlib.sha3_256(b'').digest())
 
-        self._engine.rollback(block)
+        self._engine.rollback(block.hash)
         self.assertIsNone(self._engine._precommit_data_manager.get(block))
 
     def test_invoke_v2_with_malformed_to_address_and_type_converter(self):
@@ -806,7 +806,7 @@ class TestIconServiceEngine(unittest.TestCase):
         self.assertEqual(tx_result.step_price, step_price)
 
         # Write updated states to levelDB
-        self._engine.commit(block)
+        self._engine.commit(block.height, block.hash, None)
 
         # Check whether fee charging works well
         from_balance: int = self._engine._icx_engine.get_balance(

--- a/tests/test_icon_service_engine.py
+++ b/tests/test_icon_service_engine.py
@@ -724,6 +724,37 @@ class TestIconServiceEngine(unittest.TestCase):
         self.assertEqual(ExceptionCode.INVALID_PARAMETER, e.code)
         self.assertTrue(e.message.startswith('No precommit data'))
 
+    def test_commit_change_block_hash(self):
+        block_height = 1
+        instant_block_hash = create_block_hash()
+        block_timestamp = 0
+        tx_hash = create_tx_hash()
+
+        dummy_tx = {
+            'method': 'icx_sendTransaction',
+            'params': {
+                'nid': 3,
+                'version': 3,
+                'from': self._genesis_address,
+                'to': self._to,
+                'value': 1 * 10 ** 18,
+                'stepLimit': 1000000,
+                'timestamp': 1234567890,
+                'txHash': tx_hash
+            }
+        }
+        block = Block(block_height,
+                      instant_block_hash,
+                      block_timestamp,
+                      self.genesis_block.hash)
+
+        self._engine.invoke(block, [dummy_tx])
+        block_hash = create_block_hash()
+        self._engine.commit(block.height, block.hash, block_hash)
+
+        self.assertEqual(self._engine._get_last_block().hash, block_hash)
+        self.assertEqual(self._engine._icx_storage.last_block.hash, block_hash)
+
     def test_rollback(self):
         block = Block(
             block_height=1,

--- a/tests/test_icon_service_engine.py
+++ b/tests/test_icon_service_engine.py
@@ -749,8 +749,9 @@ class TestIconServiceEngine(unittest.TestCase):
                       self.genesis_block.hash)
 
         self._engine.invoke(block, [dummy_tx])
+        instant_block_hash = block.hash
         block_hash = create_block_hash()
-        self._engine.commit(block.height, block.hash, block_hash)
+        self._engine.commit(block.height, instant_block_hash, block_hash)
 
         self.assertEqual(self._engine._get_last_block().hash, block_hash)
         self.assertEqual(self._engine._icx_storage.last_block.hash, block_hash)
@@ -766,7 +767,7 @@ class TestIconServiceEngine(unittest.TestCase):
         self.assertIsInstance(block_result, list)
         self.assertEqual(state_root_hash, hashlib.sha3_256(b'').digest())
 
-        self._engine.rollback(block.hash)
+        self._engine.rollback(block.height, block.hash)
         self.assertIsNone(self._engine._precommit_data_manager.get(block))
 
     def test_invoke_v2_with_malformed_to_address_and_type_converter(self):

--- a/tests/test_icon_service_engine.py
+++ b/tests/test_icon_service_engine.py
@@ -248,7 +248,6 @@ class TestIconServiceEngine(unittest.TestCase):
         self.assertIsNone(tx_result.score_address)
         self.assertEqual(tx_result.status, 1)
         self.assertEqual(tx_result.block_height, block_height)
-        self.assertEqual(tx_result.block_hash, block_hash)
         self.assertEqual(tx_result.tx_index, 0)
         self.assertEqual(tx_result.tx_hash, tx_hash)
 
@@ -310,7 +309,6 @@ class TestIconServiceEngine(unittest.TestCase):
         self.assertIsNone(tx_result.score_address)
         self.assertEqual(tx_result.status, 1)
         self.assertEqual(tx_result.block_height, block_height)
-        self.assertEqual(tx_result.block_hash, block_hash)
         self.assertEqual(tx_result.tx_index, 0)
         self.assertEqual(tx_result.tx_hash, tx_hash)
 
@@ -371,7 +369,6 @@ class TestIconServiceEngine(unittest.TestCase):
         self.assertIsNone(tx_result.score_address)
         self.assertEqual(tx_result.status, 1)
         self.assertEqual(tx_result.block_height, block_height)
-        self.assertEqual(tx_result.block_hash, block_hash)
         self.assertEqual(tx_result.tx_index, 0)
         self.assertEqual(tx_result.tx_hash, tx_hash)
 
@@ -430,7 +427,6 @@ class TestIconServiceEngine(unittest.TestCase):
         self.assertIsNone(tx_result.score_address)
         self.assertEqual(tx_result.status, 1)
         self.assertEqual(tx_result.block_height, block_height)
-        self.assertEqual(tx_result.block_hash, block_hash)
         self.assertEqual(tx_result.tx_index, 0)
         self.assertEqual(tx_result.tx_hash, tx_hash)
 
@@ -506,7 +502,6 @@ class TestIconServiceEngine(unittest.TestCase):
         self.assertIsNone(tx_result.score_address)
         self.assertEqual(tx_result.status, 1)
         self.assertEqual(tx_result.block_height, block_height)
-        self.assertEqual(tx_result.block_hash, block_hash)
         self.assertEqual(tx_result.tx_index, 0)
         self.assertEqual(tx_result.tx_hash, tx_hash)
 
@@ -588,7 +583,6 @@ class TestIconServiceEngine(unittest.TestCase):
         self.assertIsNone(tx_result.score_address)
         self.assertEqual(tx_result.status, 0)
         self.assertEqual(tx_result.block_height, block_height)
-        self.assertEqual(tx_result.block_hash, block_hash)
         self.assertEqual(tx_result.tx_index, 0)
         self.assertEqual(tx_result.tx_hash, tx_hash)
 
@@ -707,7 +701,6 @@ class TestIconServiceEngine(unittest.TestCase):
         self.assertIsNone(tx_result.score_address)
         self.assertEqual(tx_result.status, 0)
         self.assertEqual(tx_result.block_height, block_height)
-        self.assertEqual(tx_result.block_hash, block_hash)
         self.assertEqual(tx_result.tx_index, 0)
         self.assertEqual(tx_result.tx_hash, tx_hash)
 
@@ -827,7 +820,6 @@ class TestIconServiceEngine(unittest.TestCase):
         self.assertIsNone(tx_result.score_address)
         self.assertEqual(tx_result.status, 1)
         self.assertEqual(tx_result.block_height, block_height)
-        self.assertEqual(tx_result.block_hash, block_hash)
         self.assertEqual(tx_result.tx_index, 0)
         self.assertEqual(tx_result.tx_hash, tx_hash)
 


### PR DESCRIPTION
1. Replace instant block hash with confirmed block hash on write_precommit_data
Consider backward compatibility.

2. Change commit and rollback method's parameter
as only hash data is needed, does not get Block obj as a parameter

3. Remove block hash in tx_result 
in invoking stage, block hash getting from loopchain is instant data (not real block hash). so remove this field from tx_result