### PR TITLE
IS-402: prevent-access-score-functions-except-for-official

### DIFF
--- a/docs/api-references/classes.iconscorebase.md
+++ b/docs/api-references/classes.iconscorebase.md
@@ -17,5 +17,7 @@ IconScoreBase
         db, 
         owner, 
         icx, 
-        block_height
+        block_height,
+        block,
+        revert
 ```

--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -17,7 +17,6 @@ import os
 from typing import TYPE_CHECKING, List, Any, Optional
 
 from iconcommons.logger import Logger
-
 from .base.address import Address, generate_score_address, generate_score_address_for_tbears
 from .base.address import ZERO_SCORE_ADDRESS, GOVERNANCE_SCORE_ADDRESS
 from .base.block import Block

--- a/iconservice/iconscore/icon_score_base.py
+++ b/iconservice/iconscore/icon_score_base.py
@@ -303,9 +303,6 @@ class IconScoreObject(ABC):
     def on_update(self, **kwargs) -> None:
         pass
 
-    def on_selfdestruct(self, recipient: 'Address') -> None:
-        pass
-
 
 class IconScoreBaseMeta(ABCMeta):
 
@@ -392,10 +389,10 @@ class IconScoreBase(IconScoreObject, ContextGetter,
         pass
 
     @classmethod
-    def get_api(cls) -> dict:
+    def __get_api(cls) -> dict:
         return getattr(cls, CONST_CLASS_API, "")
 
-    def validate_external_method(self, func_name: str) -> None:
+    def __validate_external_method(self, func_name: str) -> None:
         """Validate the method indicated by func_name is an external method
 
         :param func_name: name of method
@@ -429,7 +426,7 @@ class IconScoreBase(IconScoreObject, ContextGetter,
             score_func = getattr(self, func_name)
             ret = score_func()
         else:
-            self.validate_external_method(func_name)
+            self.__validate_external_method(func_name)
             self.__check_payable(func_name)
             score_func = getattr(self, func_name)
             if arg_params is None:
@@ -558,6 +555,12 @@ class IconScoreBase(IconScoreObject, ContextGetter,
 
     @property
     def block(self) -> 'Block':
+        """
+        Duplicated function
+
+        Use block_height, now() instead.
+        """
+        warnings.warn("Use block_height, now() instead", DeprecationWarning, stacklevel=2)
         return Block(self._context.block.height, self._context.block.timestamp)
 
     @property
@@ -607,7 +610,7 @@ class IconScoreBase(IconScoreObject, ContextGetter,
     @property
     def block_height(self) -> int:
         """
-         Current block height
+        Current block height
 
         :return: current block height
         """
@@ -636,13 +639,21 @@ class IconScoreBase(IconScoreObject, ContextGetter,
         return InternalCall.other_external_call(self._context, self.address, addr_to, amount, func_name, (), kw_dict)
 
     @staticmethod
-    def revert(message: Optional[str] = None, code: int = 0) -> None:
+    def revert(message: Optional[str] = None, code: int = 0):
+        """
+        Duplicated function
+
+        Use global function `revert()` instead.
+        """
+        warnings.warn("Use static revert() instead.", DeprecationWarning, stacklevel=2)
         revert(message, code)
 
     def is_score_active(self, score_address: 'Address')-> bool:
+        warnings.warn("Forbidden function.", DeprecationWarning, stacklevel=2)
         return IconScoreContextUtil.is_score_active(self._context, score_address)
 
     def get_owner(self, score_address: Optional['Address']) -> Optional['Address']:
+        warnings.warn("Forbidden function.", DeprecationWarning, stacklevel=2)
         if not score_address:
             score_address = self.address
         return IconScoreContextUtil.get_owner(self._context, score_address)
@@ -663,7 +674,7 @@ class IconScoreBase(IconScoreObject, ContextGetter,
         return interface_cls(addr_to, self)
 
     def deploy(self, tx_hash: bytes):
-        warnings.warn("legacy function don't use.", DeprecationWarning, stacklevel=2)
+        warnings.warn("Forbidden function.", DeprecationWarning, stacklevel=2)
         if self.address == GOVERNANCE_SCORE_ADDRESS:
             # switch
             score_addr: 'Address' = self.get_score_address_by_tx_hash(tx_hash)
@@ -680,12 +691,12 @@ class IconScoreBase(IconScoreObject, ContextGetter,
 
     def get_tx_hashes_by_score_address(self,
                                        score_address: 'Address') -> Tuple[Optional[bytes], Optional[bytes]]:
-        warnings.warn("legacy function don't use.", DeprecationWarning, stacklevel=2)
+        warnings.warn("Forbidden function.", DeprecationWarning, stacklevel=2)
         return IconScoreContextUtil.get_tx_hashes_by_score_address(self._context, score_address)
 
     def get_score_address_by_tx_hash(self,
                                      tx_hash: bytes) -> Optional['Address']:
-        warnings.warn("legacy function don't use.", DeprecationWarning, stacklevel=2)
+        warnings.warn("Forbidden function.", DeprecationWarning, stacklevel=2)
         return IconScoreContextUtil.get_score_address_by_tx_hash(self._context, tx_hash)
 
     def get_fee_sharing_proportion(self):

--- a/iconservice/iconscore/icon_score_base.py
+++ b/iconservice/iconscore/icon_score_base.py
@@ -556,11 +556,11 @@ class IconScoreBase(IconScoreObject, ContextGetter,
     @property
     def block(self) -> 'Block':
         """
-        Duplicated function
+        Deprecated property
 
-        Use block_height, now() instead.
+        Use block_height and now() instead.
         """
-        warnings.warn("Use block_height, now() instead", DeprecationWarning, stacklevel=2)
+        warnings.warn("Use block_height and now() instead", DeprecationWarning, stacklevel=2)
         return Block(self._context.block.height, self._context.block.timestamp)
 
     @property
@@ -641,19 +641,19 @@ class IconScoreBase(IconScoreObject, ContextGetter,
     @staticmethod
     def revert(message: Optional[str] = None, code: int = 0):
         """
-        Duplicated function
+        Deprecated method
 
         Use global function `revert()` instead.
         """
-        warnings.warn("Use static revert() instead.", DeprecationWarning, stacklevel=2)
+        warnings.warn("Use global function revert() instead.", DeprecationWarning, stacklevel=2)
         revert(message, code)
 
-    def is_score_active(self, score_address: 'Address')-> bool:
-        warnings.warn("Forbidden function.", DeprecationWarning, stacklevel=2)
+    def is_score_active(self, score_address: 'Address') -> bool:
+        warnings.warn("Forbidden function", DeprecationWarning, stacklevel=2)
         return IconScoreContextUtil.is_score_active(self._context, score_address)
 
     def get_owner(self, score_address: Optional['Address']) -> Optional['Address']:
-        warnings.warn("Forbidden function.", DeprecationWarning, stacklevel=2)
+        warnings.warn("Forbidden function", DeprecationWarning, stacklevel=2)
         if not score_address:
             score_address = self.address
         return IconScoreContextUtil.get_owner(self._context, score_address)
@@ -674,7 +674,7 @@ class IconScoreBase(IconScoreObject, ContextGetter,
         return interface_cls(addr_to, self)
 
     def deploy(self, tx_hash: bytes):
-        warnings.warn("Forbidden function.", DeprecationWarning, stacklevel=2)
+        warnings.warn("Forbidden function", DeprecationWarning, stacklevel=2)
         if self.address == GOVERNANCE_SCORE_ADDRESS:
             # switch
             score_addr: 'Address' = self.get_score_address_by_tx_hash(tx_hash)
@@ -691,12 +691,12 @@ class IconScoreBase(IconScoreObject, ContextGetter,
 
     def get_tx_hashes_by_score_address(self,
                                        score_address: 'Address') -> Tuple[Optional[bytes], Optional[bytes]]:
-        warnings.warn("Forbidden function.", DeprecationWarning, stacklevel=2)
+        warnings.warn("Forbidden function", DeprecationWarning, stacklevel=2)
         return IconScoreContextUtil.get_tx_hashes_by_score_address(self._context, score_address)
 
     def get_score_address_by_tx_hash(self,
                                      tx_hash: bytes) -> Optional['Address']:
-        warnings.warn("Forbidden function.", DeprecationWarning, stacklevel=2)
+        warnings.warn("Forbidden function", DeprecationWarning, stacklevel=2)
         return IconScoreContextUtil.get_score_address_by_tx_hash(self._context, tx_hash)
 
     def get_fee_sharing_proportion(self):

--- a/iconservice/iconscore/icon_score_base.py
+++ b/iconservice/iconscore/icon_score_base.py
@@ -20,12 +20,6 @@ from functools import partial, wraps
 from inspect import isfunction, getmembers, signature, Parameter
 from typing import TYPE_CHECKING, Callable, Any, List, Tuple
 
-from ..base.address import Address, GOVERNANCE_SCORE_ADDRESS
-from ..base.exception import *
-from ..database.db import IconScoreDatabase, DatabaseObserver
-from ..icon_constant import ICX_TRANSFER_EVENT_LOG, REVISION_3
-from ..utils import get_main_type_from_annotations_type
-
 from .icon_score_api_generator import ScoreApiGenerator
 from .icon_score_base2 import InterfaceScore, revert, Block
 from .icon_score_constant import CONST_INDEXED_ARGS_COUNT, FORMAT_IS_NOT_FUNCTION_OBJECT, CONST_BIT_FLAG, \
@@ -37,6 +31,11 @@ from .icon_score_event_log import EventLogEmitter
 from .icon_score_step import StepType
 from .icx import Icx
 from .internal_call import InternalCall
+from ..base.address import Address, GOVERNANCE_SCORE_ADDRESS
+from ..base.exception import *
+from ..database.db import IconScoreDatabase, DatabaseObserver
+from ..icon_constant import ICX_TRANSFER_EVENT_LOG, REVISION_3
+from ..utils import get_main_type_from_annotations_type
 
 if TYPE_CHECKING:
     from .icon_score_context import IconScoreContext

--- a/iconservice/iconscore/icon_score_constant.py
+++ b/iconservice/iconscore/icon_score_constant.py
@@ -14,8 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TypeVar
 from enum import IntEnum, unique
+from typing import TypeVar
+
 from ..base.address import Address
 
 T = TypeVar('T')

--- a/iconservice/iconscore/icon_score_constant.py
+++ b/iconservice/iconscore/icon_score_constant.py
@@ -37,6 +37,10 @@ STR_FALLBACK = 'fallback'
 STR_ON_INSTALL = 'on_install'
 STR_ON_UPDATE = 'on_update'
 
+ATTR_SCORE_GET_API = "_IconScoreBase__get_api"
+ATTR_SCORE_CALL = "_IconScoreBase__call"
+ATTR_SCORE_VALIDATATE_EXTERNAL_METHOD = "_IconScoreBase__validate_external_method"
+
 
 @unique
 class ConstBitFlag(IntEnum):

--- a/iconservice/iconscore/icon_score_engine.py
+++ b/iconservice/iconscore/icon_score_engine.py
@@ -19,7 +19,8 @@
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any
 
-from .icon_score_constant import STR_FALLBACK
+from .icon_score_constant import STR_FALLBACK, ATTR_SCORE_GET_API, ATTR_SCORE_CALL, \
+    ATTR_SCORE_VALIDATATE_EXTERNAL_METHOD
 from .icon_score_context import IconScoreContext
 from .icon_score_context_util import IconScoreContextUtil
 from ..base.address import Address, ZERO_SCORE_ADDRESS
@@ -79,7 +80,8 @@ class IconScoreEngine(object):
         IconScoreEngine._validate_score_blacklist(context, icon_score_address)
 
         icon_score = IconScoreEngine._get_icon_score(context, icon_score_address)
-        return icon_score.get_api()
+        get_api = getattr(icon_score, ATTR_SCORE_GET_API)
+        return get_api()
 
     @staticmethod
     def _validate_score_blacklist(context: 'IconScoreContext', icon_score_address: 'Address'):
@@ -108,14 +110,15 @@ class IconScoreEngine(object):
         converted_params = IconScoreEngine._convert_score_params_by_annotations(icon_score, func_name, kw_params)
         context.set_func_type_by_icon_score(icon_score, func_name)
 
-        score_func = getattr(icon_score, '_IconScoreBase__call')
+        score_func = getattr(icon_score, ATTR_SCORE_CALL)
         return score_func(func_name=func_name, kw_params=converted_params)
 
     @staticmethod
     def _convert_score_params_by_annotations(icon_score: 'IconScoreBase', func_name: str, kw_params: dict) -> dict:
         tmp_params = deepcopy(kw_params)
 
-        icon_score.validate_external_method(func_name)
+        validate_external_method = getattr(icon_score, ATTR_SCORE_VALIDATATE_EXTERNAL_METHOD)
+        validate_external_method(func_name)
 
         score_func = getattr(icon_score, func_name)
         annotation_params = TypeConverter.make_annotations_from_method(score_func)
@@ -132,7 +135,7 @@ class IconScoreEngine(object):
         """
         icon_score = IconScoreEngine._get_icon_score(context, score_address)
 
-        score_func = getattr(icon_score, '_IconScoreBase__call')
+        score_func = getattr(icon_score, ATTR_SCORE_CALL)
         score_func(STR_FALLBACK)
 
     @staticmethod

--- a/iconservice/iconscore/internal_call.py
+++ b/iconservice/iconscore/internal_call.py
@@ -17,7 +17,7 @@
 from typing import TYPE_CHECKING, Optional, Any
 
 from . import system_call_handler
-from .icon_score_constant import STR_FALLBACK
+from .icon_score_constant import STR_FALLBACK, ATTR_SCORE_CALL
 from .icon_score_context_util import IconScoreContextUtil
 from .icon_score_event_log import EventLogEmitter
 from .icon_score_step import StepType
@@ -141,7 +141,7 @@ class InternalCall(object):
         try:
             icon_score = IconScoreContextUtil.get_icon_score(context, addr_to)
             context.set_func_type_by_icon_score(icon_score, func_name)
-            score_func = getattr(icon_score, '_IconScoreBase__call')
+            score_func = getattr(icon_score, ATTR_SCORE_CALL)
             return score_func(func_name=func_name, arg_params=arg_params, kw_params=kw_params)
         finally:
             context.func_type = prev_func_type

--- a/tests/icon_score/test_external_payable_call_method.py
+++ b/tests/icon_score/test_external_payable_call_method.py
@@ -25,6 +25,7 @@ from iconservice.base.transaction import Transaction
 from iconservice.database.db import IconScoreDatabase
 from iconservice.deploy.icon_score_deploy_engine import IconScoreDeployEngine
 from iconservice.iconscore.icon_score_base import IconScoreBase, external, payable
+from iconservice.iconscore.icon_score_constant import ATTR_SCORE_CALL
 from iconservice.iconscore.icon_score_context import ContextContainer, IconScoreContext
 from iconservice.iconscore.icon_score_context import IconScoreContextType, IconScoreFuncType
 
@@ -130,7 +131,7 @@ class TestExternalPayableCall(unittest.TestCase):
         self.context.context_type = IconScoreContextType.INVOKE
         self.context.func_type = IconScoreFuncType.READONLY
         test_score = ExternalCallClass(Mock())
-        func = getattr(test_score, '_IconScoreBase__call')
+        func = getattr(test_score, ATTR_SCORE_CALL)
 
         self.context.msg.value = 0
         func('func1', (), {})
@@ -139,7 +140,7 @@ class TestExternalPayableCall(unittest.TestCase):
         self.context.context_type = IconScoreContextType.QUERY
         self.context.func_type = IconScoreFuncType.READONLY
         test_score = ExternalCallClass(Mock())
-        func = getattr(test_score, '_IconScoreBase__call')
+        func = getattr(test_score, ATTR_SCORE_CALL)
 
         self.context.msg.value = 0
         func('func1', (), {})
@@ -148,7 +149,7 @@ class TestExternalPayableCall(unittest.TestCase):
         self.context.context_type = IconScoreContextType.INVOKE
         self.context.func_type = IconScoreFuncType.WRITABLE
         test_score = ExternalCallClass(Mock())
-        func = getattr(test_score, '_IconScoreBase__call')
+        func = getattr(test_score, ATTR_SCORE_CALL)
 
         self.context.msg.value = 0
         func('func2', (), {"value": 1})
@@ -157,7 +158,7 @@ class TestExternalPayableCall(unittest.TestCase):
         self.context.context_type = IconScoreContextType.QUERY
         self.context.func_type = IconScoreFuncType.WRITABLE
         test_score = ExternalCallClass(Mock())
-        func = getattr(test_score, '_IconScoreBase__call')
+        func = getattr(test_score, ATTR_SCORE_CALL)
 
         self.context.msg.value = 0
         func('func2', (), {"value": 1})
@@ -166,7 +167,7 @@ class TestExternalPayableCall(unittest.TestCase):
         self.context.context_type = IconScoreContextType.INVOKE
         self.context.func_type = IconScoreFuncType.WRITABLE
         test_score = ExternalPayableCallClass(Mock())
-        func = getattr(test_score, '_IconScoreBase__call')
+        func = getattr(test_score, ATTR_SCORE_CALL)
 
         self.context.msg.value = 0
         func('func1', (), {})
@@ -175,7 +176,7 @@ class TestExternalPayableCall(unittest.TestCase):
         self.context.context_type = IconScoreContextType.INVOKE
         self.context.func_type = IconScoreFuncType.WRITABLE
         test_score = ExternalPayableCallClass(Mock())
-        func = getattr(test_score, '_IconScoreBase__call')
+        func = getattr(test_score, ATTR_SCORE_CALL)
 
         self.context.msg.value = 1
         func('func1', (), {})
@@ -184,7 +185,7 @@ class TestExternalPayableCall(unittest.TestCase):
         self.context.context_type = IconScoreContextType.INVOKE
         self.context.func_type = IconScoreFuncType.WRITABLE
         test_score = ExternalPayableCallClass(Mock())
-        func = getattr(test_score, '_IconScoreBase__call')
+        func = getattr(test_score, ATTR_SCORE_CALL)
 
         self.context.msg.value = 0
         func('func2', (), {})
@@ -193,7 +194,7 @@ class TestExternalPayableCall(unittest.TestCase):
         self.context.context_type = IconScoreContextType.INVOKE
         self.context.func_type = IconScoreFuncType.WRITABLE
         test_score = ExternalPayableCallClass(Mock())
-        func = getattr(test_score, '_IconScoreBase__call')
+        func = getattr(test_score, ATTR_SCORE_CALL)
 
         self.context.msg.value = 1
         with self.assertRaises(BaseException) as e:
@@ -207,7 +208,7 @@ class TestExternalPayableCall(unittest.TestCase):
         test_score = ChildCallClass(Mock())
 
         self.context.msg.value = 0
-        func = getattr(test_score, '_IconScoreBase__call')
+        func = getattr(test_score, ATTR_SCORE_CALL)
         func('func1', (), {})
 
     def test_inherit_call2(self):
@@ -216,7 +217,7 @@ class TestExternalPayableCall(unittest.TestCase):
         test_score = ChildCallClass(Mock())
 
         self.context.msg.value = 0
-        func = getattr(test_score, '_IconScoreBase__call')
+        func = getattr(test_score, ATTR_SCORE_CALL)
         with self.assertRaises(BaseException) as e:
             func('func2', (), {})
         self.assertEqual(e.exception.code, ExceptionCode.METHOD_NOT_FOUND)

--- a/tests/test_icon_score_class_loader.py
+++ b/tests/test_icon_score_class_loader.py
@@ -16,9 +16,9 @@
 
 
 import inspect
-import unittest
 import os
 import sys
+import unittest
 from unittest.mock import Mock
 
 from iconservice.deploy.utils import convert_path_to_package_name
@@ -29,7 +29,6 @@ from iconservice.iconscore.icon_score_context import ContextContainer, \
     IconScoreContextType
 from iconservice.iconscore.icon_score_context import IconScoreContext
 from tests import create_address, create_tx_hash, rmtree
-
 
 TEST_ROOT_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '../'))
 

--- a/tests/test_icon_score_class_loader.py
+++ b/tests/test_icon_score_class_loader.py
@@ -24,10 +24,12 @@ from unittest.mock import Mock
 from iconservice.deploy.utils import convert_path_to_package_name
 from iconservice.iconscore.icon_score_base import IconScoreBase
 from iconservice.iconscore.icon_score_class_loader import IconScoreClassLoader
+from iconservice.iconscore.icon_score_constant import ATTR_SCORE_GET_API
 from iconservice.iconscore.icon_score_context import ContextContainer, \
     IconScoreContextType
 from iconservice.iconscore.icon_score_context import IconScoreContext
 from tests import create_address, create_tx_hash, rmtree
+
 
 TEST_ROOT_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '../'))
 
@@ -54,7 +56,7 @@ class TestIconScoreClassLoader(unittest.TestCase):
             os.makedirs(dir_path)
 
     def load_proj(self, proj: str) -> callable:
-        score_address: 'Address' = create_address(1, data=proj.encode())
+        score_address = create_address(1, data=proj.encode())
         score_path = os.path.join(self._score_root_path, score_address.to_bytes().hex())
         os.makedirs(score_path, exist_ok=True)
 
@@ -69,9 +71,12 @@ class TestIconScoreClassLoader(unittest.TestCase):
         self.__ensure_dir(self._score_root_path)
 
         score = self.load_proj('test_score01')
-        print('test_score01', score.get_api())
+
+        get_api = getattr(score, ATTR_SCORE_GET_API)
+        print('test_score01', get_api())
         score = self.load_proj('test_score02')
-        print('test_score02', score.get_api())
+        get_api = getattr(score, ATTR_SCORE_GET_API)
+        print('test_score02', get_api())
 
         ins_score = score(Mock())
 


### PR DESCRIPTION
Prevent access to all internal functions except for officially provided SCORE APIs

in goveranace API cases, add worn.
update docs except for Fee2.0