### PR TITLE
IS-552: Get I SCORE being issued on the previous calculating period from the reward calculator

### DIFF
--- a/iconservice/base/exception.py
+++ b/iconservice/base/exception.py
@@ -44,6 +44,11 @@ class ExceptionCode(IntEnum):
         return str(self.name).capitalize().replace('_', ' ')
 
 
+class InvalidBlockException(BaseException):
+    # if this exception is raised on invoke, icon service will be closed
+    pass
+
+
 class IconServiceBaseException(BaseException):
     """All custom exceptions used in IconService should inherit from this
     """

--- a/iconservice/icon_inner_service.py
+++ b/iconservice/icon_inner_service.py
@@ -21,7 +21,7 @@ from typing import Any, TYPE_CHECKING, Optional, Tuple
 from iconcommons.logger import Logger
 from iconservice.base.address import Address
 from iconservice.base.block import Block
-from iconservice.base.exception import ExceptionCode, IconServiceBaseException
+from iconservice.base.exception import ExceptionCode, IconServiceBaseException, InvalidBlockException
 from iconservice.base.type_converter import TypeConverter, ParamType
 from iconservice.base.type_converter_templates import ConstantKeys
 from iconservice.icon_constant import ICON_INNER_LOG_TAG, ICON_SERVICE_LOG_TAG, \
@@ -144,12 +144,16 @@ class IconScoreInnerTask(object):
                 'stateRootHash': bytes.hex(state_root_hash)
             }
             response = MakeResponse.make_response(results)
+        except InvalidBlockException as e:
+            self._log_exception(e, ICON_SERVICE_LOG_TAG)
+            response = MakeResponse.make_error_response(ExceptionCode.SYSTEM_ERROR, str(e))
         except IconServiceBaseException as icon_e:
             self._log_exception(icon_e, ICON_SERVICE_LOG_TAG)
             response = MakeResponse.make_error_response(icon_e.code, icon_e.message)
         except Exception as e:
             self._log_exception(e, ICON_SERVICE_LOG_TAG)
             response = MakeResponse.make_error_response(ExceptionCode.SYSTEM_ERROR, str(e))
+            self._close()
         finally:
             Logger.info(f'invoke response with {response}', ICON_INNER_LOG_TAG)
             self._icon_service_engine.clear_context_stack()

--- a/iconservice/icon_service.py
+++ b/iconservice/icon_service.py
@@ -13,19 +13,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
-import signal
 
 import argparse
-import setproctitle
+import os
+import signal
 import sys
 
-from earlgrey import MessageQueueService, aio_pika, asyncio
-
+import setproctitle
+from earlgrey import MessageQueueService, aio_pika
 from iconcommons.icon_config import IconConfig
 from iconcommons.logger import Logger
+
 from iconservice.icon_config import default_icon_config
-from iconservice.icon_constant import ICON_SERVICE_PROCTITLE_FORMAT, ICON_SCORE_QUEUE_NAME_FORMAT, ConfigKey
+from iconservice.icon_constant import ICON_SERVICE_PROCTITLE_FORMAT, ICON_SCORE_QUEUE_NAME_FORMAT, ConfigKey, \
+    ICON_EXCEPTION_LOG_TAG
 from iconservice.icon_inner_service import IconScoreInnerService
 from iconservice.icon_service_cli import ICON_SERVICE_CLI, ExitCode
 
@@ -74,6 +75,10 @@ class IconService(object):
 
         try:
             loop.run_forever()
