### PR TITLE
IS-579: Add constraint for setting irep

### DIFF
--- a/iconservice/icon_config.py
+++ b/iconservice/icon_config.py
@@ -39,5 +39,6 @@ default_icon_config = {
     ConfigKey.IISS_CALCULATE_PERIOD: 10,
     ConfigKey.TERM_PERIOD: 10,
     ConfigKey.IREP: 10_000,
+    ConfigKey.IISS_INITIAL_IREP: 37_500,
     ConfigKey.IISS_PREP_LIST: []
 }

--- a/iconservice/icon_constant.py
+++ b/iconservice/icon_constant.py
@@ -120,6 +120,7 @@ class ConfigKey:
 
     # IISS VARIABLE
     IISS_REWARD_VARIABLE = "iissRewardVariable"
+    IISS_INITIAL_IREP = "iissInitialIRep"
     REWARD_POINT = 'rewardPoint'
     REWARD_MIN = "rewardMin"
     REWARD_MAX = "rewardMAX"
@@ -198,6 +199,7 @@ PREP_MAIN_PREPS = 22
 
 IISS_MAX_REWARD_RATE = 10_000
 IISS_MIN_IREP = 10_000
+IISS_INITIAL_IREP = 37_500
 IISS_SOCKET_PATH = "/tmp/iiss.sock"
 
 IISS_ANNUAL_BLOCK = 15_768_000

--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -18,6 +18,7 @@ from copy import deepcopy
 from typing import TYPE_CHECKING, List, Any, Optional
 
 from iconcommons.logger import Logger
+
 from .base.address import Address, generate_score_address, generate_score_address_for_tbears
 from .base.address import ZERO_SCORE_ADDRESS, GOVERNANCE_SCORE_ADDRESS
 from .base.block import Block
@@ -33,7 +34,7 @@ from .deploy.icon_builtin_score_loader import IconBuiltinScoreLoader
 from .fee import FeeEngine, FeeStorage, DepositHandler
 from .icon_constant import ICON_DEX_DB_NAME, ICON_SERVICE_LOG_TAG, IconServiceFlag, ConfigKey, \
     IISS_METHOD_TABLE, PREP_METHOD_TABLE, NEW_METHOD_TABLE, REVISION_3, REV_IISS, ICX_ISSUE_TRANSACTION_INDEX, \
-    ISSUE_TRANSACTION_VERSION, REV_DECENTRALIZATION, IISS_DB
+    ISSUE_TRANSACTION_VERSION, REV_DECENTRALIZATION, IISS_DB, IISS_INITIAL_IREP
 from .iconscore.icon_pre_validator import IconPreValidator
 from .iconscore.icon_score_class_loader import IconScoreClassLoader
 from .iconscore.icon_score_context import IconScoreContext, IconScoreFuncType, ContextContainer
@@ -126,6 +127,7 @@ class IconServiceEngine(ContextContainer):
         IconScoreContext.icon_score_mapper = IconScoreMapper(is_threadsafe=True)
         IconScoreContext.icon_service_flag = service_config_flag
         IconScoreContext.legacy_tbears_mode = conf.get(ConfigKey.TBEARS_MODE, False)
+        IconScoreContext.iiss_initial_irep = conf.get(ConfigKey.IISS_INITIAL_IREP, IISS_INITIAL_IREP)
         self._init_component_context()
 
         context = IconScoreContext(IconScoreContextType.DIRECT)

--- a/iconservice/iconscore/icon_score_context.py
+++ b/iconservice/iconscore/icon_score_context.py
@@ -99,6 +99,7 @@ class IconScoreContext(object):
     icon_score_mapper: 'IconScoreMapper' = None
     icon_service_flag: int = 0
     legacy_tbears_mode: bool = False
+    iiss_initial_irep: int = 0
 
     engine: 'ContextEngine' = None
     storage: 'ContextStorage' = None

--- a/iconservice/prep/data/prep.py
+++ b/iconservice/prep/data/prep.py
@@ -15,7 +15,6 @@
 from enum import auto, Flag, IntEnum
 from typing import TYPE_CHECKING, Tuple
 
