### PR TITLE
IS-623: Remove '0x' when generating base transaction transaction hash

### DIFF
--- a/iconservice/utils/hashing/hash_generator.py
+++ b/iconservice/utils/hashing/hash_generator.py
@@ -40,5 +40,5 @@ class HashGenerator:
     @classmethod
     def generate_hash(cls, origin_data: dict) -> str:
         origin = cls.generate_salted_origin(origin_data)
-        return f'0x{hashlib.sha3_256(origin.encode()).hexdigest()}'
+        return hashlib.sha3_256(origin.encode()).hexdigest()
 

--- a/tests/hashing/test_hash_generator.py
+++ b/tests/hashing/test_hash_generator.py
@@ -39,7 +39,7 @@ class TestHashGenerator:
         main_net_tx_hash = "0xc64119ddd6b0d5034cdcd8b903dadca34e3d79cfe3e00bb2bca8a9ec48e25978"
         actual_tx_hash = HashGenerator.generate_hash(main_net_tx_data)
 
-        assert actual_tx_hash == main_net_tx_hash
+        assert actual_tx_hash == main_net_tx_hash[2:]
 
         main_net_tx_data = {
             "version": "0x3",
@@ -62,4 +62,4 @@ class TestHashGenerator:
         main_net_tx_hash = "0x77a6109d6be90643e54e4ebfbea86f966937cc7978c7105ffea9e852ef447ae3"
         actual_tx_hash = HashGenerator.generate_hash(main_net_tx_data)
 
-        assert actual_tx_hash == main_net_tx_hash
+        assert actual_tx_hash == main_net_tx_hash[2:]


### PR DESCRIPTION
reason: for v2 compatibility