### PR TITLE
[Is-556] prevent accessing db from other score

### DIFF
--- a/iconservice/iconscore/icon_score_base.py
+++ b/iconservice/iconscore/icon_score_base.py
@@ -569,6 +569,8 @@ class IconScoreBase(IconScoreObject, ContextGetter,
 
         :return: :class:`.IconScoreDatabase` db
         """
+        if self.msg.sender.is_contract:
+            raise AccessDeniedException("Can not access other SCORE's Database")
         return self.__db
 
     @property

--- a/tests/integrate_test/samples/sample_internal_call_scores/sample_link_score/sample_link_score.py
+++ b/tests/integrate_test/samples/sample_internal_call_scores/sample_link_score/sample_link_score.py
@@ -8,6 +8,9 @@ class SampleInterface(InterfaceScore):
     @interface
     def get_value(self) -> int: pass
 
+    @interface
+    def get_db(self) -> IconScoreDatabase: pass
+
 
 class SampleLinkScore(IconScoreBase):
     _SCORE_ADDR = 'score_addr'
@@ -42,3 +45,36 @@ class SampleLinkScore(IconScoreBase):
         test_interface = self.create_interface_score(self._addr_score.get(), SampleInterface)
         test_interface.set_value(value)
         self.Changed(value)
+
+    def _get_other_score_db(self):
+        interface_score = self.create_interface_score(self._addr_score.get(), SampleInterface)
+        return interface_score.get_db()
+
+    @external(readonly=True)
+    def get_other_score_db_bool(self) -> bool:
+        self._get_other_score_db()
+        return True
+
+    @external(readonly=True)
+    def get_other_score_db_int(self) -> int:
+        self._get_other_score_db()
+        return 1
+
+    @external(readonly=True)
+    def get_other_score_db_str(self) -> str:
+        self._get_other_score_db()
+        return "string"
+
+    @external(readonly=True)
+    def get_other_score_db_bytes(self) -> bytes:
+        self._get_other_score_db()
+        return b'bytestring'
+
+    @external(readonly=True)
+    def get_other_score_db_address(self) -> Address:
+        self._get_other_score_db()
+        return Address.from_string(f"hx{'0'*40}")
+
+    @external
+    def try_get_other_score_db(self):
+        self._get_other_score_db()

--- a/tests/integrate_test/samples/sample_internal_call_scores/sample_score/sample_score.py
+++ b/tests/integrate_test/samples/sample_internal_call_scores/sample_score/sample_score.py
@@ -26,3 +26,7 @@ class SampleScore(IconScoreBase):
     def set_value(self, value: int):
         self._value.set(value)
         self.Changed(value)
+
+    @external
+    def get_db(self):
+        return self.db

--- a/tests/integrate_test/test_integrate_score_internal_call.py
+++ b/tests/integrate_test/test_integrate_score_internal_call.py
@@ -19,7 +19,7 @@
 import unittest
 
 from iconservice.base.address import ZERO_SCORE_ADDRESS
-from iconservice.base.exception import ExceptionCode
+from iconservice.base.exception import ExceptionCode, AccessDeniedException
 from tests import raise_exception_start_tag, raise_exception_end_tag
 from tests.integrate_test.test_integrate_base import TestIntegrateBase
 
@@ -216,6 +216,63 @@ class TestIntegrateScoreInternalCall(TestIntegrateBase):
 
         self.assertEqual(tx_results[0].status, int(False))
         self.assertEqual(tx_results[0].failure.message, 'Max call stack size exceeded')
+
+    def test_get_other_score_db(self):
+        value1 = 1 * self._icx_factor
+        tx1 = self._make_deploy_tx("sample_internal_call_scores",
+                                   "sample_score",
+                                   self._addr_array[0],
+                                   ZERO_SCORE_ADDRESS,
+                                   deploy_params={'value': hex(value1)})
+
+        tx2 = self._make_deploy_tx("sample_internal_call_scores",
+                                   "sample_link_score",
+                                   self._addr_array[0],
+                                   ZERO_SCORE_ADDRESS)
+
+        prev_block, tx_results = self._make_and_req_block([tx1, tx2])
+
+        self._write_precommit_state(prev_block)
+
+        self.assertEqual(tx_results[0].status, int(True))
+        score_addr1 = tx_results[0].score_address
+        self.assertEqual(tx_results[1].status, int(True))
+        score_addr2 = tx_results[1].score_address
+
+        tx3 = self._make_score_call_tx(self._addr_array[0], score_addr2, "add_score_func",
+                                       {"score_addr": str(score_addr1)})
+        prev_block, tx_results = self._make_and_req_block([tx3])
+        self._write_precommit_state(prev_block)
+        self.assertEqual(tx_results[0].status, int(True))
+
+        query_request = {
+            "version": self._version,
+            "from": self._admin,
+            "to": score_addr2,
+            "dataType": "call",
+            "data": {
+                "method": "get_other_score_db_bool", "params": {}
+            }
+        }
+
+        with self.assertRaises(AccessDeniedException) as e:
+            self._query(query_request)
+
+        query_request['data']['method'] = "get_other_score_db_int"
+        self.assertRaises(AccessDeniedException, self._query, query_request)
+
+        query_request['data']['method'] = "get_other_score_db_str"
+        self.assertRaises(AccessDeniedException, self._query, query_request)
+
+        query_request['data']['method'] = "get_other_score_db_bytes"
+        self.assertRaises(AccessDeniedException, self._query, query_request)
+
+        query_request['data']['method'] = "get_other_score_db_address"
+        self.assertRaises(AccessDeniedException, self._query, query_request)
+
+        tx4 = self._make_score_call_tx(self._addr_array[0], score_addr2, "try_get_other_score_db", {})
+        prev_block, tx_results = self._make_and_req_block([tx4])
+        self.assertEqual(tx_results[0].status, int(False))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
If the SCORE method is called by internal-call, prevents the SCORE DB property from being accessed so that prevents access to the DB of another SCORE.