### PR TITLE
IS-593 Bugfix PRepEngine.handle_get_prep()

### DIFF
--- a/iconservice/icon_constant.py
+++ b/iconservice/icon_constant.py
@@ -220,11 +220,10 @@ ISSUE_TRANSACTION_VERSION = 3
 
 
 class PRepStatus(Enum):
-    NONE = 0
-    ACTIVE = 1
-    UNREGISTERED = 2
-    PENALTY1 = 3
-    PENALTY2 = 4
+    ACTIVE = 0
+    UNREGISTERED = 1
+    PENALTY1 = 2
+    PENALTY2 = 3
 
 
 PREP_STATUS_MAPPER = {

--- a/iconservice/prep/data/prep.py
+++ b/iconservice/prep/data/prep.py
@@ -134,10 +134,7 @@ class PRep(Sortable):
 
     @status.setter
     def status(self, value: 'PRepStatus'):
-        if value == PRepStatus.ACTIVE and self._status != PRepStatus.NONE:
-            raise InvalidParamsException(f"Invalid init status setting: {value}")
-        elif value != PRepStatus.ACTIVE and self._status == PRepStatus.NONE:
-            raise InvalidParamsException(f"Invalid status setting: {value}")
+        assert self._status == PRepStatus.ACTIVE
         self._status = value
 
     def update_productivity(self, is_validate: bool):
@@ -363,7 +360,7 @@ class PRep(Sortable):
 
     def to_dict(self) -> dict:
         return {
-            "status": PREP_STATUS_MAPPER[self.status],
+            "status": self._status.value,
             "registration": {
                 ConstantKeys.NAME: self.name,
                 ConstantKeys.EMAIL: self.email,

--- a/iconservice/prep/data/prep_container.py
+++ b/iconservice/prep/data/prep_container.py
@@ -120,7 +120,7 @@ class PRepContainer(object):
         """Remove a prep
 
         * Remove a prep from active_prep_dict and active_prep_list
-        * Add a prep to inactive_prep_dict
+        * Add a prep to inactive_prep_dict with frozen flag
 
         :param address:
         :param status:
@@ -139,6 +139,8 @@ class PRepContainer(object):
         assert len(self._active_prep_dict) == len(self._active_prep_list)
 
         prep.status = status
+        prep.freeze()
+
         self._inactive_prep_dict[address] = prep
 
         self._total_prep_delegated -= prep.delegated
@@ -250,6 +252,19 @@ class PRepContainer(object):
             self._active_prep_dict[prep.address] = prep
             self._active_prep_list[index] = prep
 
+        return prep
+
+    def get_inactive_prep_by_address(self, address: 'Address') -> Optional['PRep']:
+        """Returns an inactive prep indicated by a given address
+
+        :param address:
+        :return:
+        """
+        prep: 'PRep' = self._inactive_prep_dict.get(address)
+        if prep is None:
+            raise InvalidParamsException("P-Rep not found")
+
+        assert prep.is_frozen()
         return prep
 
     def __len__(self) -> int:

--- a/iconservice/prep/engine.py
+++ b/iconservice/prep/engine.py
@@ -232,14 +232,16 @@ class Engine(EngineBase, IISSEngineListener):
 
         :param context:
         :param params:
-        :return:
+        :return: the response for getPRep JSON-RPC request
         """
         ret_params: dict = TypeConverter.convert(params, ParamType.IISS_GET_PREP)
         address: 'Address' = ret_params[ConstantKeys.ADDRESS]
 
         prep: 'PRep' = self.preps.get_by_address(address)
         if prep is None:
-            raise InvalidParamsException(f"P-Rep not found: {str(address)}")
+            prep: 'PRep' = self.preps.get_inactive_prep_by_address(address)
+            if prep is None:
+                raise InvalidParamsException(f"P-Rep not found: {str(address)}")
 
         account: 'Account' = context.storage.icx.get_account(context, address, Intent.STAKE)
 

--- a/tests/integrate_test/prep/test_prep.py
+++ b/tests/integrate_test/prep/test_prep.py
@@ -20,9 +20,9 @@ from copy import deepcopy
 from typing import TYPE_CHECKING
 
 from iconservice.base.address import ZERO_SCORE_ADDRESS, GOVERNANCE_SCORE_ADDRESS
-from iconservice.base.exception import InvalidParamsException
 from iconservice.base.type_converter_templates import ConstantKeys
 from iconservice.icon_constant import REV_IISS
+from iconservice.prep.data.prep import PRepStatus
 from tests.integrate_test import create_register_prep_params
 from tests.integrate_test.test_integrate_base import TestIntegrateBase
 
@@ -186,9 +186,8 @@ class TestIntegratePrep(TestIntegrateBase):
             }
         }
 
-        with self.assertRaises(InvalidParamsException) as e:
-            self._query(query_request)
-        self.assertEqual(f"P-Rep not found: {str(address)}", e.exception.args[0])
+        response: dict = self._query(query_request)
+        self.assertEqual(PRepStatus.UNREGISTERED.value, response["status"])
 
         # Unregister a non-existing P-Rep
         address: 'Address' = self._addr_array[1]


### PR DESCRIPTION
* Fix PRepEngine.handle_get_prep() to return an inactive prep with a given address
* Add get_inactive_prep_by_address to PRepContainer
* Change the data type of prep.status (str -> int) in JSON-RPC API response
* Add unit tests