### PR TITLE
IS-499: Return total supply being stored on memory when querying

### DIFF
--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -353,7 +353,7 @@ class IconServiceEngine(ContextContainer):
         context.new_icon_score_mapper = IconScoreMapper()
         context.prep_candidate_tx_batch = PRepCandidateBatch()
         context.prep_candidate_block_batch = PRepCandidateBatch()
-        context.total_supply = self._icx_engine.get_total_supply()
+        context.total_supply = self._icx_engine.total_supply_amount
         self._set_revision_to_context(context)
         block_result = []
         precommit_flag = PrecommitFlag.NONE
@@ -812,7 +812,7 @@ class IconServiceEngine(ContextContainer):
         :param context:
         :return: icx amount in loop (1 icx == 1e18 loop)
         """
-        return self._icx_engine.get_total_supply()
+        return self._icx_engine.total_supply_amount
 
     def _handle_icx_call(self,
                          context: 'IconScoreContext',
@@ -1311,7 +1311,7 @@ class IconServiceEngine(ContextContainer):
         self._icx_context_db.write_batch(
             context=context, states=block_batch)
 
-        if precommit_data.total_supply > self._icx_engine.get_total_supply():
+        if precommit_data.total_supply > self._icx_engine.total_supply_amount:
             self._icx_engine.set_total_supply(precommit_data.total_supply)
         self._icx_storage.put_block_info(context, block_batch.block)
         self._precommit_data_manager.commit(block_batch.block)

--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -388,9 +388,9 @@ class IconServiceEngine(ContextContainer):
             context.rc_block_batch,
             context.prep_candidate_block_batch,
             prev_block_contributors,
+            context.total_supply,
             context.new_icon_score_mapper,
-            precommit_flag,
-            context.total_supply)
+            precommit_flag)
         self._precommit_data_manager.push(precommit_data)
 
         return block_result, precommit_data.state_root_hash

--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -1303,6 +1303,7 @@ class IconServiceEngine(ContextContainer):
 
         precommit_data: 'PrecommitData' = \
             self._precommit_data_manager.get(block.hash)
+        context.total_supply = precommit_data.total_supply
         block_batch = precommit_data.block_batch
         new_icon_score_mapper = precommit_data.score_mapper
         if new_icon_score_mapper:

--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -353,7 +353,7 @@ class IconServiceEngine(ContextContainer):
         context.new_icon_score_mapper = IconScoreMapper()
         context.prep_candidate_tx_batch = PRepCandidateBatch()
         context.prep_candidate_block_batch = PRepCandidateBatch()
-        context.total_supply = self._icx_engine.total_supply_amount
+        context.total_supply = self._icx_engine.total_supply
         self._set_revision_to_context(context)
         block_result = []
         precommit_flag = PrecommitFlag.NONE
@@ -812,7 +812,7 @@ class IconServiceEngine(ContextContainer):
         :param context:
         :return: icx amount in loop (1 icx == 1e18 loop)
         """
-        return self._icx_engine.total_supply_amount
+        return self._icx_engine.total_supply
 
     def _handle_icx_call(self,
                          context: 'IconScoreContext',
@@ -1311,7 +1311,7 @@ class IconServiceEngine(ContextContainer):
         self._icx_context_db.write_batch(
             context=context, states=block_batch)
 
-        if precommit_data.total_supply > self._icx_engine.total_supply_amount:
+        if precommit_data.total_supply > self._icx_engine.total_supply:
             self._icx_engine.set_total_supply(precommit_data.total_supply)
         self._icx_storage.put_block_info(context, block_batch.block)
         self._precommit_data_manager.commit(block_batch.block)

--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -1303,7 +1303,6 @@ class IconServiceEngine(ContextContainer):
 
         precommit_data: 'PrecommitData' = \
             self._precommit_data_manager.get(block.hash)
-        context.total_supply = precommit_data.total_supply
         block_batch = precommit_data.block_batch
         new_icon_score_mapper = precommit_data.score_mapper
         if new_icon_score_mapper:

--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -353,6 +353,7 @@ class IconServiceEngine(ContextContainer):
         context.new_icon_score_mapper = IconScoreMapper()
         context.prep_candidate_tx_batch = PRepCandidateBatch()
         context.prep_candidate_block_batch = PRepCandidateBatch()
+        context.total_supply = self._icx_engine.get_total_supply()
         self._set_revision_to_context(context)
         block_result = []
         precommit_flag = PrecommitFlag.NONE
@@ -388,7 +389,8 @@ class IconServiceEngine(ContextContainer):
             context.prep_candidate_block_batch,
             prev_block_contributors,
             context.new_icon_score_mapper,
-            precommit_flag)
+            precommit_flag,
+            context.total_supply)
         self._precommit_data_manager.push(precommit_data)
 
         return block_result, precommit_data.state_root_hash
