### PR TITLE
IS-590: Define 'FatalException' exception which implies close the icon service

### DIFF
--- a/iconservice/base/exception.py
+++ b/iconservice/base/exception.py
@@ -44,8 +44,12 @@ class ExceptionCode(IntEnum):
         return str(self.name).capitalize().replace('_', ' ')
 
 
-class InvalidBlockException(BaseException):
-    # if this exception is raised on invoke, icon service will be closed
+class FatalException(BaseException):
+    # if this exception is raised on invoke or commit, icon service will be closed
+    pass
+
+
+class InvalidBaseTransactionException(BaseException):
     pass
 
 

--- a/iconservice/icon_inner_service.py
+++ b/iconservice/icon_inner_service.py
@@ -150,7 +150,8 @@ class IconScoreInnerTask(object):
             response = MakeResponse.make_error_response(ExceptionCode.SYSTEM_ERROR, str(e))
         finally:
             Logger.info(f'invoke response with {response}', ICON_INNER_LOG_TAG)
-            self._icon_service_engine.clear_context_stack()
+            if self._icon_service_engine:
+                self._icon_service_engine.clear_context_stack()
             return response
 
     @message_queue_task

--- a/iconservice/icon_inner_service.py
+++ b/iconservice/icon_inner_service.py
@@ -21,7 +21,8 @@ from earlgrey import message_queue_task, MessageQueueStub, MessageQueueService
 from iconcommons.logger import Logger
 from iconservice.base.address import Address
 from iconservice.base.block import Block
-from iconservice.base.exception import ExceptionCode, IconServiceBaseException, InvalidBlockException
+from iconservice.base.exception import ExceptionCode, IconServiceBaseException, InvalidBaseTransactionException, \
+    FatalException
 from iconservice.base.type_converter import TypeConverter, ParamType
 from iconservice.base.type_converter_templates import ConstantKeys
 from iconservice.icon_constant import ICON_INNER_LOG_TAG, ICON_SERVICE_LOG_TAG, \
@@ -134,16 +135,16 @@ class IconScoreInnerTask(object):
             if main_prep_as_dict:
                 results["prep"] = main_prep_as_dict
             response = MakeResponse.make_response(results)
-        except InvalidBlockException as e:
+        except FatalException as e:
+            self._log_exception(e, ICON_SERVICE_LOG_TAG)
+            response = MakeResponse.make_error_response(ExceptionCode.SYSTEM_ERROR, str(e))
+            self._close()
+        except InvalidBaseTransactionException as e:
             self._log_exception(e, ICON_SERVICE_LOG_TAG)
             response = MakeResponse.make_error_response(ExceptionCode.SYSTEM_ERROR, str(e))
         except IconServiceBaseException as icon_e:
             self._log_exception(icon_e, ICON_SERVICE_LOG_TAG)
             response = MakeResponse.make_error_response(icon_e.code, icon_e.message)
-        except AssertionError as e:
-            self._log_exception(e, ICON_SERVICE_LOG_TAG)
-            response = MakeResponse.make_error_response(ExceptionCode.SYSTEM_ERROR, str(e))
-            self._close()
         except Exception as e:
             self._log_exception(e, ICON_SERVICE_LOG_TAG)
             response = MakeResponse.make_error_response(ExceptionCode.SYSTEM_ERROR, str(e))
@@ -178,6 +179,9 @@ class IconScoreInnerTask(object):
             if isinstance(value, Address):
                 value = str(value)
             response = MakeResponse.make_response(value)
+        except FatalException as e:
+            self._log_exception(e, ICON_SERVICE_LOG_TAG)
+            response = MakeResponse.make_error_response(ExceptionCode.SYSTEM_ERROR, str(e))
         except IconServiceBaseException as icon_e:
             self._log_exception(icon_e, ICON_SERVICE_LOG_TAG)
             response = MakeResponse.make_error_response(icon_e.code, icon_e.message)
@@ -207,6 +211,9 @@ class IconScoreInnerTask(object):
 
             if isinstance(response, Address):
                 response = str(response)
