### PR TITLE
Is-588: do not display nonfield get stake

### DIFF
--- a/iconservice/iiss/engine.py
+++ b/iconservice/iiss/engine.py
@@ -171,10 +171,13 @@ class Engine(EngineBase):
         unstake_block_beight: int = account.unstake_block_height
 
         data = {
-            "stake": stake,
-            "unstake": unstake,
-            "unstakedBlockHeight": unstake_block_beight
+            "stake": stake
         }
+
+        if unstake_block_beight:
+            data["unstake"] = unstake
+            data["unstakeBlockHeight"] = unstake_block_beight
+
         return data
 
     def handle_set_delegation(self, context: 'IconScoreContext', params: dict):

--- a/tests/integrate_test/iiss/test_iiss_stake.py
+++ b/tests/integrate_test/iiss/test_iiss_stake.py
@@ -85,15 +85,12 @@ class TestIntegrateIISSStake(TestIntegrateBase):
         # set stake 1 icx
         stake: int = 1 * 10 ** 18
         unstake: int = 0
-        unstake_block_height: int = 0
         total_stake = stake + unstake
 
         self._stake(self._addr_array[0], stake)
         actual_response: dict = self._get_stake(self._addr_array[0])
         expected_response = {
-            "stake": stake,
-            "unstake": unstake,
-            "unstakedBlockHeight": unstake_block_height
+            "stake": stake
         }
         self.assertEqual(expected_response, actual_response)
         remain_balance: int = balance - total_stake
@@ -102,16 +99,12 @@ class TestIntegrateIISSStake(TestIntegrateBase):
 
         # set stake 5 icx
         stake: int = 5 * 10 ** 18
-        unstake: int = 0
-        unstake_block_height: int = 0
         total_stake = stake + unstake
 
         self._stake(self._addr_array[0], stake)
         actual_response: dict = self._get_stake(self._addr_array[0])
         expected_response = {
             "stake": stake,
-            "unstake": unstake,
-            "unstakedBlockHeight": unstake_block_height
         }
         self.assertEqual(expected_response, actual_response)
         remain_balance: int = balance - total_stake
@@ -129,7 +122,7 @@ class TestIntegrateIISSStake(TestIntegrateBase):
         expected_response = {
             "stake": stake,
             "unstake": unstake,
-            "unstakedBlockHeight": block_height + unstake_lock_period
+            "unstakeBlockHeight": block_height + unstake_lock_period
         }
         self.assertEqual(expected_response, actual_response)
         remain_balance: int = balance - total_stake
@@ -147,7 +140,7 @@ class TestIntegrateIISSStake(TestIntegrateBase):
         expected_response = {
             "stake": stake,
             "unstake": unstake,
-            "unstakedBlockHeight": block_height + unstake_lock_period
+            "unstakeBlockHeight": block_height + unstake_lock_period
         }
         self.assertEqual(expected_response, actual_response)
         remain_balance: int = balance - total_stake
@@ -171,8 +164,6 @@ class TestIntegrateIISSStake(TestIntegrateBase):
 
         actual_response: dict = self._get_stake(self._addr_array[0])
         expected_response = {
-            "stake": 0,
-            "unstake": 0,
-            "unstakedBlockHeight": 0
+            "stake": 0
         }
         self.assertEqual(expected_response, actual_response)


### PR DESCRIPTION
Do not display unstake and unstakeBlockHeight field when its value nonexistent.