### PR TITLE
IS-571: Check term and update main and sub preps

### DIFF
--- a/iconservice/base/type_converter_templates.py
+++ b/iconservice/base/type_converter_templates.py
@@ -161,6 +161,7 @@ class ConstantKeys:
     DETAILS = 'details'
     P2P_END_POINT = 'p2pEndPoint'
     PUBLIC_KEY = 'publicKey'
+    PREP_ID = 'id'
     START_RANKING = "startRanking"
     END_RANKING = "endRanking"
     IREP = "irep"

--- a/iconservice/database/batch.py
+++ b/iconservice/database/batch.py
@@ -34,7 +34,6 @@ def digest(ordered_dict: OrderedDict):
         data.append(key)
         if value is not None:
             data.append(value)
-
     return hashlib.sha3_256(b'|'.join(data)).digest()
 
 

--- a/iconservice/icon_inner_service.py
+++ b/iconservice/icon_inner_service.py
@@ -14,11 +14,11 @@
 
 from asyncio import get_event_loop
 from concurrent.futures.thread import ThreadPoolExecutor
-
-from earlgrey import message_queue_task, MessageQueueStub, MessageQueueService
 from typing import Any, TYPE_CHECKING, Optional, Tuple
 
+from earlgrey import message_queue_task, MessageQueueStub, MessageQueueService
 from iconcommons.logger import Logger
+
 from iconservice.base.address import Address
 from iconservice.base.block import Block
 from iconservice.base.exception import ExceptionCode, IconServiceBaseException, InvalidBlockException
@@ -131,7 +131,7 @@ class IconScoreInnerTask(object):
             converted_tx_requests = params['transactions']
             converted_prev_block_generator = params.get('prevBlockGenerator')
             converted_prev_block_validators = params.get('prevBlockValidators')