-from ...base.address import Address
 from ...base.exception import InvalidParamsException
 from ...base.type_converter_templates import ConstantKeys
 from ...icon_constant import PRepStatus, PREP_STATUS_MAPPER, PENALTY_GRACE_PERIOD, MIN_PRODUCTIVITY_PERCENTAGE
@@ -185,7 +184,8 @@ class PRep(object):
         return prep
 
     @staticmethod
-    def from_dict(address: 'Address', data: dict, block_height: int, tx_index: int) -> 'PRep':
+    def from_dict(address: 'Address', data: dict, block_height: int, tx_index: int,
+                  irep: int) -> 'PRep':
         prep = PRep(address)
 
         prep._status: int = PRepStatus.ACTIVE
@@ -199,7 +199,7 @@ class PRep(object):
         # Required items
         prep.p2p_end_point: str = data[ConstantKeys.P2P_END_POINT]
         prep.public_key: bytes = data[ConstantKeys.PUBLIC_KEY]
-        prep.irep: int = data[ConstantKeys.IREP]
+        prep.irep: int = irep
         prep.irep_block_height: int = block_height
 
         # Registration time
@@ -218,7 +218,7 @@ class PRep(object):
         # Required items
         self.p2p_end_point: str = params.get(ConstantKeys.P2P_END_POINT, self.p2p_end_point)
 
-        if ConstantKeys.IREP in params:
+        if ConstantKeys.IREP in params and self.irep != params[ConstantKeys.IREP]:
             self.irep: int = params[ConstantKeys.IREP]
             self.irep_block_height: int = block_height
 

--- a/iconservice/prep/data/prep.py
+++ b/iconservice/prep/data/prep.py
@@ -218,7 +218,7 @@ class PRep(object):
         # Required items
         self.p2p_end_point: str = params.get(ConstantKeys.P2P_END_POINT, self.p2p_end_point)
 
-        if ConstantKeys.IREP in params and self.irep != params[ConstantKeys.IREP]:
+        if ConstantKeys.IREP in params:
             self.irep: int = params[ConstantKeys.IREP]
             self.irep_block_height: int = block_height
 

--- a/tests/integrate_test/prep/test_preps.py
+++ b/tests/integrate_test/prep/test_preps.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING
 from iconservice.base.address import ZERO_SCORE_ADDRESS, GOVERNANCE_SCORE_ADDRESS
 from iconservice.base.exception import InvalidParamsException
 from iconservice.base.type_converter_templates import ConstantKeys
-from iconservice.icon_constant import IISS_MAX_DELEGATIONS, IISS_MIN_IREP
+from iconservice.icon_constant import IISS_MAX_DELEGATIONS, IISS_MIN_IREP, IISS_INITIAL_IREP
 from iconservice.icon_constant import REV_IISS
 from tests.integrate_test.test_integrate_base import TestIntegrateBase
 
@@ -142,7 +142,7 @@ class TestIntegratePRep(TestIntegrateBase):
             ConstantKeys.DETAILS: "json",
             ConstantKeys.P2P_END_POINT: "ip",
             ConstantKeys.PUBLIC_KEY: f'publicKey1'.encode(),
-            ConstantKeys.IREP: IISS_MIN_IREP
+            ConstantKeys.IREP: IISS_INITIAL_IREP
         }
         self._reg_prep(self._addr_array[0], data)
 

--- a/tests/integrate_test/prep/test_preps.py
+++ b/tests/integrate_test/prep/test_preps.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING
 from iconservice.base.address import ZERO_SCORE_ADDRESS, GOVERNANCE_SCORE_ADDRESS
 from iconservice.base.exception import InvalidParamsException
 from iconservice.base.type_converter_templates import ConstantKeys
-from iconservice.icon_constant import IISS_MAX_DELEGATIONS, IISS_MIN_IREP, IISS_INITIAL_IREP
+from iconservice.icon_constant import IISS_MAX_DELEGATIONS, IISS_INITIAL_IREP
 from iconservice.icon_constant import REV_IISS
 from tests.integrate_test.test_integrate_base import TestIntegrateBase
 
@@ -70,8 +70,6 @@ class TestIntegratePRep(TestIntegrateBase):
         data = deepcopy(data)
         value: str = data[ConstantKeys.PUBLIC_KEY].hex()
         data[ConstantKeys.PUBLIC_KEY] = value