+        except FatalException as e:
+            self._log_exception(e, ICON_SERVICE_LOG_TAG)
+            response = MakeResponse.make_error_response(ExceptionCode.SYSTEM_ERROR, str(e))
         except IconServiceBaseException as icon_e:
             self._log_exception(icon_e, ICON_SERVICE_LOG_TAG)
             response = MakeResponse.make_error_response(icon_e.code, icon_e.message)
@@ -248,6 +255,10 @@ class IconScoreInnerTask(object):
 
             self._icon_service_engine.commit(block_height, instant_block_hash, block_hash)
             response = MakeResponse.make_response(ExceptionCode.OK)
+        except FatalException as e:
+            self._log_exception(e, ICON_SERVICE_LOG_TAG)
+            response = MakeResponse.make_error_response(ExceptionCode.SYSTEM_ERROR, str(e))
+            self._close()
         except IconServiceBaseException as icon_e:
             self._log_exception(icon_e, ICON_SERVICE_LOG_TAG)
             response = MakeResponse.make_error_response(icon_e.code, icon_e.message)
@@ -277,6 +288,10 @@ class IconScoreInnerTask(object):
 
             self._icon_service_engine.rollback(block_height, instant_block_hash)
             response = MakeResponse.make_response(ExceptionCode.OK)
+        except FatalException as e:
+            self._log_exception(e, ICON_SERVICE_LOG_TAG)
+            response = MakeResponse.make_error_response(ExceptionCode.SYSTEM_ERROR, str(e))
+            self._close()
         except IconServiceBaseException as icon_e:
             self._log_exception(icon_e, ICON_SERVICE_LOG_TAG)
             response = MakeResponse.make_error_response(icon_e.code, icon_e.message)
@@ -304,6 +319,9 @@ class IconScoreInnerTask(object):
                 request, ParamType.VALIDATE_TRANSACTION)
             self._icon_service_engine.validate_transaction(converted_request)
             response = MakeResponse.make_response(ExceptionCode.OK)
+        except FatalException as e:
+            self._log_exception(e, ICON_SERVICE_LOG_TAG)
+            response = MakeResponse.make_error_response(ExceptionCode.SYSTEM_ERROR, str(e))
         except IconServiceBaseException as icon_e:
             self._log_exception(icon_e, ICON_SERVICE_LOG_TAG)
             response = MakeResponse.make_error_response(icon_e.code, icon_e.message)

--- a/iconservice/icon_service.py
+++ b/iconservice/icon_service.py
@@ -24,6 +24,7 @@ from earlgrey import MessageQueueService, aio_pika
 from iconcommons.icon_config import IconConfig
 from iconcommons.logger import Logger
 
+from iconservice.base.exception import FatalException
 from iconservice.icon_config import default_icon_config
 from iconservice.icon_constant import ICON_SERVICE_PROCTITLE_FORMAT, ICON_SCORE_QUEUE_NAME_FORMAT, ConfigKey, \
     ICON_EXCEPTION_LOG_TAG
@@ -75,7 +76,7 @@ class IconService(object):
 
         try:
             loop.run_forever()
-        except Exception as e:
+        except FatalException as e:
             Logger.exception(e, ICON_EXCEPTION_LOG_TAG)
             Logger.error(e, ICON_EXCEPTION_LOG_TAG)
             self._inner_service.clean_close()

--- a/iconservice/icon_service.py
+++ b/iconservice/icon_service.py
@@ -85,7 +85,7 @@ class IconService(object):
             If the function is called when the operation is not an endless loop 
             in an asynchronous function, the await is terminated immediately.
             """
-            Logger.debug("loop has been stopped and will close the loop")
+            Logger.debug("loop has been stopped and will be closed")
             loop.run_until_complete(loop.shutdown_asyncgens())
             loop.close()
 

--- a/iconservice/icon_service.py
+++ b/iconservice/icon_service.py
@@ -85,6 +85,7 @@ class IconService(object):
             If the function is called when the operation is not an endless loop 
             in an asynchronous function, the await is terminated immediately.
             """
+            Logger.debug("loop has been stopped and will close the loop")
             loop.run_until_complete(loop.shutdown_asyncgens())
             loop.close()
 