-            tx_results, state_root_hash = self._icon_service_engine.invoke(
+            tx_results, state_root_hash, main_prep_as_dict = self._icon_service_engine.invoke(
                 block=block,
                 tx_requests=converted_tx_requests,
                 prev_block_generator=converted_prev_block_generator,
@@ -143,6 +143,9 @@ class IconScoreInnerTask(object):
                 'txResults': convert_tx_results,
                 'stateRootHash': bytes.hex(state_root_hash)
             }
+
+            if main_prep_as_dict:
+                results["prep"] = main_prep_as_dict
             response = MakeResponse.make_response(results)
         except InvalidBlockException as e:
             self._log_exception(e, ICON_SERVICE_LOG_TAG)

--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -17,6 +17,7 @@ import os
 from typing import TYPE_CHECKING, List, Any, Optional
 
 from iconcommons.logger import Logger
+
 from .base.address import Address, generate_score_address, generate_score_address_for_tbears
 from .base.address import ZERO_SCORE_ADDRESS, GOVERNANCE_SCORE_ADDRESS
 from .base.block import Block
@@ -30,7 +31,8 @@ from .deploy import DeployEngine, DeployStorage
 from .deploy.icon_builtin_score_loader import IconBuiltinScoreLoader
 from .fee import FeeEngine, FeeStorage, DepositHandler
 from .icon_constant import ICON_DEX_DB_NAME, ICON_SERVICE_LOG_TAG, IconServiceFlag, ConfigKey, \
-    IISS_METHOD_TABLE, PREP_METHOD_TABLE, NEW_METHPD_TABLE, REVISION_3, REV_IISS, ICX_ISSUE_TRANSACTION_INDEX
+    IISS_METHOD_TABLE, PREP_METHOD_TABLE, NEW_METHPD_TABLE, REVISION_3, REV_IISS, ICX_ISSUE_TRANSACTION_INDEX, \
+    REV_DECENTRALIZATION
 from .iconscore.icon_pre_validator import IconPreValidator
 from .iconscore.icon_score_class_loader import IconScoreClassLoader
 from .iconscore.icon_score_context import IconScoreContext, IconScoreFuncType, ContextContainer
@@ -400,6 +402,10 @@ class IconServiceEngine(ContextContainer):
 
         preps = context.preps.get_snapshot()
 
+        main_prep_as_dict: Optional[dict] = None
+        if context.revision >= REV_DECENTRALIZATION and context.engine.prep.check_end_block_height(context):
+            main_prep_as_dict = context.engine.prep.make_prep_tx_result(context)
+
         # Save precommit data
         # It will be written to levelDB on commit
         precommit_data = PrecommitData(
@@ -414,7 +420,7 @@ class IconServiceEngine(ContextContainer):
             precommit_flag)
         self._precommit_data_manager.push(precommit_data)
 
-        return block_result, precommit_data.state_root_hash
+        return block_result, precommit_data.state_root_hash, main_prep_as_dict
 
     def _update_revision_if_necessary(self,
                                       flags: 'PrecommitFlag',

--- a/iconservice/iiss/engine.py
+++ b/iconservice/iiss/engine.py
@@ -17,6 +17,7 @@
 from typing import TYPE_CHECKING, Any, Optional, List
 
 from iconcommons.logger import Logger
+
 from .reward_calc.data_creator import DataCreator as RewardCalcDataCreator
 from .reward_calc.ipc.message import CalculateResponse
 from .reward_calc.ipc.reward_calc_proxy import RewardCalcProxy
@@ -37,7 +38,6 @@ if TYPE_CHECKING:
     from .reward_calc.msg_data import TxData, DelegationInfo, DelegationTx, Header, BlockProduceInfoData, PRepsData
     from .reward_calc.msg_data import GovernanceVariable
     from .storage import Reward
-    from ..prep.term import Term
     from ..prep.data.prep import PRep
 
 
@@ -330,9 +330,6 @@ class Engine(EngineBase):
         return data
 
     def genesis_update_db(self, context: 'IconScoreContext', precommit_data: 'PrecommitData'):
-        preps: list = context.engine.prep.preps.get_preps()
-        term: 'Term' = context.engine.prep.term
-        term.save(context, precommit_data.block.height, preps, term.incentive_rep)
         self._put_next_calc_block_height(context, precommit_data.block.height)
 
         self._put_header_for_rc(context, precommit_data)

--- a/iconservice/prep/engine.py
+++ b/iconservice/prep/engine.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import hashlib
+from collections import OrderedDict
 from typing import TYPE_CHECKING, Any, Optional
 
 from iconcommons.logger import Logger
+
 from .data.prep import PRep
 from .data.prep_container import PRepContainer
 from .term import Term
@@ -26,6 +29,7 @@ from ..base.type_converter_templates import ConstantKeys
 from ..iconscore.icon_score_event_log import EventLogEmitter
 from ..icx.storage import Intent
 from ..iiss.reward_calc import RewardCalcDataCreator
+from ..precommit_data_manager import PrecommitData
 
 if TYPE_CHECKING:
     from . import PRepStorage
@@ -163,6 +167,30 @@ class Engine(EngineBase):
             context: 'IconScoreContext', offset: int):
         total_delegated_amount: int = context.storage.iiss.get_total_prep_delegated(context)
         context.storage.iiss.put_total_prep_delegated(context, total_delegated_amount + offset)
+
+    def check_end_block_height(self, context: 'IconScoreContext') -> bool:
+        return self.term.end_block_height == context.block.height or self.term.end_block_height == -1
+
+    def make_prep_tx_result(self, context: 'IconScoreContext') -> Optional[dict]:
+        self.term.save(context, context.block.height, self.preps.get_preps(), self.term.incentive_rep)
+        main_preps = self.term.main_preps
+        prep_as_dict = None
+        if len(main_preps) > 0:
+            prep_as_dict = OrderedDict()
+            preps_as_list = []
+            preps_as_list_for_roothash = []
+            for prep in self.term.main_preps:
+                prep_info_as_dict = OrderedDict()
+                prep_info_as_dict[ConstantKeys.PREP_ID] = prep.address
+                prep_info_as_dict[ConstantKeys.PUBLIC_KEY] = prep.public_key
+                prep_info_as_dict[ConstantKeys.P2P_END_POINT] = prep.p2p_end_point
+                preps_as_list.append(prep_info_as_dict)
+                preps_as_list_for_roothash.extend(
+                    [prep.address.to_bytes(), prep.public_key, prep.p2p_end_point.encode()])
+            prep_as_dict["preps"] = preps_as_list
+            prep_as_dict["state"] = 0
+            prep_as_dict["rootHash"] = hashlib.sha3_256(b'|'.join(preps_as_list_for_roothash)).digest()
+        return prep_as_dict
 
     def handle_get_prep(self, context: 'IconScoreContext', params: dict) -> dict:
         """Returns registration information of a P-Rep

--- a/iconservice/prep/term.py
+++ b/iconservice/prep/term.py
@@ -100,7 +100,8 @@ class Term(object):
 
         self._sequence += 1
         self._end_block_height = current_block_height + self._period
-        self._main_preps = preps
+        self._main_preps = preps[:PREP_COUNT]
+        self._sub_preps = preps[PREP_COUNT: PREP_MAX_PREPS]
         self._incentive_rep = incentive_rep
 
     def _make_prep_for_db(self, preps: List['PRep']) -> list:

--- a/tests/integrate_test/prep/test_prep.py
+++ b/tests/integrate_test/prep/test_prep.py
@@ -22,8 +22,8 @@ from typing import TYPE_CHECKING
 from iconservice.base.address import ZERO_SCORE_ADDRESS, GOVERNANCE_SCORE_ADDRESS
 from iconservice.base.exception import InvalidParamsException
 from iconservice.base.type_converter_templates import ConstantKeys
-from iconservice.icon_constant import REV_IISS
-from tests import create_tx_hash
+from iconservice.icon_constant import REV_IISS, REV_DECENTRALIZATION
+from tests import create_address
 from tests.integrate_test.test_integrate_base import TestIntegrateBase
 
 if TYPE_CHECKING:
@@ -65,7 +65,7 @@ class TestIntegratePrep(TestIntegrateBase):
         if revision >= REV_IISS:
             # issue tx must be exists after revision 5
             tx_list.insert(0, self._make_dummy_issue_tx())
-        prev_block, tx_results = self._make_and_req_block(tx_list)
+        prev_block, tx_result = self._make_and_req_block(tx_list)
         self._write_precommit_state(prev_block)
 
     def _reg_prep(self, address: 'Address', data: dict, revision: int = REV_IISS):
@@ -264,3 +264,157 @@ class TestIntegratePrep(TestIntegrateBase):
         self.assertEqual(0, total_delegated)
         self.assertEqual(10, len(prep_list))
 
+    def test_update_prep_list(self):
+        """
+        Scenario
+        1. generates preps
+        2. sets revision to REV_DECENTRALIZATION and generates main and sub preps
+        3. checks its tx result
+        4. unregisters the first main prep
+        5. delegates 10000 to the last prep
+        6. check main preps sorted
+        :return:
+        """
+        _PREPS_LEN = 200
+        _MAIN_PREPS_LEN = 22
+        _AMOUNT_DELEGATE = 10000
+        self._update_governance()
+        self._set_revision(REV_IISS)
+        self._addr_array = [create_address() for _ in range(_PREPS_LEN)]
+
+        # generate preps
+        for i in range(_PREPS_LEN):
+            reg_data: dict = {
+                ConstantKeys.NAME: f"name{i}",
+                ConstantKeys.EMAIL: f"email{i}",
+                ConstantKeys.WEBSITE: f"website{i}",
+                ConstantKeys.DETAILS: f"json{i}",
+                ConstantKeys.P2P_END_POINT: f"ip{i}",
+                ConstantKeys.PUBLIC_KEY: f'publicKey{i}'.encode(),
+                ConstantKeys.IREP: _PREPS_LEN + i
+            }
+            self._reg_prep(self._addr_array[i], reg_data)
+
+        query_request = {
+            "version": self._version,
+            "from": self._addr_array[0],
+            "to": ZERO_SCORE_ADDRESS,
+            "dataType": "call",
+            "data": {
+                "method": "getPRepList",
+                "params": {
+                    "address": str(self._addr_array[0])
+                }
+            }
+        }
+        response = self._query(query_request)
+        total_delegated: int = response['totalDelegated']
+        prep_list: list = response['preps']
+
+        self.assertEqual(0, total_delegated)
+        self.assertEqual(_PREPS_LEN, len(prep_list))
+
+        # set revision to REV_DECENTRALIZATION
+        tx = self._make_score_call_tx(self._admin, GOVERNANCE_SCORE_ADDRESS, 'setRevision',
+                                      {"code": hex(REV_DECENTRALIZATION), "name": f"1.1.{REV_DECENTRALIZATION}"})
+        tx_list = [tx]
+        # issue tx must be exists after revision 5
+        tx_list.insert(0, self._make_dummy_issue_tx())
+        prev_block, tx_results, main_prep_as_dict = self._make_and_req_block(tx_list)
+
+        # check if tx_result has all of field correctly
+        self.assertTrue('preps' and 'state' and 'rootHash' in main_prep_as_dict)
+        self.assertTrue(_MAIN_PREPS_LEN, len(main_prep_as_dict["preps"]))
+        self.assertEqual(0, main_prep_as_dict["state"])
+
+        self._write_precommit_state(prev_block)
+        self.assertEqual(tx_results[0].status, int(True))
+        self.assertEqual(0, main_prep_as_dict["state"])
+
+        # check if generating main preps
+        query_request = {
+            "version": self._version,
+            "from": self._addr_array[0],
+            "to": ZERO_SCORE_ADDRESS,
+            "dataType": "call",
+            "data": {
+                "method": "getMainPRepList",
+                "params": {
+                    "address": str(self._addr_array[0])
+                }
+            }
+        }
+        org_response_of_main_prep_list = self._query(query_request)
+        self.assertEqual(_MAIN_PREPS_LEN, len(org_response_of_main_prep_list["preps"]))
+
+        # check if generating sub preps
+        query_request = {
+            "version": self._version,
+            "from": self._addr_array[0],
+            "to": ZERO_SCORE_ADDRESS,
+            "dataType": "call",
+            "data": {
+                "method": "getSubPRepList",
+                "params": {
+                    "address": str(self._addr_array[0])
+                }
+            }
+        }
+        response = self._query(query_request)
+        self.assertEqual(min(_PREPS_LEN - _MAIN_PREPS_LEN, 100 - _MAIN_PREPS_LEN), len(response["preps"]))
+
+        # un-register first main prep
+        first_main_prep = org_response_of_main_prep_list["preps"][0]["address"]
+        self._unreg_prep(first_main_prep)
+
+        query_request = {
+            "version": self._version,
+            "from": self._addr_array[0],
+            "to": ZERO_SCORE_ADDRESS,
+            "dataType": "call",
+            "data": {
+                "method": "getPRep",
+                "params": {
+                    "address": str(first_main_prep)
+                }
+            }
+        }
+
+        with self.assertRaises(InvalidParamsException) as e:
+            self._query(query_request)
+        self.assertEqual(f'P-Rep not found: {str(first_main_prep)}', e.exception.args[0])
+
+        # stake
+        self._stake(self._admin, _AMOUNT_DELEGATE)
+
+        # delegate 10000 to last prep
+        last_addr = self._addr_array[_PREPS_LEN - 1]
+        delegations = [{
+            "address": str(last_addr),
+            "value": hex(_AMOUNT_DELEGATE)
+        }]
+        self._delegate(self._admin, delegations)
+
+        for i in range(7):
+            if i == 6:
+                prev_block, tx_results, _ = self._make_and_req_block([])
+            else:
+                prev_block, tx_results = self._make_and_req_block([])
+            self._write_precommit_state(prev_block)
+
+        query_request = {
+            "version": self._version,
+            "from": self._addr_array[0],
+            "to": ZERO_SCORE_ADDRESS,
+            "dataType": "call",
+            "data": {
+                "method": "getMainPRepList",
+                "params": {
+                    "address": str(self._addr_array[0])
+                }
+            }
+        }
+        # check if sorted correctly
+        response_of_main_prep_list = self._query(query_request)
+        org_response_of_main_prep_list["preps"][0] = {"address": last_addr, "delegated": _AMOUNT_DELEGATE}
+        self.assertEqual(org_response_of_main_prep_list["preps"], response_of_main_prep_list["preps"])

--- a/tests/integrate_test/test_integrate_base.py
+++ b/tests/integrate_test/test_integrate_base.py
@@ -318,11 +318,13 @@ class TestIntegrateBase(TestCase):
 
         block = Block(block_height, block_hash, timestamp_us, self._prev_block_hash)
 
-        invoke_response, _ = self.icon_service_engine.invoke(block=block,
+        invoke_response, _, main_prep_as_dict = self.icon_service_engine.invoke(block=block,
                                                              tx_requests=tx_list,
                                                              prev_block_generator=prev_block_generator,
                                                              prev_block_validators=prev_block_validators)
 
+        if main_prep_as_dict:
+            return block, invoke_response, main_prep_as_dict
         return block, invoke_response
 
     def _write_precommit_state(self, block: 'Block') -> None:


### PR DESCRIPTION
- Checks end block height and update main and sub preps on Prep engine
- Adds check valid revision, REV_DECENTRALIZATION for updating main and sub preps on icon service engine
- Makes prep transaction result on invoke
- Adds PREP_ID constant on config
- Removes saving term logic on iiss engine
- Assigns to a variable, main preps and sub ones on Term class
- Adds integration-test for checking term and updating preps




