### PR TITLE
IS-402: Prevent access score functions except for official ones

### DIFF
--- a/iconservice/iconscore/icon_score_base.py
+++ b/iconservice/iconscore/icon_score_base.py
@@ -34,7 +34,7 @@ from .internal_call import InternalCall
 from ..base.address import Address, GOVERNANCE_SCORE_ADDRESS
 from ..base.exception import *
 from ..database.db import IconScoreDatabase, DatabaseObserver
-from ..icon_constant import ICX_TRANSFER_EVENT_LOG, REVISION_3
+from ..icon_constant import ICX_TRANSFER_EVENT_LOG, REVISION_3, REVISION_4
 from ..utils import get_main_type_from_annotations_type
 
 if TYPE_CHECKING:
@@ -649,14 +649,14 @@ class IconScoreBase(IconScoreObject, ContextGetter,
 
     def is_score_active(self, score_address: 'Address') -> bool:
         warnings.warn("Forbidden function", DeprecationWarning, stacklevel=2)
-        if self._context.revision < REVISION_3:
+        if self._context.revision < REVISION_4:
             return IconScoreContextUtil.is_score_active(self._context, score_address)
         else:
             raise AccessDeniedException('No permission')
 
     def get_owner(self, score_address: Optional['Address']) -> Optional['Address']:
         warnings.warn("Forbidden function", DeprecationWarning, stacklevel=2)
-        if self._context.revision < REVISION_3:
+        if self._context.revision < REVISION_4:
             return IconScoreContextUtil.get_owner(self._context, score_address)
         else:
             raise AccessDeniedException('No permission')
@@ -678,7 +678,7 @@ class IconScoreBase(IconScoreObject, ContextGetter,
 
     def deploy(self, tx_hash: bytes):
         warnings.warn("Forbidden function", DeprecationWarning, stacklevel=2)
-        if self._context.revision < REVISION_3:
+        if self._context.revision < REVISION_4:
             if self.address == GOVERNANCE_SCORE_ADDRESS:
                 # switch
                 score_addr: 'Address' = self.get_score_address_by_tx_hash(tx_hash)
@@ -698,7 +698,7 @@ class IconScoreBase(IconScoreObject, ContextGetter,
     def get_tx_hashes_by_score_address(self,
                                        score_address: 'Address') -> Tuple[Optional[bytes], Optional[bytes]]:
         warnings.warn("Forbidden function", DeprecationWarning, stacklevel=2)
-        if self._context.revision < REVISION_3:
+        if self._context.revision < REVISION_4:
             return IconScoreContextUtil.get_tx_hashes_by_score_address(self._context, score_address)
         else:
             raise AccessDeniedException('No permission')
@@ -706,7 +706,7 @@ class IconScoreBase(IconScoreObject, ContextGetter,
     def get_score_address_by_tx_hash(self,
                                      tx_hash: bytes) -> Optional['Address']:
         warnings.warn("Forbidden function", DeprecationWarning, stacklevel=2)
-        if self._context.revision < REVISION_3:
+        if self._context.revision < REVISION_4:
             return IconScoreContextUtil.get_score_address_by_tx_hash(self._context, tx_hash)
         else:
             raise AccessDeniedException('No permission')

--- a/iconservice/iconscore/icon_score_base.py
+++ b/iconservice/iconscore/icon_score_base.py
@@ -34,7 +34,7 @@ from .internal_call import InternalCall
 from ..base.address import Address, GOVERNANCE_SCORE_ADDRESS
 from ..base.exception import *
 from ..database.db import IconScoreDatabase, DatabaseObserver
-from ..icon_constant import ICX_TRANSFER_EVENT_LOG, REVISION_3, REVISION_4
+from ..icon_constant import ICX_TRANSFER_EVENT_LOG, REVISION_3
 from ..utils import get_main_type_from_annotations_type
 
 if TYPE_CHECKING:
@@ -649,14 +649,14 @@ class IconScoreBase(IconScoreObject, ContextGetter,
 
     def is_score_active(self, score_address: 'Address') -> bool:
         warnings.warn("Forbidden function", DeprecationWarning, stacklevel=2)
-        if self._context.revision < REVISION_4:
+        if self._context.revision <= REVISION_3:
             return IconScoreContextUtil.is_score_active(self._context, score_address)
         else:
             raise AccessDeniedException('No permission')
 
     def get_owner(self, score_address: Optional['Address']) -> Optional['Address']:
         warnings.warn("Forbidden function", DeprecationWarning, stacklevel=2)
-        if self._context.revision < REVISION_4:
+        if self._context.revision <= REVISION_3:
             return IconScoreContextUtil.get_owner(self._context, score_address)
         else:
             raise AccessDeniedException('No permission')
@@ -678,27 +678,25 @@ class IconScoreBase(IconScoreObject, ContextGetter,
 
     def deploy(self, tx_hash: bytes):
         warnings.warn("Forbidden function", DeprecationWarning, stacklevel=2)
-        if self._context.revision < REVISION_4:
-            if self.address == GOVERNANCE_SCORE_ADDRESS:
-                # switch
-                score_addr: 'Address' = self.get_score_address_by_tx_hash(tx_hash)
-                owner: 'Address' = self.get_owner(score_addr)
-                tmp_sender: 'Address' = self._context.msg.sender
+        if self._context.revision <= REVISION_3 and \
+                self.address == GOVERNANCE_SCORE_ADDRESS:
+            # switch
+            score_addr: 'Address' = self.get_score_address_by_tx_hash(tx_hash)
+            owner: 'Address' = self.get_owner(score_addr)
+            tmp_sender: 'Address' = self._context.msg.sender
 
-                self._context.msg.sender = owner
-                try:
-                    IconScoreContextUtil.deploy(self._context, tx_hash)
-                finally:
-                    self._context.msg.sender = tmp_sender
-            else:
-                raise AccessDeniedException('No permission')
+            self._context.msg.sender = owner
+            try:
+                IconScoreContextUtil.deploy(self._context, tx_hash)
+            finally:
+                self._context.msg.sender = tmp_sender
         else:
             raise AccessDeniedException('No permission')
 
     def get_tx_hashes_by_score_address(self,
                                        score_address: 'Address') -> Tuple[Optional[bytes], Optional[bytes]]:
         warnings.warn("Forbidden function", DeprecationWarning, stacklevel=2)
-        if self._context.revision < REVISION_4:
+        if self._context.revision <= REVISION_3:
             return IconScoreContextUtil.get_tx_hashes_by_score_address(self._context, score_address)
         else:
             raise AccessDeniedException('No permission')
@@ -706,7 +704,7 @@ class IconScoreBase(IconScoreObject, ContextGetter,
     def get_score_address_by_tx_hash(self,
                                      tx_hash: bytes) -> Optional['Address']:
         warnings.warn("Forbidden function", DeprecationWarning, stacklevel=2)
-        if self._context.revision < REVISION_4:
+        if self._context.revision <= REVISION_3:
             return IconScoreContextUtil.get_score_address_by_tx_hash(self._context, tx_hash)
         else:
             raise AccessDeniedException('No permission')

--- a/iconservice/iconscore/icon_system_score_base.py
+++ b/iconservice/iconscore/icon_system_score_base.py
@@ -16,7 +16,7 @@
 
 from abc import abstractmethod
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Tuple
 
 from .icon_score_context_util import IconScoreContextUtil
 from ..base.exception import AccessDeniedException
@@ -66,3 +66,9 @@ class IconSystemScoreBase(IconScoreBase):
 
     def get_deploy_info(self, address: 'Address') -> Optional['IconScoreDeployInfo']:
         return IconScoreContextUtil.get_deploy_info(self._context, address)
+
+    def is_score_active(self, score_address: 'Address') -> bool:
+        return IconScoreContextUtil.is_score_active(self._context, score_address)
+
+    def get_owner(self, score_address: Optional['Address']) -> Optional['Address']:
+        return IconScoreContextUtil.get_owner(self._context, score_address)

--- a/tests/test_icon_score_step.py
+++ b/tests/test_icon_score_step.py
@@ -29,6 +29,7 @@ from iconservice.iconscore.icon_score_base import \
     IconScoreBase, eventlog, external
 from iconservice.iconscore.icon_score_base2 import sha3_256
 from iconservice.iconscore.icon_score_context import ContextContainer
+from iconservice.iconscore.icon_score_context_util import IconScoreContextUtil
 from iconservice.iconscore.icon_score_engine import IconScoreEngine
 from iconservice.iconscore.icon_score_step import \
     StepType, IconScoreStepCounter, IconScoreStepCounterFactory
@@ -278,7 +279,10 @@ class TestIconScoreStepCounter(unittest.TestCase):
             ContextContainer._push_context(args[0])
 
             context_db = self._inner_task._icon_service_engine._icx_context_db
+            ori_func = IconScoreContextUtil.get_owner
+            IconScoreContextUtil.get_owner = Mock()
             score = SampleScore(IconScoreDatabase(to_, context_db))
+            IconScoreContextUtil.get_owner = ori_func
             score.get_db()
 
             ContextContainer._pop_context()
@@ -322,7 +326,10 @@ class TestIconScoreStepCounter(unittest.TestCase):
         def intercept_query(*args, **kwargs):
             ContextContainer._push_context(args[0])
             context_db = self._inner_task._icon_service_engine._icx_context_db
+            ori_func = IconScoreContextUtil.get_owner
+            IconScoreContextUtil.get_owner = Mock()
             score = SampleScore(IconScoreDatabase(to_, context_db))
+            IconScoreContextUtil.get_owner = ori_func
             ret = score.query_db()
             ContextContainer._pop_context()
             return ret
@@ -369,7 +376,10 @@ class TestIconScoreStepCounter(unittest.TestCase):
         def intercept_invoke(*args, **kwargs):
             ContextContainer._push_context(args[0])
             context_db = self._inner_task._icon_service_engine._icx_context_db
+            ori_func = IconScoreContextUtil.get_owner
+            IconScoreContextUtil.get_owner = Mock()
             score = SampleScore(IconScoreDatabase(to_, context_db))
+            IconScoreContextUtil.get_owner = ori_func
             score.remove_db()
             ContextContainer._pop_context()
 
@@ -745,10 +755,6 @@ class SampleScore(IconScoreBase):
 
     def on_update(self) -> None:
         pass
-
-    def get_owner(self,
-                  score_address: Optional['Address']) -> Optional['Address']:
-        return None
 
     @eventlog(indexed=2)
     def SampleEvent(


### PR DESCRIPTION
every time deploying and loading SCORE, it occurs warn log (get_owner, is_score_active).
so we fixed that issue.