--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -23,7 +23,7 @@ from .base.address import Address, generate_score_address, generate_score_addres
 from .base.address import ZERO_SCORE_ADDRESS, GOVERNANCE_SCORE_ADDRESS
 from .base.block import Block
 from .base.exception import ExceptionCode, IconServiceBaseException, ScoreNotFoundException, \
-    AccessDeniedException, IconScoreException, InvalidParamsException, InvalidBlockException
+    AccessDeniedException, IconScoreException, InvalidParamsException, InvalidBaseTransactionException
 from .base.message import Message
 from .base.transaction import Transaction
 from .base.type_converter import TypeConverter
@@ -454,7 +454,8 @@ class IconServiceEngine(ContextContainer):
             for index, tx_request in enumerate(tx_requests):
                 if index == BASE_TRANSACTION_INDEX and self._is_decentralized(context):
                     if not tx_request['params'].get('dataType') == "base":
-                        raise InvalidBlockException("Invalid block: first transaction must be an base transaction")
+                        raise InvalidBaseTransactionException("Invalid block: "
+                                                              "first transaction must be an base transaction")
                     tx_result = self._invoke_base_request(context, tx_request, is_block_editable, regulator)
                 else:
                     tx_result = self._invoke_request(context, tx_request, index)
@@ -713,8 +714,8 @@ class IconServiceEngine(ContextContainer):
                 "issue": regulator.corrected_icx_issue_amount
             }
             if issue_data_in_tx != issue_data_in_db:
