### PR TITLE
IS-626: Add new properties to PRep class

### DIFF
--- a/iconservice/base/type_converter_templates.py
+++ b/iconservice/base/type_converter_templates.py
@@ -165,6 +165,8 @@ class ConstantKeys:
 
     # IISS
     DELEGATIONS = "delegations"
+    COUNTRY = "country"
+    CITY = "city"
     EMAIL = 'email'
     WEBSITE = 'website'
     DETAILS = 'details'
@@ -361,6 +363,8 @@ type_convert_templates[ParamType.IISS_REG_PREP] = {
 
 type_convert_templates[ParamType.IISS_SET_PREP] = {
     ConstantKeys.NAME: ValueType.STRING,
+    ConstantKeys.COUNTRY: ValueType.STRING,
+    ConstantKeys.CITY: ValueType.STRING,
     ConstantKeys.EMAIL: ValueType.STRING,
     ConstantKeys.WEBSITE: ValueType.STRING,
     ConstantKeys.DETAILS: ValueType.STRING,

--- a/iconservice/icon_constant.py
+++ b/iconservice/icon_constant.py
@@ -247,6 +247,12 @@ class PRepStatus(Enum):
     PENALTY2 = 3
 
 
+class PRepGrade(Enum):
+    MAIN = 0
+    SUB = 1
+    CANDIDATE = 2
+
+
 PREP_STATUS_MAPPER = {
     PRepStatus.ACTIVE: "active",
     PRepStatus.UNREGISTERED: "unregistered",

--- a/iconservice/prep/data/prep.py
+++ b/iconservice/prep/data/prep.py
@@ -457,7 +457,7 @@ class PRep(Sortable):
         return data
 
     def __str__(self) -> str:
-        return str(self.to_dict())
+        return str(self.to_dict(PRepDictType.FULL))
 
     def copy(self, flags: 'PRepFlag' = PRepFlag.NONE) -> 'PRep':
         prep = copy.copy(self)

--- a/iconservice/prep/engine.py
+++ b/iconservice/prep/engine.py
@@ -14,11 +14,10 @@
 
 import hashlib
 from collections import OrderedDict
-from typing import TYPE_CHECKING, Any, Optional, List, Dict
+from typing import TYPE_CHECKING, Any, Optional, List
 
 from iconcommons.logger import Logger
-
-from .data.prep import PRep, PRepDictType, PRepGrade
+from .data.prep import PRep, PRepDictType
 from .data.prep_container import PRepContainer
 from .term import Term
 from .validator import validate_prep_data, validate_irep

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ secp256k1==0.13.2
 earlgrey>=0.0.4
 iconcommons>=1.0.5
 msgpack
+iso3166

--- a/tests/integrate_test/iiss/prevote/test_prep.py
+++ b/tests/integrate_test/iiss/prevote/test_prep.py
@@ -23,7 +23,7 @@ from copy import deepcopy
 from iconservice.base.address import Address
 from iconservice.base.exception import InvalidParamsException, ExceptionCode
 from iconservice.base.type_converter_templates import ConstantKeys
-from iconservice.icon_constant import IISS_INITIAL_IREP
+from iconservice.icon_constant import IISS_INITIAL_IREP, PRepGrade, PRepStatus
 from iconservice.icon_constant import REV_IISS, PREP_MAIN_PREPS, ConfigKey, IISS_MAX_DELEGATIONS, ICX_IN_LOOP
 from tests.integrate_test.iiss.test_iiss_base import TestIISSBase
 
@@ -97,6 +97,8 @@ class TestIntegratePrep(TestIISSBase):
                             "irep": self._config[ConfigKey.INITIAL_IREP],
                             "irepUpdateBlockHeight": register_block_height,
                             "name": expected_params['name'],
+                            "country": expected_params["country"],
+                            "city": expected_params["city"],
                             "p2pEndpoint": expected_params['p2pEndpoint'],
                             "publicKey": bytes.fromhex(expected_params['publicKey'][2:]),
                             "website": expected_params['website']
@@ -106,7 +108,8 @@ class TestIntegratePrep(TestIISSBase):
                             "totalBlocks": 0,
                             "validatedBlocks": 0
                         },
-                    "status": 0
+                    "status": PRepStatus.ACTIVE.value,
+                    "grade": PRepGrade.CANDIDATE.value
                 }
             self.assertEqual(expected_response, response)
 
@@ -139,6 +142,8 @@ class TestIntegratePrep(TestIISSBase):
                             "irep": self._config[ConfigKey.INITIAL_IREP],
                             "irepUpdateBlockHeight": register_block_height,
                             "name": f"new{str(self._addr_array[i])}",
+                            "country": expected_params["country"],
+                            "city": expected_params["city"],
                             "p2pEndpoint": expected_params['p2pEndpoint'],
                             "publicKey": bytes.fromhex(expected_params['publicKey'][2:]),
                             "website": expected_params['website']
@@ -148,7 +153,8 @@ class TestIntegratePrep(TestIISSBase):
                             "totalBlocks": 0,
                             "validatedBlocks": 0
                         },
