### PR TITLE
IS-556: Prevent accessing SCORE's DB from the other SCORE

### DIFF
--- a/iconservice/deploy/engine.py
+++ b/iconservice/deploy/engine.py
@@ -119,8 +119,11 @@ class Engine(EngineBase):
             raise InvalidParamsException(f'tx_params is None: 0x{tx_hash.hex()}')
 
         score_address: 'Address' = tx_params.score_address
+        tmp_current = context.current_address
+        context.current_address = score_address
         self._score_deploy(context, tx_params)
         context.storage.deploy.update_score_info(context, score_address, tx_hash)
+        context.current_address = tmp_current
 
     def _score_deploy(self, context: 'IconScoreContext', tx_params: 'IconScoreDeployTXParams'):
         """

--- a/iconservice/deploy/icon_builtin_score_loader.py
+++ b/iconservice/deploy/icon_builtin_score_loader.py
@@ -42,8 +42,7 @@ class IconBuiltinScoreLoader(object):
         return os.path.join(root_path, 'builtin_scores')
 
     @staticmethod
-    def load_builtin_scores(context: 'IconScoreContext', builtin_score_owner_str: str):
-        builtin_score_owner = Address.from_string(builtin_score_owner_str)
+    def load_builtin_scores(context: 'IconScoreContext', builtin_score_owner: 'Address'):
         for score_name, value in BUILTIN_SCORE_ADDRESS_MAPPER.items():
             score_address = Address.from_string(value)
 

--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -18,9 +18,7 @@ from copy import deepcopy
 from typing import TYPE_CHECKING, List, Any, Optional
 
 from iconcommons.logger import Logger
-from iconservice.icx.issue.regulator import Regulator
-from iconservice.inner_call import inner_call
-from iconservice.utils.hashing.hash_generator import HashGenerator
+
 from .base.address import Address, generate_score_address, generate_score_address_for_tbears
 from .base.address import ZERO_SCORE_ADDRESS, GOVERNANCE_SCORE_ADDRESS
 from .base.block import Block
@@ -51,13 +49,16 @@ from .iconscore.icon_score_step import IconScoreStepCounterFactory, StepType, ge
 from .iconscore.icon_score_trace import Trace, TraceType
 from .icx import IcxEngine, IcxStorage
 from .icx.issue import IssueEngine, IssueStorage
+from .icx.issue.regulator import Regulator
 from .iiss import IISSEngine, IISSStorage
 from .iiss.reward_calc import RewardCalcStorage
+from .inner_call import inner_call
 from .precommit_data_manager import PrecommitData, PrecommitDataManager, PrecommitFlag
 from .prep import PRepEngine, PRepStorage
 from .utils import sha3_256, int_to_bytes, is_flags_on, ContextEngine, ContextStorage
 from .utils import to_camel_case
 from .utils.bloom import BloomFilter
+from .utils.hashing.hash_generator import HashGenerator
 
 if TYPE_CHECKING:
     from .iconscore.icon_score_event_log import EventLog
@@ -139,7 +140,8 @@ class IconServiceEngine(ContextContainer):
         last_block: 'Block' = IconScoreContext.storage.icx.last_block
         self._precommit_data_manager.last_block = last_block
 
-        self._load_builtin_scores(context, conf[ConfigKey.BUILTIN_SCORE_OWNER])
+        self._load_builtin_scores(
+            context, Address.from_string(conf[ConfigKey.BUILTIN_SCORE_OWNER]))
         self._init_global_value_by_governance_score(context)
 
     def _init_component_context(self):
@@ -216,13 +218,17 @@ class IconServiceEngine(ContextContainer):
                 make_flag |= flag
         return make_flag
 
-    def _load_builtin_scores(self, context: 'IconScoreContext', builtin_owner: 'str'):
+    def _load_builtin_scores(self, context: 'IconScoreContext', builtin_score_owner: 'Address'):
+        current_address: 'Address' = context.current_address
+        context.current_address = GOVERNANCE_SCORE_ADDRESS
+
         try:
             self._push_context(context)
-            IconBuiltinScoreLoader.load_builtin_scores(
-                context, builtin_owner)
+            IconBuiltinScoreLoader.load_builtin_scores(context, builtin_score_owner)
         finally:
             self._pop_context()
+
+        context.current_address = current_address
 
     def _init_global_value_by_governance_score(self, context: 'IconScoreContext'):
         """Initialize step_counter_factory with parameters