-                raise InvalidBlockException("Have difference between "
-                                            "base transaction and actual db data")
+                raise InvalidBaseTransactionException("Have difference between "
+                                                      "base transaction and actual db data")
 
         context.tx = Transaction(tx_hash=request['params']['txHash'],
                                  index=BASE_TRANSACTION_INDEX,

--- a/iconservice/iconscore/icon_score_context.py
+++ b/iconservice/iconscore/icon_score_context.py
@@ -18,6 +18,7 @@ import threading
 import warnings
 from typing import TYPE_CHECKING, Optional, List
 
+from ..base.exception import FatalException
 from .icon_score_trace import Trace
 from ..base.block import Block
 from ..base.message import Message
@@ -72,7 +73,7 @@ class ContextContainer(object):
         if context_stack is not None and len(context_stack) > 0:
             return context_stack.pop()
         else:
-            raise AssertionError('Failed to pop a context out of context_stack')
+            raise FatalException('Failed to pop a context out of context_stack')
 
     @staticmethod
     def _clear_context() -> None:

--- a/iconservice/iconscore/icon_score_context_util.py
+++ b/iconservice/iconscore/icon_score_context_util.py
@@ -22,7 +22,7 @@ from .icon_score_mapper_object import IconScoreInfo
 from .score_package_validator import ScorePackageValidator
 from .utils import get_package_name_by_address_and_tx_hash, get_score_deploy_path
 from ..base.address import Address, ZERO_SCORE_ADDRESS, GOVERNANCE_SCORE_ADDRESS
-from ..base.exception import ScoreNotFoundException, AccessDeniedException
+from ..base.exception import ScoreNotFoundException, AccessDeniedException, FatalException
 from ..database.db import IconScoreDatabase
 from ..database.factory import ContextDatabaseFactory
 from ..icon_constant import IconScoreContextType, IconServiceFlag, DeployState
@@ -125,7 +125,7 @@ class IconScoreContextUtil(object):
                 IconScoreContextUtil.create_score_info(context, address, current_tx_hash)
             score_mapper[address] = score_info
         elif score_info.tx_hash != current_tx_hash:
-            raise AssertionError(
+            raise FatalException(
                 f'scoreInfo.txHash(0x{score_info.tx_hash.hex()}) != txHash(0x{current_tx_hash.hex()})')
 
         return score_info

--- a/iconservice/icx/issue/regulator.py
+++ b/iconservice/icx/issue/regulator.py
@@ -16,7 +16,7 @@
 from typing import Optional, Tuple, Union
 
 from .storage import RegulatorVariable
-from ...base.exception import AccessDeniedException
+from ...base.exception import AccessDeniedException, FatalException
 from ...icon_constant import ISCORE_EXCHANGE_RATE
 from ...iconscore.icon_score_context import IconScoreContext
 
@@ -160,7 +160,7 @@ class Regulator:
 
         # check if RC has sent response about 'CALCULATE' requests. every period should get response
         if prev_calc_period_issued_iscore is None:
-            raise AssertionError("There is no prev_calc_period_iscore")
+            raise FatalException("There is no prev_calc_period_iscore")
 
         # get difference between icon_service and reward_calc after set exchange rates
         prev_calc_over_issued_iscore: int = \

--- a/iconservice/iiss/engine.py
+++ b/iconservice/iiss/engine.py
@@ -25,7 +25,7 @@ from .reward_calc.ipc.reward_calc_proxy import RewardCalcProxy
 from ..base.ComponentBase import EngineBase
 from ..base.address import Address
 from ..base.address import ZERO_SCORE_ADDRESS
-from ..base.exception import InvalidParamsException, InvalidRequestException
+from ..base.exception import InvalidParamsException, InvalidRequestException, FatalException
 from ..base.type_converter import TypeConverter
 from ..base.type_converter_templates import ConstantKeys, ParamType
 from ..icon_constant import IISS_MAX_DELEGATIONS, ISCORE_EXCHANGE_RATE, ICON_SERVICE_LOG_TAG
@@ -99,7 +99,7 @@ class Engine(EngineBase):
     def calculate_callback(cb_data: 'CalculateResponse'):
         # cb_data.success == False: RC has reset the state to before 'CALCULATE' request
         if not cb_data.success:
-            raise AssertionError(f"Reward calc has failed calculating about block height:{cb_data.block_height}")
+            raise FatalException(f"Reward calc has failed calculating about block height:{cb_data.block_height}")
 
         IconScoreContext.storage.rc.put_prev_calc_period_issued_iscore(cb_data.iscore)
         Logger.debug(f"calculate callback called with {cb_data}", ICON_SERVICE_LOG_TAG)

--- a/iconservice/iiss/storage.py
+++ b/iconservice/iiss/storage.py
@@ -55,8 +55,7 @@ class Storage(StorageBase):
     def check_config_before_init(reward_variable: dict):
         for value in reward_variable.values():
             if not 0 < value <= IISS_MAX_REWARD_RATE:
-                raise FatalException(f"Invalid reward variable: Cannot set zero or under "
-                                     f"and more than {IISS_MAX_REWARD_RATE}")
+                raise FatalException(f"Out of reward rate range: 0 < {value} <= {IISS_MAX_REWARD_RATE}")
 
     def put_reward_prep(self, context: 'IconScoreContext', reward_prep: 'Reward'):
         self._db.put(context, self.REWARD_PREP_KEY, reward_prep.to_bytes())

--- a/iconservice/iiss/storage.py
+++ b/iconservice/iiss/storage.py
@@ -14,6 +14,7 @@
 
 from typing import TYPE_CHECKING, Optional
 
+from ..base.exception import FatalException
 from ..base.ComponentBase import StorageBase
 from ..icon_constant import IISS_MAX_REWARD_RATE, ConfigKey
 from ..utils.msgpack_for_db import MsgPackForDB
@@ -54,7 +55,7 @@ class Storage(StorageBase):
     def check_config_before_init(reward_variable: dict):
         for value in reward_variable.values():
             if not 0 < value <= IISS_MAX_REWARD_RATE:
-                raise AssertionError(f"Invalid reward variable: Cannot set zero or under "
+                raise FatalException(f"Invalid reward variable: Cannot set zero or under "
                                      f"and more than {IISS_MAX_REWARD_RATE}")
 
     def put_reward_prep(self, context: 'IconScoreContext', reward_prep: 'Reward'):

--- a/tests/icx/issue/test_issue_regulator.py
+++ b/tests/icx/issue/test_issue_regulator.py
@@ -17,7 +17,7 @@ import pytest
 from unittest.mock import Mock, patch
 
 from iconservice.base.block import Block
-from iconservice.base.exception import AccessDeniedException
+from iconservice.base.exception import AccessDeniedException, FatalException
 from iconservice.database.db import ContextDatabase
 from iconservice.icon_constant import IconScoreContextType, ISCORE_EXCHANGE_RATE
 from iconservice.iconscore.icon_score_context import IconScoreContext
@@ -250,7 +250,7 @@ class TestIssueRegulator:
         icx_issue_amount = 1000
         over_issued_i_score = 0
 
-        with pytest.raises(AssertionError):
+        with pytest.raises(FatalException):
             self.issue_regulator._correct_issue_amount_on_calc_period(prev_calc_period_issued_icx,
                                                                       prev_calc_period_issued_iscore,
                                                                       over_issued_i_score,

--- a/tests/integrate_test/test_integrate_base_transaction_validation.py
+++ b/tests/integrate_test/test_integrate_base_transaction_validation.py
@@ -20,7 +20,7 @@ from copy import deepcopy
 
 from iconservice.base.address import ZERO_SCORE_ADDRESS, Address, AddressPrefix, GOVERNANCE_SCORE_ADDRESS
 from iconservice.base.block import Block
-from iconservice.base.exception import InvalidBlockException
+from iconservice.base.exception import InvalidBaseTransactionException
 from iconservice.base.type_converter_templates import ConstantKeys
 from iconservice.icon_config import default_icon_config
 from iconservice.icon_constant import ISSUE_CALCULATE_ORDER, ISSUE_EVENT_LOG_MAPPER, REV_IISS, \
@@ -236,7 +236,7 @@ class TestIntegrateBaseTransactionValidation(TestIntegrateBase):
         invalid_tx_list = [
             self._make_dummy_tx()
         ]
-        self.assertRaises(InvalidBlockException, self._make_and_req_block_for_issue_test, invalid_tx_list)
+        self.assertRaises(InvalidBaseTransactionException, self._make_and_req_block_for_issue_test, invalid_tx_list)
 
         # failure case: when first transaction is not a issue transaction
         # but 2nd is a issue transaction, should raise error
@@ -244,14 +244,14 @@ class TestIntegrateBaseTransactionValidation(TestIntegrateBase):
             self._make_dummy_tx(),
             self._make_issue_tx(self.issue_data)
         ]
-        self.assertRaises(InvalidBlockException, self._make_and_req_block_for_issue_test, invalid_tx_list)
+        self.assertRaises(InvalidBaseTransactionException, self._make_and_req_block_for_issue_test, invalid_tx_list)
 
         # failure case: if there are more than 2 issue transaction, should raise error
         invalid_tx_list = [
             self._make_issue_tx(self.issue_data),
             self._make_issue_tx(self.issue_data)
         ]
-        self.assertRaises(InvalidBlockException, self._make_and_req_block_for_issue_test, invalid_tx_list)
+        self.assertRaises(InvalidBaseTransactionException, self._make_and_req_block_for_issue_test, invalid_tx_list)
 
         # failure case: when there is no issue transaction, should raise error
         invalid_tx_list = [
@@ -259,7 +259,7 @@ class TestIntegrateBaseTransactionValidation(TestIntegrateBase):
             self._make_dummy_tx(),
             self._make_dummy_tx()
         ]
-        self.assertRaises(InvalidBlockException, self._make_and_req_block_for_issue_test, invalid_tx_list)
+        self.assertRaises(InvalidBaseTransactionException, self._make_and_req_block_for_issue_test, invalid_tx_list)
 
     def test_validate_base_transaction_format(self):
         # isBlockEditable is false in this method
@@ -277,7 +277,7 @@ class TestIntegrateBaseTransactionValidation(TestIntegrateBase):
                 self._make_dummy_tx(),
                 self._make_dummy_tx()
             ]
-            self.assertRaises(InvalidBlockException, self._make_and_req_block_for_issue_test, tx_list)
+            self.assertRaises(InvalidBaseTransactionException, self._make_and_req_block_for_issue_test, tx_list)
             copied_issue_data[group_key] = temp
 
         # more than
@@ -288,7 +288,7 @@ class TestIntegrateBaseTransactionValidation(TestIntegrateBase):
             self._make_dummy_tx(),
             self._make_dummy_tx()
         ]
-        self.assertRaises(InvalidBlockException, self._make_and_req_block_for_issue_test, tx_list)
+        self.assertRaises(InvalidBaseTransactionException, self._make_and_req_block_for_issue_test, tx_list)
 
         # failure case: when group's inner data key (i.e. incentiveRep, rewardRep, etc) is different
         # with stateDB (except value), should raise error
@@ -302,7 +302,7 @@ class TestIntegrateBaseTransactionValidation(TestIntegrateBase):
                 self._make_dummy_tx(),
                 self._make_dummy_tx()
             ]