-        value: str = hex(data[ConstantKeys.IREP])
-        data[ConstantKeys.IREP] = value
 
         tx = self._make_score_call_tx(address,
                                       ZERO_SCORE_ADDRESS,
@@ -142,7 +140,6 @@ class TestIntegratePRep(TestIntegrateBase):
             ConstantKeys.DETAILS: "json",
             ConstantKeys.P2P_END_POINT: "ip",
             ConstantKeys.PUBLIC_KEY: f'publicKey1'.encode(),
-            ConstantKeys.IREP: IISS_INITIAL_IREP
         }
         self._reg_prep(self._addr_array[0], data)
 
@@ -156,10 +153,10 @@ class TestIntegratePRep(TestIntegrateBase):
         self.assertEqual(expected_response[ConstantKeys.DETAILS], register[ConstantKeys.DETAILS])
         self.assertEqual(expected_response[ConstantKeys.P2P_END_POINT], register[ConstantKeys.P2P_END_POINT])
         self.assertEqual(expected_response[ConstantKeys.PUBLIC_KEY], register[ConstantKeys.PUBLIC_KEY])
-        self.assertEqual(expected_response[ConstantKeys.IREP], register[ConstantKeys.IREP])
+        self.assertEqual(IISS_INITIAL_IREP, register[ConstantKeys.IREP])
 
         data1: dict = {
-            ConstantKeys.IREP: IISS_MIN_IREP + 100,
+            ConstantKeys.IREP: IISS_INITIAL_IREP + 100,
         }
         self._set_prep(self._addr_array[0], data1)
 
@@ -187,7 +184,6 @@ class TestIntegratePRep(TestIntegrateBase):
                 ConstantKeys.DETAILS: f"json{i}",
                 ConstantKeys.P2P_END_POINT: f"ip{i}",
                 ConstantKeys.PUBLIC_KEY: f'publicKey1'.encode(),
-                ConstantKeys.IREP: IISS_MIN_IREP+i
             }
             self._reg_prep(self._addr_array[i], data)
 
@@ -210,7 +206,6 @@ class TestIntegratePRep(TestIntegrateBase):
                 ConstantKeys.DETAILS: f"json{i}",
                 ConstantKeys.P2P_END_POINT: f"ip{i}",
                 ConstantKeys.PUBLIC_KEY: f'publicKey1'.encode(),
-                ConstantKeys.IREP: IISS_MIN_IREP+i
             }
             self._reg_prep(self._addr_array[i], data)
 

--- a/tests/integrate_test/prep/test_preps2.py
+++ b/tests/integrate_test/prep/test_preps2.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING
 from iconservice.base.address import ZERO_SCORE_ADDRESS, GOVERNANCE_SCORE_ADDRESS
 from iconservice.base.exception import InvalidParamsException
 from iconservice.base.type_converter_templates import ConstantKeys
-from iconservice.icon_constant import IconScoreContextType, REV_IISS, PREP_SUB_PREPS
+from iconservice.icon_constant import IconScoreContextType, REV_IISS, PREP_SUB_PREPS, IISS_INITIAL_IREP
 from iconservice.icon_constant import REV_DECENTRALIZATION, IISS_MIN_IREP, PREP_MAIN_PREPS
 from iconservice.iconscore.icon_score_context import IconScoreContext
 from iconservice.iiss import get_minimum_delegate_for_bottom_prep
@@ -73,8 +73,6 @@ class TestIntegratePrep(TestIntegrateBase):
         data = deepcopy(data)
         value: str = data[ConstantKeys.PUBLIC_KEY].hex()
         data[ConstantKeys.PUBLIC_KEY] = value