@@ -810,7 +812,7 @@ class IconServiceEngine(ContextContainer):
         :param context:
         :return: icx amount in loop (1 icx == 1e18 loop)
         """
-        return self._icx_engine.get_total_supply(context)
+        return self._icx_engine.get_total_supply()
 
     def _handle_icx_call(self,
                          context: 'IconScoreContext',
@@ -1309,6 +1311,8 @@ class IconServiceEngine(ContextContainer):
         self._icx_context_db.write_batch(
             context=context, states=block_batch)
 
+        if precommit_data.total_supply > self._icx_engine.get_total_supply():
+            self._icx_engine.set_total_supply(precommit_data.total_supply)
         self._icx_storage.put_block_info(context, block_batch.block)
         self._precommit_data_manager.commit(block_batch.block)
 

--- a/iconservice/iconscore/icon_score_context.py
+++ b/iconservice/iconscore/icon_score_context.py
@@ -138,6 +138,7 @@ class IconScoreContext(object):
         self.event_logs: List['EventLog'] = None
         self.traces: List['Trace'] = None
         self.fee_sharing_proportion = 0  # The proportion of fee by SCORE in percent (0-100)
+        self.total_supply = 0
 
         self.msg_stack = []
         self.event_log_stack = []

--- a/iconservice/icx/icx_engine.py
+++ b/iconservice/icx/icx_engine.py
@@ -24,7 +24,7 @@ from .icx_account import Account
 from .icx_storage import IcxStorage, Intent
 from ..base.address import Address
 from ..base.exception import InvalidParamsException
-from ..icon_constant import ICX_LOG_TAG
+from ..icon_constant import ICX_LOG_TAG, IconScoreContextType
 
 if TYPE_CHECKING:
     from ..iconscore.icon_score_context import IconScoreContext
@@ -218,14 +218,17 @@ class IcxEngine(object):
         return account.balance
 
     # todo: need to be refactoring
-    def get_total_supply(self, context: 'IconScoreContext') -> int:
+    def get_total_supply(self) -> int:
         """Get the total supply of icx coin
 
         :param context:
         :return: (int) amount in loop (1 icx == 1e18 loop)
         """
-        # todo: to be refactored (using memory)
-        return self._storage.get_total_supply(context)
+
+        return self._total_supply_amount
+
+    def set_total_supply(self, total_supply: int):
+        self._total_supply_amount = total_supply
 
     def charge_fee(self,
                    context: 'IconScoreContext',

--- a/iconservice/icx/icx_engine.py
+++ b/iconservice/icx/icx_engine.py
@@ -44,10 +44,8 @@ class IcxEngine(object):
         """Constructor
         """
         self._storage: 'IcxStorage' = None
-        # todo: refactoring
         self._total_supply_amount: int = 0
         self._genesis_address: 'Address' = None
-        # todo: refactoring
         self._fee_treasury_address: 'Address' = None
 
     def open(self, storage: 'IcxStorage') -> None:
@@ -70,6 +68,10 @@ class IcxEngine(object):
     @property
     def storage(self) -> 'IcxStorage':
         return self._storage
+
+    @property
+    def total_supply_amount(self) -> int:
+        return self._total_supply_amount
 
     def close(self) -> None:
         """Close resources
@@ -217,16 +219,13 @@ class IcxEngine(object):
         account: 'Account' = self._storage.get_account(context, address)
         return account.balance
 
-    # todo: need to be refactoring
-    def get_total_supply(self) -> int:
-        """Get the total supply of icx coin
-
-        :return: (int) amount in loop (1 icx == 1e18 loop)
-        """
-
-        return self._total_supply_amount
-
     def set_total_supply(self, total_supply: int):