-            self.assertRaises(InvalidBlockException, self._make_and_req_block_for_issue_test, tx_list)
+            self.assertRaises(InvalidBaseTransactionException, self._make_and_req_block_for_issue_test, tx_list)
             del data['dummy_key']
 
         # less than
@@ -316,7 +316,7 @@ class TestIntegrateBaseTransactionValidation(TestIntegrateBase):
                     self._make_dummy_tx(),
                     self._make_dummy_tx()
                 ]
-                self.assertRaises(InvalidBlockException, self._make_and_req_block_for_issue_test, tx_list)
+                self.assertRaises(InvalidBaseTransactionException, self._make_and_req_block_for_issue_test, tx_list)
                 data[key] = temp
 
     def test_validate_base_transaction_value_editable_block(self):

--- a/tests/test_icon_inner_service.py
+++ b/tests/test_icon_inner_service.py
@@ -15,13 +15,55 @@
 # limitations under the License.
 
 import unittest
+from unittest.mock import Mock, patch
 
+from iconcommons import IconConfig
+
+from iconservice.base.exception import FatalException, InvalidBaseTransactionException, IconServiceBaseException
 from iconservice.base.type_converter_templates import ConstantKeys
 from iconservice.icon_inner_service import IconScoreInnerTask
+from iconservice.icon_service_engine import IconServiceEngine
 from tests import create_block_hash
 
 
 class TestIconInnerService(unittest.TestCase):