-                    "status": 0
+                    "status": PRepStatus.ACTIVE.value,
+                    "grade": PRepGrade.CANDIDATE.value
                 }
             self.assertEqual(expected_response, response)
 

--- a/tests/integrate_test/iiss/test_iiss_base.py
+++ b/tests/integrate_test/iiss/test_iiss_base.py
@@ -145,6 +145,8 @@ class TestIISSBase(TestIntegrateBase):
 
         return {
             ConstantKeys.NAME: name,
+            ConstantKeys.COUNTRY: "ZZZ",
+            ConstantKeys.CITY: "Unknown",
             ConstantKeys.EMAIL: f"{name}@example.com",
             ConstantKeys.WEBSITE: f"https://{name}.example.com",
             ConstantKeys.DETAILS: f"https://{name}.example.com/details",

--- a/tests/prep/test_prep.py
+++ b/tests/prep/test_prep.py
@@ -48,6 +48,8 @@ def prep():
     )
 
     assert prep.name == NAME
+    # "ZZZ" is the 3-letter country code that means unknown country
+    assert prep.country == "ZZZ"
     assert prep.email == EMAIL
     assert prep.website == WEBSITE
     assert prep.details == DETAILS
@@ -80,14 +82,18 @@ def test_freeze(prep):
 def test_set_ok(prep):
     kwargs = {
         "name": "Best P-Rep",
+        "country": "KOR",
+        "city": "Seoul",
         "email": "best@example.com",
         "website": "https://node.example.com",
         "details": "https://node.example.com/details",
-        "p2p_endpoint": "https://node.example.com:7100",
+        "p2p_endpoint": "node.example.com:7100",
     }
 
     prep.set(**kwargs)
     assert prep.name == kwargs["name"]
+    assert prep.country == kwargs["country"]
+    assert prep.city == kwargs["city"]
     assert prep.email == kwargs["email"]
     assert prep.website == kwargs["website"]
     assert prep.details == kwargs["details"]
@@ -102,4 +108,3 @@ def test_set_error(prep):
 
     with pytest.raises(TypeError):
         prep.set(**kwargs)
-

--- a/tests/prep/test_prep_container.py
+++ b/tests/prep/test_prep_container.py
@@ -34,7 +34,7 @@ def _create_dummy_prep(index: int) -> 'PRep':
         email=f"node{index}@example.com",
         website=f"https://node{index}.example.com",
         details=f"https://node{index}.example.com/details",
-        p2p_endpoint=f"https://node{index}.example.com:7100",
+        p2p_endpoint=f"node{index}.example.com:7100",
         public_key=public_key,
         delegated=random.randint(0, 1000),
         irep=10_000,


### PR DESCRIPTION
* Add grade, country and city attributes to PRep class
* Add iso3166 package to requirements.txt
* Update PRep.to_dict()
* Fix unittest failures
* Focused on getPRep and getPRepList JSON-RPC API only
* To add "stake" to PRep class is not included