+        """Set total supply of icx coin
+
+        :param total_supply: total icx coin supply amount
+        """
+        assert total_supply > self._total_supply_amount
+
         self._total_supply_amount = total_supply
 
     def charge_fee(self,

--- a/iconservice/icx/icx_engine.py
+++ b/iconservice/icx/icx_engine.py
@@ -197,12 +197,12 @@ class IcxEngine(object):
         :param context:
         :param storage: state db manager
         """
-        Logger.debug('_load_total_supply_amount() start', ICX_LOG_TAG)
+        Logger.debug('_load_total_supply() start', ICX_LOG_TAG)
 
         total_supply = storage.get_total_supply(context)
         self._total_supply = total_supply
         Logger.info(f'total_supply: {total_supply}', ICX_LOG_TAG)
-        Logger.debug('_load_total_supply_amount() end', ICX_LOG_TAG)
+        Logger.debug('_load_total_supply() end', ICX_LOG_TAG)
 
     def get_balance(self,
                     context: 'IconScoreContext',

--- a/iconservice/icx/icx_engine.py
+++ b/iconservice/icx/icx_engine.py
@@ -44,7 +44,7 @@ class IcxEngine(object):
         """Constructor
         """
         self._storage: 'IcxStorage' = None
-        self._total_supply_amount: int = 0
+        self._total_supply: int = 0
         self._genesis_address: 'Address' = None
         self._fee_treasury_address: 'Address' = None
 
@@ -63,15 +63,15 @@ class IcxEngine(object):
         self._storage.load_last_block_info(context)
         self._load_address_from_storage(context, storage, self._GENESIS_DB_KEY)
         self._load_address_from_storage(context, storage, self._TREASURY_DB_KEY)
-        self._load_total_supply_amount_from_storage(context, storage)
+        self._load_total_supply_from_storage(context, storage)
 
     @property
     def storage(self) -> 'IcxStorage':
         return self._storage
 
     @property
-    def total_supply_amount(self) -> int:
-        return self._total_supply_amount
+    def total_supply(self) -> int:
+        return self._total_supply
 
     def close(self) -> None:
         """Close resources
@@ -128,8 +128,8 @@ class IcxEngine(object):
         self._storage.put_account(context, account)
 
         if account.balance > 0:
-            self._total_supply_amount += account.balance
-            self._storage.put_total_supply(context, self._total_supply_amount)
+            self._total_supply += account.balance
+            self._storage.put_total_supply(context, self._total_supply)
 
         if coin_part_type in [CoinPartType.GENESIS, CoinPartType.TREASURY]:
             self._put_special_account(context, account)
@@ -188,7 +188,7 @@ class IcxEngine(object):
             Logger.info(f'{db_key}: {address}', ICX_LOG_TAG)
         Logger.debug(f'_load_address_from_storage() end(address type: {db_key})', ICX_LOG_TAG)
 
-    def _load_total_supply_amount_from_storage(
+    def _load_total_supply_from_storage(
             self,
             context: Optional['IconScoreContext'],
             storage: IcxStorage) -> None:
@@ -199,9 +199,9 @@ class IcxEngine(object):
         """
         Logger.debug('_load_total_supply_amount() start', ICX_LOG_TAG)
 
-        total_supply_amount = storage.get_total_supply(context)
-        self._total_supply_amount = total_supply_amount
-        Logger.info(f'total_supply: {total_supply_amount}', ICX_LOG_TAG)
+        total_supply = storage.get_total_supply(context)
+        self._total_supply = total_supply
+        Logger.info(f'total_supply: {total_supply}', ICX_LOG_TAG)
         Logger.debug('_load_total_supply_amount() end', ICX_LOG_TAG)
 
     def get_balance(self,
@@ -224,9 +224,9 @@ class IcxEngine(object):
 
         :param total_supply: total icx coin supply amount
         """
-        assert total_supply > self._total_supply_amount
+        assert total_supply > self._total_supply
 
-        self._total_supply_amount = total_supply
+        self._total_supply = total_supply
 
     def charge_fee(self,
                    context: 'IconScoreContext',

--- a/iconservice/icx/icx_engine.py
+++ b/iconservice/icx/icx_engine.py
@@ -221,7 +221,6 @@ class IcxEngine(object):
     def get_total_supply(self) -> int:
         """Get the total supply of icx coin
 
-        :param context:
         :return: (int) amount in loop (1 icx == 1e18 loop)
         """
 

--- a/iconservice/icx/icx_engine.py
+++ b/iconservice/icx/icx_engine.py
@@ -192,7 +192,7 @@ class IcxEngine(object):
             self,
             context: Optional['IconScoreContext'],
             storage: IcxStorage) -> None:
-        """Load total coin supply amount from state db
+        """Load total coin supply from state db
 
         :param context:
         :param storage: state db manager

--- a/iconservice/icx/icx_issue_engine.py
+++ b/iconservice/icx/icx_issue_engine.py
@@ -50,7 +50,7 @@ class IcxIssueEngine:
         if amount > 0:
             to_account = self._storage.get_account(context, to)
             to_account.deposit(amount)
-            current_total_supply = context.total_supply()
+            current_total_supply = context.total_supply
             total_supply_after_issuing = current_total_supply + amount
 
             self._storage.put_account(context, to_account)

--- a/iconservice/icx/icx_issue_engine.py
+++ b/iconservice/icx/icx_issue_engine.py
@@ -50,10 +50,12 @@ class IcxIssueEngine:
         if amount > 0:
             to_account = self._storage.get_account(context, to)
             to_account.deposit(amount)
-            current_total_supply = self._storage.get_total_supply(context)
+            current_total_supply = context.total_supply()
+            total_supply_after_issuing = current_total_supply + amount
 
             self._storage.put_account(context, to_account)
-            self._storage.put_total_supply(context, current_total_supply + amount)
+            self._storage.put_total_supply(context, total_supply_after_issuing)
+            context.total_supply = total_supply_after_issuing
 
     @staticmethod
     def _create_issue_event_log(group_key, issue_data_in_db) -> 'EventLog':

--- a/iconservice/icx/icx_storage.py
+++ b/iconservice/icx/icx_storage.py
@@ -206,11 +206,13 @@ class IcxStorage(object):
 
         return bool(value)
 
+    # This method being called only when open period
     def get_total_supply(self, context: 'IconScoreContext') -> int:
         """Returns the total supply.
 
         :return: (int) coin total supply in loop (1 icx == 1e18 loop)
         """
+
         value = self._db.get(context, self._TOTAL_SUPPLY_KEY)
 
         amount = 0

--- a/iconservice/iiss/commit_delegator.py
+++ b/iconservice/iiss/commit_delegator.py
@@ -107,7 +107,7 @@ class CommitDelegator(object):
     def _put_gv_for_rc(cls, context: 'IconScoreContext', precommit_data: 'PrecommitData'):
         gv: 'GovernanceVariable' = context.prep_candidate_engine.get_gv(context)
 
-        current_total_supply = context.total_supply
+        current_total_supply = precommit_data.total_supply
         current_total_candidate_delegated = cls.variable.issue.get_total_candidate_delegated(context)
         # todo: after demo, should consider about record these variable to formula (i.e. record in memory)
         r_min = cls.variable.issue.get_reward_min(context)

--- a/iconservice/iiss/commit_delegator.py
+++ b/iconservice/iiss/commit_delegator.py
@@ -107,7 +107,7 @@ class CommitDelegator(object):
     def _put_gv_for_rc(cls, context: 'IconScoreContext', precommit_data: 'PrecommitData'):
         gv: 'GovernanceVariable' = context.prep_candidate_engine.get_gv(context)
 
-        current_total_supply = context.total_supply()
+        current_total_supply = context.total_supply
         current_total_candidate_delegated = cls.variable.issue.get_total_candidate_delegated(context)
         # todo: after demo, should consider about record these variable to formula (i.e. record in memory)
         r_min = cls.variable.issue.get_reward_min(context)

--- a/iconservice/iiss/commit_delegator.py
+++ b/iconservice/iiss/commit_delegator.py
@@ -107,7 +107,7 @@ class CommitDelegator(object):
     def _put_gv_for_rc(cls, context: 'IconScoreContext', precommit_data: 'PrecommitData'):
         gv: 'GovernanceVariable' = context.prep_candidate_engine.get_gv(context)
 
-        current_total_supply = cls.icx_storage.get_total_supply(context)
+        current_total_supply = context.total_supply()
         current_total_candidate_delegated = cls.variable.issue.get_total_candidate_delegated(context)
         # todo: after demo, should consider about record these variable to formula (i.e. record in memory)
         r_min = cls.variable.issue.get_reward_min(context)

--- a/iconservice/precommit_data_manager.py
+++ b/iconservice/precommit_data_manager.py
@@ -49,9 +49,9 @@ class PrecommitData(object):
                  rc_block_batch: list,
                  prep_candidate_block_batch: 'PRepCandidateBatch',
                  prev_block_contributors: Optional[dict],
+                 total_supply: int,
                  score_mapper: Optional['IconScoreMapper'] = None,
-                 precommit_flag: PrecommitFlag = PrecommitFlag.NONE,
-                 total_supply: int = 0):
+                 precommit_flag: PrecommitFlag = PrecommitFlag.NONE):
         """
 
         :param block_batch: changed states for a block

--- a/iconservice/precommit_data_manager.py
+++ b/iconservice/precommit_data_manager.py
@@ -50,7 +50,8 @@ class PrecommitData(object):
                  prep_candidate_block_batch: 'PRepCandidateBatch',
                  prev_block_contributors: Optional[dict],
                  score_mapper: Optional['IconScoreMapper'] = None,
-                 precommit_flag: PrecommitFlag = PrecommitFlag.NONE):
+                 precommit_flag: PrecommitFlag = PrecommitFlag.NONE,
+                 total_supply: int = 0):
         """
 
         :param block_batch: changed states for a block