+    def setUp(self):
+        self.icon_inner_task_open_patcher = patch('iconservice.icon_inner_service.IconScoreInnerTask._open')
+        self.icon_inner_task_close_patcher = patch('iconservice.icon_inner_service.IconScoreInnerTask._close')
+        _ = self.icon_inner_task_open_patcher.start()
+        _ = self.icon_inner_task_close_patcher.start()
+
+        IconScoreInnerTask._open = Mock()
+        self.inner_task = IconScoreInnerTask(Mock(spec=IconConfig))
+        icon_service_engine = Mock(spec=IconServiceEngine)
+        self.inner_task._icon_service_engine = icon_service_engine
+
+        block = {
+            ConstantKeys.BLOCK_HEIGHT: hex(0),
+            ConstantKeys.BLOCK_HASH: create_block_hash().hex(),
+            ConstantKeys.TIMESTAMP: hex(0),
+            ConstantKeys.PREV_BLOCK_HASH: create_block_hash().hex()
+        }
+        self.mocked_invoke_request = {"block": block, "transactions": []}
+        self.mocked_write_precommit_request = {
+            ConstantKeys.BLOCK_HEIGHT: hex(0),
+            ConstantKeys.BLOCK_HASH: create_block_hash().hex()
+        }
+        self.mocked_query_request = {
+            ConstantKeys.METHOD: "icx_call",
+            ConstantKeys.PARAMS: {}
+        }
+
+        exception_msg = "non fatal exception"
+        exception_list = [InvalidBaseTransactionException,
+                          IconServiceBaseException,
+                          Exception]
+        self.exception_list = list(map(lambda exception: exception(exception_msg), exception_list))
+
+    def tearDown(self):
+        self.icon_inner_task_open_patcher.stop()
+        self.icon_inner_task_close_patcher.stop()
+
     def test_get_block_info_for_precommit_state(self):
         block_height = 10
         instant_block_hash = create_block_hash()
@@ -60,3 +102,107 @@ class TestIconInnerService(unittest.TestCase):
         self.assertRaises(KeyError,
                           IconScoreInnerTask._get_block_info_for_precommit_state,
                           invalid_precommit_data_format)