-        value: str = hex(data[ConstantKeys.IREP])
-        data[ConstantKeys.IREP] = value
 
         tx = self._make_score_call_tx(address,
                                       ZERO_SCORE_ADDRESS,
@@ -117,7 +115,7 @@ class TestIntegratePrep(TestIntegrateBase):
         self._write_precommit_state(prev_block)
 
     # decentralize by delegate to n accounts.
-    def _decentralize(self, main_preps: list, delegate_amount: int):
+    def _decentralize(self, preps: list, delegate_amount: int):
 
         # Can delegate up to 10 preps at a time
         stake_amount: int = delegate_amount * 10
@@ -134,7 +132,7 @@ class TestIntegratePrep(TestIntegrateBase):
         self._stake(addr3, stake_amount)
 
         # register preps
-        for i, address in enumerate(main_preps):
+        for i, address in enumerate(preps):
             data: dict = {
                 ConstantKeys.NAME: f"name{i}",
                 ConstantKeys.EMAIL: f"email{i}",
@@ -142,7 +140,6 @@ class TestIntegratePrep(TestIntegrateBase):
                 ConstantKeys.DETAILS: f"json{i}",
                 ConstantKeys.P2P_END_POINT: f"ip{i}",
                 ConstantKeys.PUBLIC_KEY: f'publicKey{i}'.encode(),
-                ConstantKeys.IREP: IISS_MIN_IREP
             }
             self._reg_prep(address, data)
 
@@ -151,21 +148,21 @@ class TestIntegratePrep(TestIntegrateBase):
             {
                 "address": str(address),
                 "value": hex(delegate_amount)
-            }for address in main_preps[:10]]
+            }for address in preps[:10]]
         self._delegate(addr1, data)
 
         data: list = [
             {
                 "address": str(address),
                 "value": hex(delegate_amount)
-            }for address in main_preps[10:20]]
+            }for address in preps[10:20]]
         self._delegate(addr2, data)
 
         data: list = [
             {
                 "address": str(address),
                 "value": hex(delegate_amount)
-            }for address in main_preps[20:22]]
+            }for address in preps[20:22]]
         self._delegate(addr3, data)
 
     def _send_icx_in_loop(self, to_addr: 'Address', balance: int):
@@ -492,7 +489,7 @@ class TestIntegratePrep(TestIntegrateBase):
         # generate preps
         for i in range(_PREPS_LEN):
             if i < PREP_MAIN_PREPS:
-                buf_total_irep += IISS_MIN_IREP + i
+                buf_total_irep += IISS_INITIAL_IREP
             reg_data: dict = {
                 ConstantKeys.NAME: f"name{i}",
                 ConstantKeys.EMAIL: f"email{i}",
@@ -500,7 +497,6 @@ class TestIntegratePrep(TestIntegrateBase):
                 ConstantKeys.DETAILS: f"json{i}",
                 ConstantKeys.P2P_END_POINT: f"ip{i}",
                 ConstantKeys.PUBLIC_KEY: f'publicKey{i}'.encode(),
-                ConstantKeys.IREP: IISS_MIN_IREP + i
             }
             self._reg_prep(addr_array[i], reg_data)
 
@@ -579,3 +575,159 @@ class TestIntegratePrep(TestIntegrateBase):
         validated_blocks: int = info['stats']['validatedBlocks']
         self.assertEqual(10, total_blocks)
         self.assertEqual(0, validated_blocks)