@@ -69,6 +70,7 @@ class PrecommitData(object):
 
         self.state_root_hash: bytes = self.block_batch.digest()
         self.block = block_batch.block
+        self.total_supply = total_supply
 
 
 class PrecommitDataManager(object):

--- a/tests/icx/test_icx_engine.py
+++ b/tests/icx/test_icx_engine.py
@@ -171,7 +171,7 @@ class TestIcxEngine(unittest.TestCase, ContextContainer):
         self.assertEqual(0, balance)
 
     def test_get_total_supply(self):
-        total_supply = self.engine.get_total_supply()
+        total_supply = self.engine.total_supply_amount
 
         self.assertEqual(self.total_supply, total_supply)
 

--- a/tests/icx/test_icx_engine.py
+++ b/tests/icx/test_icx_engine.py
@@ -171,7 +171,7 @@ class TestIcxEngine(unittest.TestCase, ContextContainer):
         self.assertEqual(0, balance)
 
     def test_get_total_supply(self):
-        total_supply = self.engine.get_total_supply(self.context)
+        total_supply = self.engine.get_total_supply()
 
         self.assertEqual(self.total_supply, total_supply)
 

--- a/tests/icx/test_icx_engine.py
+++ b/tests/icx/test_icx_engine.py
@@ -81,7 +81,7 @@ class TestIcxEngine(unittest.TestCase, ContextContainer):
 
         self.engine._storage.put_account.assert_called()
         self.engine._put_special_account.assert_called()