--- a/tests/database/test_db_db.py
+++ b/tests/database/test_db_db.py
@@ -17,6 +17,7 @@
 
 import os
 import unittest
+from unittest.mock import patch
 
 from iconservice.base.address import Address, AddressPrefix
 from iconservice.base.exception import DatabaseException
@@ -225,12 +226,16 @@ class TestIconScoreDatabase(unittest.TestCase):
     def test_address(self):
         self.assertEqual(self.address, self.db.address)
 
-    def test_put_and_get(self):
+    @patch('iconservice.iconscore.icon_score_context.ContextGetter._context')
+    def test_put_and_get(self, context):
+        context.current_address = self.address
         db = self.db
         key = self.address.body
         value = 100
 
         self.assertIsNone(db.get(key))
 
+        context.readonly = False
+        context.type = IconScoreContextType.DIRECT
         db.put(key, value.to_bytes(32, DATA_BYTE_ORDER))
         self.assertEqual(value.to_bytes(32, DATA_BYTE_ORDER), db.get(key))

--- a/tests/database/test_db_observer.py
+++ b/tests/database/test_db_observer.py
@@ -15,13 +15,16 @@
 # limitations under the License.
 
 import unittest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from iconservice import IconScoreDatabase
 from iconservice.base.address import AddressPrefix, Address
 from iconservice.database.db import ContextDatabase
 from iconservice.database.db import DatabaseObserver
+from iconservice.icon_constant import IconScoreContextType
 from iconservice.utils import sha3_256
+
+CONTEXT_PATH = "iconservice.iconscore.icon_score_context.ContextGetter._context"
 
 
 def hash_db_key(address: 'Address', key: bytes) -> bytes:
@@ -39,15 +42,18 @@ class TestDatabaseObserver(unittest.TestCase):
         def get(caller, key):
             return self.last_value
 
-        score_address = Address.from_data(AddressPrefix.CONTRACT, b'score')
+        self.score_address = Address.from_data(AddressPrefix.CONTRACT, b'score')
         context_db = Mock(spec=ContextDatabase)
         context_db.get = get
         self._observer = Mock(spec=DatabaseObserver)
-        self._icon_score_database = IconScoreDatabase(score_address, context_db)
+        self._icon_score_database = IconScoreDatabase(self.score_address, context_db)
         self._icon_score_database.set_observer(self._observer)
 
-    def test_set(self):
+    @patch(CONTEXT_PATH)
+    def test_set(self, context):
         value = b"value1"
+        context.type = IconScoreContextType.DIRECT
+        context.current_address = self.score_address
         self._icon_score_database.put(self.key_, value)
         self._observer.on_put.assert_called()
         args, _ = self._observer.on_put.call_args
@@ -56,8 +62,11 @@ class TestDatabaseObserver(unittest.TestCase):
         self.assertEqual(value, args[3])
         self.last_value = value
 
-    def test_replace(self):
+    @patch(CONTEXT_PATH)
+    def test_replace(self, context):
         value = b"value2"
+        context.type = IconScoreContextType.DIRECT
+        context.current_address = self.score_address
         self._icon_score_database.put(self.key_, value)
         self._observer.on_put.assert_called()
         args, _ = self._observer.on_put.call_args
@@ -74,7 +83,10 @@ class TestDatabaseObserver(unittest.TestCase):
         self.assertEqual(self.key_, args[1])
         self.assertEqual(value, args[2])
 
-    def test_delete(self):
+    @patch(CONTEXT_PATH)
+    def test_delete(self, context):
+        context.type = IconScoreContextType.DIRECT
+        context.current_address = self.score_address
         self.last_value = b"oldvalue"
         self._icon_score_database.delete(self.key_)
         self._observer.on_delete.assert_called()

--- a/tests/icon_score/test_icon_container_db.py
+++ b/tests/icon_score/test_icon_container_db.py
@@ -32,6 +32,7 @@ class TestIconContainerDB(unittest.TestCase):
     def setUp(self):
         self.db = self.create_db()
         self._context = IconScoreContext(IconScoreContextType.DIRECT)
+        self._context.current_address = self.db.address
 
         ContextContainer._push_context(self._context)
         pass