+
+    def test_prep_set_irep_in_term(self):
+        _PREPS_LEN = 22
+        self._update_governance()
+        self._set_revision(REV_IISS)
+
+        addr_array = [create_address() for _ in range(_PREPS_LEN)]
+
+        total_supply = 2_000_000 * self._icx_factor
+
+        # Minimum_delegate_amount is 0.02 * total_supply
+        # In this test delegate 0.03*total_supply because `Issue transaction` exists since REV_IISS
+        delegate_amount = total_supply * 3 // 1000
+
+        # generate preps
+        self._decentralize(addr_array, delegate_amount)
+
+        # set revision to REV_DECENTRALIZATION
+        tx = self._make_score_call_tx(self._admin, GOVERNANCE_SCORE_ADDRESS, 'setRevision',
+                                      {"code": hex(REV_DECENTRALIZATION), "name": f"1.1.{REV_DECENTRALIZATION}"})
+        prev_block, tx_results, main_prep_as_dict = self._make_and_req_block_for_prep_test([tx])
+        self.assertIsNotNone(main_prep_as_dict)
+        data: dict = {
+            ConstantKeys.NAME: "name0",
+            ConstantKeys.EMAIL: "email0",
+            ConstantKeys.WEBSITE: "website0",
+            ConstantKeys.DETAILS: "json0",
+            ConstantKeys.P2P_END_POINT: "ip0",
+            ConstantKeys.PUBLIC_KEY: f'publicKey0'.encode(),
+        }
+
+        expected_response: dict = data
+        response: dict = self._get_prep(addr_array[0])
+        register = response["registration"]
+
+        self.assertEqual(expected_response[ConstantKeys.NAME], register[ConstantKeys.NAME])
+        self.assertEqual(expected_response[ConstantKeys.EMAIL], register[ConstantKeys.EMAIL])
+        self.assertEqual(expected_response[ConstantKeys.WEBSITE], register[ConstantKeys.WEBSITE])
+        self.assertEqual(expected_response[ConstantKeys.DETAILS], register[ConstantKeys.DETAILS])
+        self.assertEqual(expected_response[ConstantKeys.P2P_END_POINT], register[ConstantKeys.P2P_END_POINT])
+        self.assertEqual(expected_response[ConstantKeys.PUBLIC_KEY], register[ConstantKeys.PUBLIC_KEY])
+        self.assertEqual(IISS_INITIAL_IREP, register[ConstantKeys.IREP])
+
+        irep_value = int(IISS_INITIAL_IREP * 1.2)
+
+        set_prep_data1: dict = {
+            ConstantKeys.IREP: irep_value,
+        }
+        self._set_prep(addr_array[0], set_prep_data1)
+
+        response: dict = self._get_prep(addr_array[0])
+        register = response["registration"]
+        self.assertEqual(data[ConstantKeys.NAME], register[ConstantKeys.NAME])
+        self.assertEqual(data[ConstantKeys.WEBSITE], register[ConstantKeys.WEBSITE])
+        self.assertEqual(hex(set_prep_data1[ConstantKeys.IREP]), hex(register[ConstantKeys.IREP]))
+
+        irep_value2 = int(irep_value * 1.1)
+
+        set_prep_data2: dict = {
+            ConstantKeys.IREP: hex(irep_value2),
+        }
+        tx = self._make_score_call_tx(addr_array[0],
+                                      ZERO_SCORE_ADDRESS,
+                                      'setPRep',
+                                      set_prep_data2)
+        prev_block, tx_results = self._make_and_req_block([tx])
+        set_result = tx_results[0]
+        self.assertEqual(set_result.status, 0)
+        failure_message = set_result.failure.message
+        self.assertEqual(failure_message, "Can update irep only one time in term")
+
+        response: dict = self._get_prep(addr_array[0])
+        register = response["registration"]
+        self.assertEqual(data[ConstantKeys.NAME], register[ConstantKeys.NAME])
+        self.assertEqual(data[ConstantKeys.WEBSITE], register[ConstantKeys.WEBSITE])
+        self.assertNotEqual(set_prep_data2[ConstantKeys.IREP], hex(register[ConstantKeys.IREP]))
+
+    def test_prep_set_irep_in_term2(self):
+        """Test for setting same irep value several time in term and other irep value"""
+        _PREPS_LEN = 22
+        self._update_governance()
+        self._set_revision(REV_IISS)
+
+        addr_array = [create_address() for _ in range(_PREPS_LEN)]
+
+        total_supply = 2_000_000 * self._icx_factor
+
+        # Minimum_delegate_amount is 0.02 * total_supply
+        # In this test delegate 0.03*total_supply because `Issue transaction` exists since REV_IISS
+        delegate_amount = total_supply * 3 // 1000
+
+        # generate preps
+        self._decentralize(addr_array, delegate_amount)
+
+        # set revision to REV_DECENTRALIZATION
+        tx = self._make_score_call_tx(self._admin, GOVERNANCE_SCORE_ADDRESS, 'setRevision',
+                                      {"code": hex(REV_DECENTRALIZATION), "name": f"1.1.{REV_DECENTRALIZATION}"})
+        prev_block, tx_results, main_prep_as_dict = self._make_and_req_block_for_prep_test([tx])
+        self.assertIsNotNone(main_prep_as_dict)
+        data: dict = {
+            ConstantKeys.NAME: "name0",
+            ConstantKeys.EMAIL: "email0",
+            ConstantKeys.WEBSITE: "website0",
+            ConstantKeys.DETAILS: "json0",
+            ConstantKeys.P2P_END_POINT: "ip0",
+            ConstantKeys.PUBLIC_KEY: f'publicKey0'.encode(),
+        }
+
+        expected_response: dict = data
+        response: dict = self._get_prep(addr_array[0])
+        register = response["registration"]
+
+        self.assertEqual(expected_response[ConstantKeys.NAME], register[ConstantKeys.NAME])
+        self.assertEqual(expected_response[ConstantKeys.EMAIL], register[ConstantKeys.EMAIL])
+        self.assertEqual(expected_response[ConstantKeys.WEBSITE], register[ConstantKeys.WEBSITE])
+        self.assertEqual(expected_response[ConstantKeys.DETAILS], register[ConstantKeys.DETAILS])
+        self.assertEqual(expected_response[ConstantKeys.P2P_END_POINT], register[ConstantKeys.P2P_END_POINT])
+        self.assertEqual(expected_response[ConstantKeys.PUBLIC_KEY], register[ConstantKeys.PUBLIC_KEY])
+        self.assertEqual(IISS_INITIAL_IREP, register[ConstantKeys.IREP])
+
+        for i in range(3):
+            irep_set_data: dict = {
+                ConstantKeys.IREP: hex(IISS_INITIAL_IREP),
+            }
+            tx = self._make_score_call_tx(addr_array[0],
+                                          ZERO_SCORE_ADDRESS,
+                                          'setPRep',
+                                          irep_set_data)
+            prev_block, tx_results = self._make_and_req_block([tx])
+            self._write_precommit_state(prev_block)
+            set_result = tx_results[0]
+            self.assertEqual(set_result.status, 1)
+
+        irep_value2 = int(IISS_INITIAL_IREP * 1.2)
+        irep_set_data: dict = {
+            ConstantKeys.IREP: hex(irep_value2),
+        }
+        tx = self._make_score_call_tx(addr_array[0],
+                                      ZERO_SCORE_ADDRESS,
+                                      'setPRep',
+                                      irep_set_data)
+        prev_block, tx_results = self._make_and_req_block([tx])
+        self._write_precommit_state(prev_block)
+        set_result = tx_results[0]
+        self.assertEqual(set_result.status, 1)
+
+        irep_set_data[ConstantKeys.IREP] = hex(int(irep_value2*1.1))
+        tx = self._make_score_call_tx(addr_array[0],
+                                      ZERO_SCORE_ADDRESS,
+                                      'setPRep',
+                                      irep_set_data)
+        prev_block, tx_results = self._make_and_req_block([tx])
+        set_result = tx_results[0]
+        failure_message = set_result.failure.message
+        self.assertEqual(set_result.status, 0)
+        self.assertEqual(failure_message, 'Can update irep only one time in term')