-        self.assertEqual(self.total_supply, self.engine._total_supply_amount)
+        self.assertEqual(self.total_supply, self.engine._total_supply)
 
         # general
         self.engine._put_special_account = Mock()
@@ -93,7 +93,7 @@ class TestIcxEngine(unittest.TestCase, ContextContainer):
 
         self.engine._storage.put_account.assert_called()
         self.engine._put_special_account.assert_not_called()
-        self.assertEqual(self.total_supply, self.engine._total_supply_amount)
+        self.assertEqual(self.total_supply, self.engine._total_supply)
 
     def test_put_special_account(self):
         # failure case: input general account
@@ -171,7 +171,7 @@ class TestIcxEngine(unittest.TestCase, ContextContainer):
         self.assertEqual(0, balance)
 
     def test_get_total_supply(self):
-        total_supply = self.engine.total_supply_amount
+        total_supply = self.engine.total_supply
 
         self.assertEqual(self.total_supply, total_supply)
 

--- a/tests/integrate_test/test_integrate_issue_transaction_validation.py
+++ b/tests/integrate_test/test_integrate_issue_transaction_validation.py
@@ -226,3 +226,4 @@ class TestIntegrateIssueTransactionValidation(TestIntegrateBase):
 
         self.assertEqual(before_total_supply + self.icx_issue_value, after_total_supply)
         self.assertEqual(before_treasury_icx_amount + self.icx_issue_value, after_treasury_icx_amount)
+


### PR DESCRIPTION
- Implement logic of updating total supply member variable of icx engine when commit period.
- Add total_supply member variable on pre-commit and context

- Set total_supply of context in commit period 
  - IISS logic use total_supply data in commit period. so need to set total_supply.