### PR TITLE
IS-637: PRep.stake management

### DIFF
--- a/iconservice/prep/data/prep.py
+++ b/iconservice/prep/data/prep.py
@@ -87,6 +87,7 @@ class PRep(Sortable):
             public_key: bytes = b"",
             irep: int = 0,
             irep_block_height: int = 0,
+            stake: int = 0,
             delegated: int = 0,
             block_height: int = 0,
             tx_index: int = 0,
@@ -111,6 +112,7 @@ class PRep(Sortable):
         :param p2p_endpoint:
         :param irep:
         :param irep_block_height:
+        :param stake:
         :param delegated:
         :param block_height:
         :param tx_index:
@@ -123,7 +125,7 @@ class PRep(Sortable):
         # flags
         self._flags: 'PRepFlag' = flags
 
-        # The delegated amount retrieved from account
+        self._stake: int = stake
         self._delegated: int = delegated
 
         # status
@@ -230,11 +232,22 @@ class PRep(Sortable):
         return self._address
 
     @property
+    def stake(self) -> int:
+        return self._stake
+
+    @stake.setter
+    def stake(self, value: int):
+        assert value >= 0
+        self._check_access_permission()
+        self._stake = value
+
+    @property
     def delegated(self) -> int:
         return self._delegated
 
     @delegated.setter
     def delegated(self, value: int):
+        assert value >= 0
         self._check_access_permission()
         self._delegated = value
 
@@ -355,6 +368,7 @@ class PRep(Sortable):
             self.grade.value,
             self.name,
             self.country,
+            self.city,
             self.email,
             self.website,
             self.details,
@@ -432,12 +446,18 @@ class PRep(Sortable):
         )
 
     def to_dict(self, dict_type: 'PRepDictType') -> dict:
+        """Returns the P-Rep information in dict format
+
+        :param dict_type: FULL(getPRep), ABRIDGED(getPRepList)
+        :return:
+        """
         data = {
             "status": self._status.value,
             "grade": self.grade.value,
             "name": self.name,
             "country": self.country,
             "city": self.city,
+            "stake": self._stake,
             "delegated": self._delegated,
             "totalBlocks": self._total_blocks,
             "validatedBlocks": self._validated_blocks

--- a/iconservice/prep/data/prep_container.py
+++ b/iconservice/prep/data/prep_container.py
@@ -22,7 +22,6 @@ from .prep import PRep, PRepFlag, PRepStatus
 from .sorted_list import SortedList
 from ...base.address import Address
 from ...base.exception import InvalidParamsException, AccessDeniedException
-from ...iconscore.icon_score_context import IconScoreContext
 
 
 class PRepContainer(object):
@@ -55,25 +54,22 @@ class PRepContainer(object):
         assert self._total_prep_delegated >= 0
         return self._total_prep_delegated
 
-    def load(self, context: 'IconScoreContext'):
-        """Load active and inactive P-Rep list from StateDB on startup
+    def put(self, prep: 'PRep'):
+        """Put a P-Rep object loaded from db into PRepContainer
 
-        :param context:
+        DO NOT CALL this method anywhere but for PRepEngine.open()
+
+        :param prep:
         :return:
         """
-        for prep in context.storage.prep.get_prep_iterator():
-            if prep.status == PRepStatus.ACTIVE:
-                self._active_prep_dict[prep.address] = prep
-                self._active_prep_list.add(prep)
+        if prep.status == PRepStatus.ACTIVE:
+            self._active_prep_dict[prep.address] = prep
+            self._active_prep_list.add(prep)
 
-                self._total_prep_delegated += prep.delegated
-                assert self._total_prep_delegated >= 0
-            else:
-                self._inactive_prep_dict[prep.address] = prep
-
-            prep.freeze()
-
-        self._flags |= PRepFlag.FROZEN
+            self._total_prep_delegated += prep.delegated
+            assert self._total_prep_delegated >= 0
+        else:
+            self._inactive_prep_dict[prep.address] = prep
 
     def freeze(self):
         """Freeze data in PRepContainer

--- a/tests/integrate_test/iiss/prevote/test_iiss_stake.py
+++ b/tests/integrate_test/iiss/prevote/test_iiss_stake.py
@@ -42,7 +42,7 @@ class TestIISSStake(TestIISSBase):
         self.assertEqual(int(True), tx_results[0].status)
         self._write_precommit_state(prev_block)
 
-        # gain 100 icx
+        # transfer 100 icx to self.addr_array[0]
         balance: int = 100 * ICX_IN_LOOP
         tx = self._make_icx_send_tx(self._genesis, self._addr_array[0], balance)
         prev_block, tx_results = self._make_and_req_block([tx])

--- a/tests/integrate_test/iiss/prevote/test_prep.py
+++ b/tests/integrate_test/iiss/prevote/test_prep.py
@@ -19,8 +19,9 @@
 import hashlib
 import os
 from copy import deepcopy
+from typing import List
 
-from iconservice.base.address import Address
+from iconservice.base.address import Address, AddressPrefix
 from iconservice.base.exception import InvalidParamsException, ExceptionCode
 from iconservice.base.type_converter_templates import ConstantKeys
 from iconservice.icon_constant import IISS_INITIAL_IREP, PRepGrade, PRepStatus
@@ -187,10 +188,10 @@ class TestIntegratePrep(TestIISSBase):
         self._write_precommit_state(prev_block)
 
         with self.assertRaises(InvalidParamsException) as e:
-            self.get_prep_list(start_index=-1)
+            self.get_prep_list(start_ranking=-1)
 
         with self.assertRaises(InvalidParamsException) as e:
-            self.get_prep_list(end_index=-1)
+            self.get_prep_list(end_ranking=-1)
 
         with self.assertRaises(InvalidParamsException) as e:
             self.get_prep_list(0, 1)
@@ -205,7 +206,7 @@ class TestIntegratePrep(TestIISSBase):
         actual_preps: list = response['preps']
         self.assertEqual(1, len(actual_preps))
 
-        response: dict = self.get_prep_list(start_index=1)
+        response: dict = self.get_prep_list(start_ranking=1)
         actual_preps: list = response['preps']
         self.assertEqual(prep_count, len(actual_preps))
 
@@ -270,7 +271,7 @@ class TestIntegratePrep(TestIISSBase):
         actual_list: list = response["preps"]
         self.assertEqual(0, len(actual_list))
 
-        response: dict = self.get_prep_list(end_index=IISS_MAX_DELEGATIONS)
+        response: dict = self.get_prep_list(end_ranking=IISS_MAX_DELEGATIONS)
         preps: list = []
         for i in range(IISS_MAX_DELEGATIONS):
             address: 'Address' = self._addr_array[i]
@@ -281,8 +282,9 @@ class TestIntegratePrep(TestIISSBase):
                     "country": "ZZZ",
                     "city": "Unknown",
                     "address": address,
-                    "delegated": delegation_amount,
                     "name": f"node{address}",
+                    "stake": stake_amount if i == 0 else 0,
+                    "delegated": delegation_amount,
                     "totalBlocks": 0,
                     "validatedBlocks": 0
                 }
@@ -498,3 +500,132 @@ class TestIntegratePrep(TestIISSBase):
         prev_block, tx_results = self._make_and_req_block([tx])
         tx_result = tx_results[0]
         self.assertTrue(tx_result.status)