+        except Exception as e:
+            Logger.exception(e, ICON_EXCEPTION_LOG_TAG)
+            Logger.error(e, ICON_EXCEPTION_LOG_TAG)
+            self._inner_service.clean_close()
         finally:
             """
             If the function is called when the operation is not an endless loop 

--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -519,7 +519,6 @@ class IconServiceEngine(ContextContainer):
         treasury_address: 'Address' = context.storage.icx.fee_treasury
         tx_result = TransactionResult(context.tx, context.block)
         tx_result.to = treasury_address
-        # todo: below i_score is temp data, will be removed
         i_score: Optional[int] = context.storage.rc.get_prev_calc_period_issued_i_score()
 
         try:

--- a/iconservice/icx/issue/engine.py
+++ b/iconservice/icx/issue/engine.py
@@ -28,8 +28,8 @@ if TYPE_CHECKING:
 
 
 class Engine(EngineBase):
-    def _issue(self,
-               context: 'IconScoreContext',
+    @staticmethod
+    def _issue(context: 'IconScoreContext',
                to: 'Address',
                amount: int):
         if amount > 0:

--- a/iconservice/icx/issue_data_validator.py
+++ b/iconservice/icx/issue_data_validator.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ..base.exception import IllegalFormatException
+from ..base.exception import InvalidBlockException
 
 
 class IssueDataValidator:
@@ -21,9 +21,9 @@ class IssueDataValidator:
     def validate_format(tx_data: dict, db_data: dict):
         try:
             if not tx_data.keys() == db_data.keys():
-                raise IllegalFormatException("invalid issue transaction format")
+                raise InvalidBlockException("invalid issue transaction format")
         except AttributeError:
-            raise IllegalFormatException("invalid issue transaction format")
+            raise InvalidBlockException("invalid issue transaction format")
 
         for key, val in db_data.items():
             if isinstance(val, dict):

--- a/iconservice/iiss/reward_calc/storage.py
+++ b/iconservice/iiss/reward_calc/storage.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Optional
 
 from iconcommons import Logger
 
+from ...utils.msgpack_for_db import MsgPackForDB
 from ..reward_calc.db import Database as RewardCalcDatabase
 from ..reward_calc.msg_data import TxData
 from ...base.exception import DatabaseException
@@ -33,6 +34,7 @@ class Storage(object):
     _IISS_RC_DB_NAME_PREFIX = "iiss_rc_db_"
 
     _KEY_FOR_GETTING_LAST_TRANSACTION_INDEX = b'last_transaction_index'
+    _KEY_FOR_PREV_CALC_PERIOD_ISSUED_I_SCORE = b'prev_calc_period_issued_i_score'
 
     def __init__(self):
         self._path: str = ""
@@ -55,6 +57,19 @@ class Storage(object):
         if self._db:
             self._db.close()
             self._db = None
+
+    def put_prev_calc_period_issued_i_score(self, i_score: int):
+        # do not versioning this value as this temporary data
+        i_score = MsgPackForDB.dumps(i_score)
+        self._db.put(self._KEY_FOR_PREV_CALC_PERIOD_ISSUED_I_SCORE, i_score)
+
+    def get_prev_calc_period_issued_i_score(self) -> Optional[int]:
+        prev_calc_period_issued_i_score = self._db.get(self._KEY_FOR_PREV_CALC_PERIOD_ISSUED_I_SCORE)
+        if prev_calc_period_issued_i_score is None:
+            return None
+
+        i_score = MsgPackForDB.loads(prev_calc_period_issued_i_score)
+        return i_score
 
     @staticmethod
     def put(batch: list, iiss_data: 'Data'):

--- a/tests/integrate_test/test_integrate_issue_transaction_validation.py
+++ b/tests/integrate_test/test_integrate_issue_transaction_validation.py
@@ -19,7 +19,7 @@
 from copy import deepcopy
 
 from iconservice.base.address import ZERO_SCORE_ADDRESS, Address, AddressPrefix, GOVERNANCE_SCORE_ADDRESS
-from iconservice.base.exception import IllegalFormatException
+from iconservice.base.exception import InvalidBlockException
 from iconservice.icon_config import default_icon_config
 from iconservice.icon_constant import ISSUE_CALCULATE_ORDER, ISSUE_EVENT_LOG_MAPPER, ConfigKey, REV_IISS
 from tests import create_address
@@ -64,7 +64,7 @@ class TestIntegrateIssueTransactionValidation(TestIntegrateBase):
         invalid_tx_list = [
             self._make_dummy_tx()
         ]
-        self.assertRaises(AssertionError, self._make_and_req_block, invalid_tx_list)
+        self.assertRaises(InvalidBlockException, self._make_and_req_block, invalid_tx_list)
 
         # failure case: when first transaction is not a issue transaction
         # but 2nd is a issue transaction, should raise error
@@ -72,7 +72,7 @@ class TestIntegrateIssueTransactionValidation(TestIntegrateBase):
             self._make_dummy_tx(),
             self._make_issue_tx(self.issue_data)
         ]
-        self.assertRaises(AssertionError, self._make_and_req_block, invalid_tx_list)
+        self.assertRaises(InvalidBlockException, self._make_and_req_block, invalid_tx_list)
 
         # failure case: if there are more than 2 issue transaction, should raise error
         invalid_tx_list = [
@@ -87,7 +87,7 @@ class TestIntegrateIssueTransactionValidation(TestIntegrateBase):
             self._make_dummy_tx(),
             self._make_dummy_tx()
         ]
-        self.assertRaises(AssertionError, self._make_and_req_block, invalid_tx_list)
+        self.assertRaises(InvalidBlockException, self._make_and_req_block, invalid_tx_list)
 
     def test_validate_issue_transaction_format(self):
         # failure case: when group(i.e. prep, eep, dapp) key in the issue transaction's data is different with
@@ -103,7 +103,7 @@ class TestIntegrateIssueTransactionValidation(TestIntegrateBase):
                 self._make_dummy_tx(),
                 self._make_dummy_tx()
             ]
-            self.assertRaises(IllegalFormatException, self._make_and_req_block, tx_list)
+            self.assertRaises(InvalidBlockException, self._make_and_req_block, tx_list)
             copied_issue_data[group_key] = temp
 
         # more than
@@ -114,7 +114,7 @@ class TestIntegrateIssueTransactionValidation(TestIntegrateBase):
             self._make_dummy_tx(),
             self._make_dummy_tx()
         ]
-        self.assertRaises(IllegalFormatException, self._make_and_req_block, tx_list)
+        self.assertRaises(InvalidBlockException, self._make_and_req_block, tx_list)
 
         # failure case: when group's inner data key (i.e. incentiveRep, rewardRep, etc) is different
         # with stateDB (except value), should raise error
@@ -128,7 +128,7 @@ class TestIntegrateIssueTransactionValidation(TestIntegrateBase):
                 self._make_dummy_tx(),
                 self._make_dummy_tx()
             ]
-            self.assertRaises(IllegalFormatException, self._make_and_req_block, tx_list)
+            self.assertRaises(InvalidBlockException, self._make_and_req_block, tx_list)
             del data['dummy_key']
 
         # less than
@@ -142,7 +142,7 @@ class TestIntegrateIssueTransactionValidation(TestIntegrateBase):
                     self._make_dummy_tx(),
                     self._make_dummy_tx()
                 ]
-                self.assertRaises(IllegalFormatException, self._make_and_req_block, tx_list)
+                self.assertRaises(InvalidBlockException, self._make_and_req_block, tx_list)
                 data[key] = temp
 
     def test_validate_issue_transaction_value(self):


### PR DESCRIPTION
1. Implement logic about getting I-SCORE from the reward calculator

2. Define new exception: InvalidBlockException
If this exception raise, return the error response implying the negative vote to loopchain.

3. After this implementation, raising an exception which inherits Exception (e.g. AssertionError) will be treated as a shutdown of icon service. (so close the icon inner service)