--- a/tests/integrate_test/samples/sample_internal_call_scores/sample_link_score/sample_link_score.py
+++ b/tests/integrate_test/samples/sample_internal_call_scores/sample_link_score/sample_link_score.py
@@ -8,6 +8,9 @@ class SampleInterface(InterfaceScore):
     @interface
     def get_value(self) -> int: pass
 
+    @interface
+    def get_db(self) -> IconScoreDatabase: pass
+
 
 class SampleLinkScore(IconScoreBase):
     _SCORE_ADDR = 'score_addr'
@@ -42,3 +45,18 @@ class SampleLinkScore(IconScoreBase):
         test_interface = self.create_interface_score(self._addr_score.get(), SampleInterface)
         test_interface.set_value(value)
         self.Changed(value)
+
+    def _get_other_score_db(self):
+        interface_score = self.create_interface_score(self._addr_score.get(), SampleInterface)
+        return interface_score.get_db()
+
+    @external(readonly=True)
+    def get_data_from_other_score(self) -> bool:
+        db = self._get_other_score_db()
+        db.get(b'dummy_key')
+        return True
+
+    @external
+    def put_data_to_other_score_db(self):
+        db = self._get_other_score_db()
+        db.put(b'dummy_key', b'dummy_value')

--- a/tests/integrate_test/samples/sample_internal_call_scores/sample_score/sample_score.py
+++ b/tests/integrate_test/samples/sample_internal_call_scores/sample_score/sample_score.py
@@ -26,3 +26,7 @@ class SampleScore(IconScoreBase):
     def set_value(self, value: int):
         self._value.set(value)
         self.Changed(value)
+
+    @external
+    def get_db(self):
+        return self.db

--- a/tests/integrate_test/test_integrate_score_internal_call.py
+++ b/tests/integrate_test/test_integrate_score_internal_call.py
@@ -19,7 +19,7 @@
 import unittest
 
 from iconservice.base.address import ZERO_SCORE_ADDRESS
-from iconservice.base.exception import ExceptionCode
+from iconservice.base.exception import ExceptionCode, AccessDeniedException
 from tests import raise_exception_start_tag, raise_exception_end_tag
 from tests.integrate_test.test_integrate_base import TestIntegrateBase
 
@@ -216,6 +216,49 @@ class TestIntegrateScoreInternalCall(TestIntegrateBase):
 
         self.assertEqual(tx_results[0].status, int(False))
         self.assertEqual(tx_results[0].failure.message, 'Max call stack size exceeded')
+
+    def test_get_other_score_db(self):
+        value1 = 1 * self._icx_factor
+        tx1 = self._make_deploy_tx("sample_internal_call_scores",
+                                   "sample_score",
+                                   self._addr_array[0],
+                                   ZERO_SCORE_ADDRESS,
+                                   deploy_params={'value': hex(value1)})
+
+        tx2 = self._make_deploy_tx("sample_internal_call_scores",
+                                   "sample_link_score",
+                                   self._addr_array[0],
+                                   ZERO_SCORE_ADDRESS)
+
+        prev_block, tx_results = self._make_and_req_block([tx1, tx2])
+
+        self._write_precommit_state(prev_block)
+
+        self.assertEqual(tx_results[0].status, int(True))
+        score_addr1 = tx_results[0].score_address
+        self.assertEqual(tx_results[1].status, int(True))
+        score_addr2 = tx_results[1].score_address
+
+        tx3 = self._make_score_call_tx(self._addr_array[0], score_addr2, "add_score_func",
+                                       {"score_addr": str(score_addr1)})
+        prev_block, tx_results = self._make_and_req_block([tx3])
+        self._write_precommit_state(prev_block)
+        self.assertEqual(tx_results[0].status, int(True))
+
+        query_request = {
+            "version": self._version,
+            "from": self._admin,
+            "to": score_addr2,
+            "dataType": "call",
+            "data": {
+                "method": "get_data_from_other_score", "params": {}
+            }
+        }
+
+        self._query(query_request) # Query method does not raise AccessDenied exception
+        tx4 = self._make_score_call_tx(self._addr_array[0], score_addr2, "try_get_other_score_db", {})
+        prev_block, tx_results = self._make_and_req_block([tx4])
+        self.assertEqual(tx_results[0].status, int(False))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Check db ownership on writing to IconScoreDatabase
* Put GOVERNANCE_ADDRESS to context.current_address before loading builtin-scores.
* Put `SCORE_ADDRESS` to `current_address` when deploying SCORE
* Update writing-permission-related unit tests