+
+    def test_prep_stake(self):
+        """Test P-Rep stake management
+        """
+
+        # Update governance SCORE
+        self.update_governance()
+
+        # set Revision REV_IISS
+        tx: dict = self.create_set_revision_tx(REV_IISS)
+        prev_block, tx_results = self._make_and_req_block([tx])
+        self.assertEqual(int(True), tx_results[0].status)
+        self._write_precommit_state(prev_block)
+
+        # Create a user address
+        user_address: 'Address' = Address.from_prefix_and_int(AddressPrefix.EOA, 1234)
+
+        # The number of address is 100
+        prep_addresses: List['Address'] = self._addr_array
+        public_keys: List[bytes] = self.public_key_array
+        prep_count = 30
+
+        # Transfer 100 icx to 30 prep addresses and one user address
+        tx_list: list = [
+            self._make_icx_send_tx(self._genesis, user_address, 100 * ICX_IN_LOOP)
+        ]
+        for i in range(prep_count):
+            prep_address: 'Address' = prep_addresses[i]
+            assert user_address != prep_address
+
+            tx: dict = self._make_icx_send_tx(self._genesis, prep_address, 3000 * ICX_IN_LOOP)
+            tx_list.append(tx)
+
+        prev_block, tx_results = self._make_and_req_block(tx_list)
+        self._write_precommit_state(prev_block)
+        self.assertEqual(prep_count + 1, len(tx_results))
+
+        # Check whether transactions succeeded
+        for tx_result in tx_results:
+            self.assertEqual(int(True), tx_result.status)
+
+        # Register 30 P-Rep candidates
+        tx_list: list = []
+        for i in range(prep_count):
+            prep_address: 'Address' = prep_addresses[i]
+            public_key: str = f"0x{public_keys[i].hex()}"
+
+            tx: dict = self.create_register_prep_tx(prep_address, public_key=public_key)
+            tx_list.append(tx)
+
+        prev_block, tx_results = self._make_and_req_block(tx_list)
+        self._write_precommit_state(prev_block)
+
+        # Check whether transactions succeeded
+        for tx_result in tx_results:
+            self.assertEqual(int(True), tx_result.status)
+
+        # Check whether the stake of each P-Rep is 0
+        response: dict = self.get_prep_list(start_ranking=1)
+        preps: list = response["preps"]
+        self.assertEqual(prep_count, len(preps))
+        for prep in preps:
+            self.assertEqual(0, prep["stake"])
+
+        # Change the stake of each P-Rep
+        total_stake: int = 0
+        tx_list = []
+        for i in range(prep_count):
+            prep_address: 'Address' = prep_addresses[i]
+            stake: int = i * 10 * ICX_IN_LOOP
+            total_stake += stake
+
+            tx = self.create_set_stake_tx(prep_address, stake)
+            tx_list.append(tx)
+
+        prev_block, tx_results = self._make_and_req_block(tx_list)
+        self._write_precommit_state(prev_block)
+
+        # Check whether transactions succeeded
+        for tx_result in tx_results:
+            self.assertEqual(int(True), tx_result.status)
+
+        # Check whether the stake of each P-Rep is correct.
+        response: dict = self.get_prep_list(start_ranking=1)
+        self.assertEqual(total_stake, response["totalStake"])
+
+        preps: list = response["preps"]
+        self.assertEqual(prep_count, len(preps))
+        for i in range(prep_count):
+            stake: int = i * 10 * ICX_IN_LOOP
+            prep: dict = preps[i]
+            self.assertEqual(stake, prep["stake"])
+
+        # Change the stake of each P-Rep
+        total_stake = 0
+        stake: int = 10 * ICX_IN_LOOP
+        tx_list = []
+        for i in range(prep_count):
+            prep_address: 'Address' = prep_addresses[i]
+            total_stake += stake
+
+            tx = self.create_set_stake_tx(prep_address, stake)
+            tx_list.append(tx)
+
+        prev_block, tx_results = self._make_and_req_block(tx_list)
+        self._write_precommit_state(prev_block)
+
+        # setStake with user_address
+        stake = 50 * ICX_IN_LOOP
+        tx_list = [self.create_set_stake_tx(user_address, stake)]
+
+        prev_block, tx_results = self._make_and_req_block(tx_list)
+        self._write_precommit_state(prev_block)
+        total_stake += stake
+
+        # Check the stakes of P-Reps
+        response: dict = self.get_prep_list(start_ranking=1)
+        # total_stake means the sum of stakes which all addresses have
+        self.assertEqual(total_stake, response["totalStake"])
+
+        preps: list = response["preps"]
+        self.assertEqual(prep_count, len(preps))
+
+        for i in range(prep_count):
+            prep: dict = preps[i]
+            self.assertEqual(10 * ICX_IN_LOOP, prep["stake"])
+
+            prep: dict = self.get_prep(prep["address"])
+            self.assertEqual(10 * ICX_IN_LOOP, prep["stake"])

--- a/tests/integrate_test/iiss/test_iiss_base.py
+++ b/tests/integrate_test/iiss/test_iiss_base.py
@@ -214,13 +214,13 @@ class TestIISSBase(TestIntegrateBase):
         return self._query(query_request)
 
     def get_prep_list(self,
-                      start_index: Optional[int] = None,
-                      end_index: Optional[int] = None) -> dict:
+                      start_ranking: Optional[int] = None,
+                      end_ranking: Optional[int] = None) -> dict:
         params = {}