--- a/tests/integrate_test/prep/test_preps2.py
+++ b/tests/integrate_test/prep/test_preps2.py
@@ -236,7 +236,6 @@ class TestIntegratePrep(TestIntegrateBase):
                 ConstantKeys.DETAILS: f"json{i}",
                 ConstantKeys.P2P_END_POINT: f"ip{i}",
                 ConstantKeys.PUBLIC_KEY: f'publicKey{i}'.encode(),
-                ConstantKeys.IREP: IISS_MIN_IREP + i
             }
             self._reg_prep(self._addr_array[i], reg_data)
 
@@ -597,6 +596,14 @@ class TestIntegratePrep(TestIntegrateBase):
                                       {"code": hex(REV_DECENTRALIZATION), "name": f"1.1.{REV_DECENTRALIZATION}"})
         prev_block, tx_results, main_prep_as_dict = self._make_and_req_block_for_prep_test([tx])
         self.assertIsNotNone(main_prep_as_dict)
+
+        for i in range(2):
+            prev_block, tx_results = self._make_and_req_block(
+                [],
+                prev_block_generator=addr_array[0],
+                prev_block_validators=[addr_array[1], addr_array[2]])
+            self._write_precommit_state(prev_block)
+
         data: dict = {
             ConstantKeys.NAME: "name0",
             ConstantKeys.EMAIL: "email0",


### PR DESCRIPTION
* Set irep to 37,500 when registering prep.
* PRep can update irep only one time in term.