+
+    def test_fatal_exception_catch_on_invoke(self):
+        # invoke thread: invoke, write_precommit_state, remove_precommit_state
+
+        # success case: when FatalException having been raised on invoke
+        # should close the icon service after sending error response
+        expected_error_msg = "fatal exception on invoke"
+        expected_error_code = 32001
+
+        def mocked_invoke(block,
+                          tx_requests,
+                          prev_block_generator,
+                          prev_block_validators,
+                          is_block_editable):
+            raise FatalException(expected_error_msg)
+
+        self.inner_task._icon_service_engine.invoke = mocked_invoke
+        response = self.inner_task._invoke(self.mocked_invoke_request)
+        assert expected_error_code, response['error']['code']
+        assert expected_error_msg, response['error']['message']
+        assert self.inner_task._close.called
+
+        self.inner_task._close.reset_mock()
+
+        # success case: when other exception having been raised, error response should be returned
+        for exception in self.exception_list:
+            expected_error_msg = exception.args[0]
+
+            def mocked_invoke(block,
+                              tx_requests,
+                              prev_block_generator,
+                              prev_block_validators,
+                              is_block_editable):
+                raise exception
+
+            self.inner_task._icon_service_engine.invoke = mocked_invoke
+            response = self.inner_task._invoke(self.mocked_invoke_request)
+            assert expected_error_msg, response['error']['message']
+            assert not self.inner_task._close.called
+            self.inner_task._close.reset_mock()
+
+    def test_fatal_exception_catch_on_write_precommit_state(self):
+        # success case: when FatalException having been raised on write_precommit_state,
+        # should close the icon service after sending error response
+        expected_error_msg = "fatal exception on write_precommit_state"
+        expected_error_code = 32001
+
+        def mocked_write_precommit(block_height, instant_block_hash, block_hash):
+            raise FatalException(expected_error_msg)
+
+        self.inner_task._icon_service_engine.commit = mocked_write_precommit
+        response = self.inner_task._write_precommit_state(self.mocked_write_precommit_request)
+        assert expected_error_code, response['error']['code']
+        assert expected_error_msg, response['error']['message']
+        assert self.inner_task._close.called
+
+        self.inner_task._close.reset_mock()
+
+        # success case: when other exception having been raised, error response should be returned
+        for exception in self.exception_list:
+            expected_error_msg = exception.args[0]
+
+            def mocked_write_precommit(block_height, instant_block_hash, block_hash):
+                raise exception
+
+            self.inner_task._icon_service_engine.invoke = mocked_write_precommit
+            response = self.inner_task._invoke(self.mocked_write_precommit_request)
+            assert expected_error_msg, response['error']['message']
+            assert not self.inner_task._close.called
+            self.inner_task._close.reset_mock()
+
+    def test_fatal_exception_catch_on_query_thread(self):
+        # query thread: query
+
+        # success case: when FatalException having been raised on query, call (inner call),
+        # should not close the icon service
+        expected_error_msg = "fatal exception on query"
+        expected_error_code = 32001
+
+        def mocked_query(method,
+                         params):
+            raise FatalException(expected_error_msg)
+
+        self.inner_task._icon_service_engine.query = mocked_query
+        response = self.inner_task._query(self.mocked_query_request)
+        assert expected_error_code, response['error']['code']
+        assert expected_error_msg, response['error']['message']
+        assert not self.inner_task._close.called
+
+        self.inner_task._close.reset_mock()
+
+        # success case: when other exception having been raised, error response should be returned
+        for exception in self.exception_list:
+            expected_error_msg = exception.args[0]
+
+            def mocked_query(method,
+                             params):
+                raise exception
+
+            self.inner_task._icon_service_engine.invoke = mocked_query
+            response = self.inner_task._query(self.mocked_query_request)
+            assert expected_error_msg, response['error']['message']
+            assert not self.inner_task._close.called
+            self.inner_task._close.reset_mock()


### PR DESCRIPTION
This exception implies closing the icon service because  the fatal error has been raised

this exception is treated as below in inner task
- In case of FatalException having been raised on invoke thread, should close the icon service after sending an error response.
- In case of FatalException having been raised on query thread, should not close the icon service.