-        if start_index is not None:
-            params['startRanking'] = hex(start_index)
-        if end_index is not None:
-            params['endRanking'] = hex(end_index)
+        if start_ranking is not None:
+            params['startRanking'] = hex(start_ranking)
+        if end_ranking is not None:
+            params['endRanking'] = hex(end_ranking)
 
         query_request = {
             "version": self._version,

--- a/tests/prep/test_prep.py
+++ b/tests/prep/test_prep.py
@@ -19,41 +19,61 @@ import pytest
 
 from iconservice.base.address import AddressPrefix, Address
 from iconservice.base.exception import AccessDeniedException
+from iconservice.icon_constant import IISS_INITIAL_IREP
 from iconservice.prep.data import PRep
 
 NAME = "banana"
 EMAIL = "banana@example.com"
+COUNTRY = "KOR"
+CITY = "Seoul"
 WEBSITE = "https://banana.example.com"
 DETAILS = "https://banana.example.com/details"
-P2P_END_POINT = "https://banana.example.com:7100"
-IREP = 10_000
+P2P_END_POINT = "banana.example.com:7100"
+IREP = IISS_INITIAL_IREP
+STAKE = 100
+DELEGATED = 100
 BLOCK_HEIGHT = 777
 TX_INDEX = 0
 
 
 @pytest.fixture
 def prep():
+    public_key: bytes = b""
     address = Address(AddressPrefix.EOA, os.urandom(20))
     prep = PRep(
         address,
         name=NAME,
+        country=COUNTRY,
+        city=CITY,
         email=EMAIL,
         website=WEBSITE,
         details=DETAILS,
         p2p_endpoint=P2P_END_POINT,
+        public_key=public_key,
         irep=IREP,
         irep_block_height=BLOCK_HEIGHT,
+        stake=STAKE,
+        delegated=DELEGATED,
         block_height=BLOCK_HEIGHT,
         tx_index=TX_INDEX
     )
 
+    assert prep.address == address
     assert prep.name == NAME
     # "ZZZ" is the 3-letter country code that means unknown country
-    assert prep.country == "ZZZ"
+    assert prep.country == "KOR"
+    assert prep.city == CITY
     assert prep.email == EMAIL
     assert prep.website == WEBSITE
     assert prep.details == DETAILS
     assert prep.p2p_endpoint == P2P_END_POINT
+    assert prep.public_key == public_key
+    assert prep.irep == IREP
+    assert prep.irep_block_height == BLOCK_HEIGHT
+    assert prep.stake == STAKE
+    assert prep.delegated == DELEGATED
+    assert prep.total_blocks == 0
+    assert prep.validated_blocks == 0
 
     return prep
 
@@ -108,3 +128,26 @@ def test_set_error(prep):
 
     with pytest.raises(TypeError):
         prep.set(**kwargs)
+
+
+def test_from_bytes_and_to_bytes(prep):
+    data = prep.to_bytes()
+    prep2 = PRep.from_bytes(data)
+
+    assert prep.address == prep2.address
+    assert prep.name == prep2.name
+    assert prep.country == prep2.country
+    assert prep.city == prep2.city
+    assert prep.email == prep2.email
+    assert prep.website == prep2.website
+    assert prep.details == prep2.details
+    assert prep.p2p_endpoint == prep2.p2p_endpoint
+    assert prep.public_key == prep2.public_key
+    assert prep.irep == prep2.irep
+    assert prep.irep_block_height == prep2.irep_block_height
+    assert prep.total_blocks == prep2.total_blocks
+    assert prep.validated_blocks == prep2.validated_blocks
+
+    # Properties which is not serialized in PRep.to_bytes()
+    assert prep2.stake == 0
+    assert prep2.delegated == 0


### PR DESCRIPTION
* Add stake property to PRep class
* Add test_from_bytes_and_to_bytes to test_prep.py
* Add test_prep_stake to prevote/test_prep.py
* Rename start_index and end_index to start_ranking and end_ranking in unittest