### PR TITLE
IS-642: Do not calculate i score for block producers until decentralized

### DIFF
--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -360,10 +360,6 @@ class IconServiceEngine(ContextContainer):
             ContextDatabaseFactory.close()
             self._clear_context()
 
-    @staticmethod
-    def _is_decentralized(context: 'IconScoreContext') -> bool:
-        return context.revision >= REV_DECENTRALIZATION and context.engine.prep.term.sequence != -1
-
     def invoke(self,
                block: 'Block',
                tx_requests: list,
@@ -407,7 +403,7 @@ class IconServiceEngine(ContextContainer):
         base_tx_result: Optional['TransactionResult'] = None
 
         regulator: Optional['Regulator'] = None
-        if is_block_editable and self._is_decentralized(context):
+        if is_block_editable and context.is_decentralized():
             base_transaction, regulator = BaseTransactionCreator.create_base_transaction(context)
             # todo: if the txhash field is add to addedTransaction, should remove this logic
             tx_params_to_added = deepcopy(base_transaction["params"])
@@ -425,7 +421,7 @@ class IconServiceEngine(ContextContainer):
             context.tx_batch.clear()
         else:
             for index, tx_request in enumerate(tx_requests):
-                if index == BASE_TRANSACTION_INDEX and self._is_decentralized(context):
+                if index == BASE_TRANSACTION_INDEX and context.is_decentralized():
                     if not tx_request['params'].get('dataType') == "base":
                         raise InvalidBaseTransactionException("Invalid block: "
                                                               "first transaction must be an base transaction")
@@ -517,7 +513,7 @@ class IconServiceEngine(ContextContainer):
                              prev_block_generator: Optional['Address'] = None,
                              prev_block_validators: Optional[List['Address']] = None):
 
-        if not self._is_decentralized(context):
+        if not context.is_decentralized():
             return
 
         validates: set = set()

--- a/iconservice/iconscore/icon_score_context.py
+++ b/iconservice/iconscore/icon_score_context.py
@@ -24,7 +24,7 @@ from ..base.block import Block
 from ..base.message import Message
 from ..base.transaction import Transaction
 from ..database.batch import BlockBatch, TransactionBatch
-from ..icon_constant import IconScoreContextType, IconScoreFuncType
+from ..icon_constant import IconScoreContextType, IconScoreFuncType, REV_DECENTRALIZATION
 
 if TYPE_CHECKING:
     from .icon_score_base import IconScoreBase
@@ -145,6 +145,9 @@ class IconScoreContext(object):
     @property
     def total_supply(self):
         return self.storage.icx.get_total_supply(self)
+
+    def is_decentralized(self) -> bool:
+        return self.revision >= REV_DECENTRALIZATION and self.engine.prep.term.sequence != -1
 
     def set_func_type_by_icon_score(self, icon_score: 'IconScoreBase', func_name: str):
         is_func_readonly = getattr(icon_score, '_IconScoreBase__is_func_readonly')

--- a/iconservice/prep/data/prep.py
+++ b/iconservice/prep/data/prep.py
@@ -437,7 +437,7 @@ class PRep(Sortable):
             # Required items
             p2p_endpoint=data[ConstantKeys.P2P_ENDPOINT],
             public_key=data[ConstantKeys.PUBLIC_KEY],
-            irep=IISS_INITIAL_IREP,
+            irep=0,
             irep_block_height=block_height,
 
             # Registration time

--- a/iconservice/prep/engine.py
+++ b/iconservice/prep/engine.py
@@ -77,7 +77,7 @@ class Engine(EngineBase, IISSEngineListener):
 
     def open(self, context: 'IconScoreContext', term_period: int, irep: int):
         self._load_preps(context)
-        self.term.load(context, term_period, irep)
+        self.term.load(context, term_period)
         self._initial_irep = irep
 
         context.engine.iiss.add_listener(self)

--- a/iconservice/prep/engine.py
+++ b/iconservice/prep/engine.py
@@ -27,7 +27,7 @@ from ..base.address import Address, ZERO_SCORE_ADDRESS
 from ..base.exception import InvalidParamsException, MethodNotFoundException
 from ..base.type_converter import TypeConverter, ParamType
 from ..base.type_converter_templates import ConstantKeys
-from ..icon_constant import IISS_MAX_DELEGATIONS, REV_DECENTRALIZATION
+from ..icon_constant import IISS_MAX_DELEGATIONS, REV_DECENTRALIZATION, IISS_MIN_IREP
 from ..icon_constant import PREP_MAIN_PREPS, PREP_MAIN_AND_SUB_PREPS
 from ..icon_constant import PrepResultState
 from ..iconscore.icon_score_context import IconScoreContext
@@ -71,12 +71,14 @@ class Engine(EngineBase, IISSEngineListener):
 
         self.preps = PRepContainer()
         self.term = Term()
+        self._initial_irep: Optional[int] = None
 
         Logger.debug("PRepEngine.__init__() end")
 
     def open(self, context: 'IconScoreContext', term_period: int, irep: int):
         self._load_preps(context)
         self.term.load(context, term_period, irep)
+        self._initial_irep = irep
 
         context.engine.iiss.add_listener(self)
 
@@ -210,8 +212,10 @@ class Engine(EngineBase, IISSEngineListener):
         prep.delegated = account.delegated_amount
 
         # Set an initial value to irep of a P-Rep on registerPRep
-        if self.term.irep > 0:
+        if context.is_decentralized():
             prep.set_irep(self.term.irep, context.block.height)
+        else:
+            prep.set_irep(self._initial_irep, context.block.height)
 
         # Update preps in context
         context.preps.add(prep)
@@ -304,7 +308,7 @@ class Engine(EngineBase, IISSEngineListener):
             total_weighted_irep += prep.irep * prep.delegated
             total_delegated += prep.delegated
 
-        return total_weighted_irep // total_delegated if total_delegated > 0 else 0
+        return total_weighted_irep // total_delegated if total_delegated > 0 else IISS_MIN_IREP
 
     def handle_get_prep(self, context: 'IconScoreContext', params: dict) -> dict:
         """Returns the details of a P-Rep including information on registration, delegation and statistics

--- a/iconservice/prep/term.py
+++ b/iconservice/prep/term.py
@@ -70,7 +70,7 @@ class Term(object):
     def total_supply(self) -> int:
         return self._total_supply
 
-    def load(self, context: 'IconScoreContext', term_period: int, irep: int):
+    def load(self, context: 'IconScoreContext', term_period: int):
         data: Optional[list] = context.storage.prep.get_term(context)
         if data:
             version = data[0]
@@ -84,7 +84,7 @@ class Term(object):
             self._total_supply = data[5]
         else:
             self._period = term_period
-            self._irep = irep
+            self._irep = 0
             self._total_supply = context.total_supply
 
     @staticmethod

--- a/tests/integrate_test/iiss/decentralized/test_decentralized.py
+++ b/tests/integrate_test/iiss/decentralized/test_decentralized.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from iconservice.icon_constant import REV_DECENTRALIZATION, REV_IISS, \
-    PREP_MAIN_PREPS, ICX_IN_LOOP, IISS_INITIAL_IREP, ConfigKey
+    PREP_MAIN_PREPS, ICX_IN_LOOP, ConfigKey, IISS_MIN_IREP
 from tests.integrate_test.iiss.test_iiss_base import TestIISSBase
 from tests.integrate_test.test_integrate_base import TOTAL_SUPPLY
 
@@ -174,7 +174,7 @@ class TestIISSDecentralized(TestIISSBase):
         self.make_blocks_to_end_calculation()
 
         # set governance variable
-        tx: dict = self.create_set_governance_variables(self._addr_array[prep_id], IISS_INITIAL_IREP)
+        tx: dict = self.create_set_governance_variables(self._addr_array[prep_id], IISS_MIN_IREP)
         self.estimate_step(tx)
 
         # unregister prep

--- a/tests/integrate_test/iiss/decentralized/test_decentralized.py
+++ b/tests/integrate_test/iiss/decentralized/test_decentralized.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from iconservice.icon_constant import REV_DECENTRALIZATION, REV_IISS, \
-    PREP_MAIN_PREPS, ICX_IN_LOOP, ConfigKey, IISS_MIN_IREP
+    PREP_MAIN_PREPS, ICX_IN_LOOP, ConfigKey, IISS_MIN_IREP, IISS_INITIAL_IREP
 from tests.integrate_test.iiss.test_iiss_base import TestIISSBase
 from tests.integrate_test.test_integrate_base import TOTAL_SUPPLY
 
@@ -180,3 +180,111 @@ class TestIISSDecentralized(TestIISSBase):
         # unregister prep
         tx: dict = self.create_unregister_prep_tx(self._addr_array[prep_id])
         self.estimate_step(tx)
+
+    def test_irep_each_revision(self):
+        # decentralized
+        self.update_governance()
+
+        # set Revision REV_IISS
+        tx: dict = self.create_set_revision_tx(REV_IISS)
+        prev_block, tx_results = self._make_and_req_block([tx])
+        self._write_precommit_state(prev_block)
+
+        expected_irep_when_rev_iiss = 0
+        response: dict = self.get_iiss_info()
+        self.assertEqual(expected_irep_when_rev_iiss, response['variable']['irep'])
+
+        main_preps = self._addr_array[:PREP_MAIN_PREPS]
+
+        total_supply = TOTAL_SUPPLY * ICX_IN_LOOP
+        # Minimum_delegate_amount is 0.02 * total_supply
+        # In this test delegate 0.03*total_supply because `Issue transaction` exists since REV_IISS
+        minimum_delegate_amount_for_decentralization: int = total_supply * 2 // 1000 + 1
+        init_balance: int = minimum_delegate_amount_for_decentralization * 10
+
+        # distribute icx PREP_MAIN_PREPS ~ PREP_MAIN_PREPS + PREP_MAIN_PREPS - 1
+        tx_list: list = []
+        for i in range(PREP_MAIN_PREPS):
+            tx: dict = self._make_icx_send_tx(self._genesis,
+                                              self._addr_array[PREP_MAIN_PREPS + i],
+                                              init_balance)
+            tx_list.append(tx)
+        prev_block, tx_results = self._make_and_req_block(tx_list)
+        for tx_result in tx_results:
+            self.assertEqual(int(True), tx_result.status)
+        self._write_precommit_state(prev_block)
+
+        # stake PREP_MAIN_PREPS ~ PREP_MAIN_PREPS + PREP_MAIN_PREPS - 1
+        stake_amount: int = minimum_delegate_amount_for_decentralization
+        tx_list: list = []
+        for i in range(PREP_MAIN_PREPS):
+            tx: dict = self.create_set_stake_tx(self._addr_array[PREP_MAIN_PREPS + i],
+                                                stake_amount)
+            tx_list.append(tx)
+        prev_block, tx_results = self._make_and_req_block(tx_list)
+        for tx_result in tx_results:
+            self.assertEqual(int(True), tx_result.status)
+        self._write_precommit_state(prev_block)
+
+        # distribute icx for register PREP_MAIN_PREPS ~ PREP_MAIN_PREPS + PREP_MAIN_PREPS - 1
+        tx_list: list = []
+        for i in range(PREP_MAIN_PREPS):
+            tx: dict = self._make_icx_send_tx(self._genesis,
+                                              self._addr_array[i],
+                                              3000 * ICX_IN_LOOP)
+            tx_list.append(tx)
+        prev_block, tx_results = self._make_and_req_block(tx_list)
+        for tx_result in tx_results:
+            self.assertEqual(int(True), tx_result.status)
+        self._write_precommit_state(prev_block)
+
+        # register PRep
+        tx_list: list = []
+
+        for i, address in enumerate(main_preps):
+            tx: dict = self.create_register_prep_tx(address, public_key=f"0x{self.public_key_array[i].hex()}")
+            tx_list.append(tx)
+        prev_block, tx_results = self._make_and_req_block(tx_list)
+        for tx_result in tx_results:
+            self.assertEqual(int(True), tx_result.status)
+
+        self._write_precommit_state(prev_block)
+
+        # irep of each prep should be 50,000 ICX when revision IISS_REV
+        expected_inital_irep_of_prep = IISS_INITIAL_IREP
+        for address in main_preps:
+            response = self.get_prep(address)
+            self.assertEqual(expected_inital_irep_of_prep, response['irep'])
+
+        # delegate to PRep
+        tx_list: list = []
+        for i in range(PREP_MAIN_PREPS):
+            tx: dict = self.create_set_delegation_tx(self._addr_array[PREP_MAIN_PREPS + i],
+                                                     [
+                                                         (
+                                                             self._addr_array[i],
+                                                             minimum_delegate_amount_for_decentralization
+                                                         )
+                                                     ])
+            tx_list.append(tx)
+        prev_block, tx_results = self._make_and_req_block(tx_list)
+        for tx_result in tx_results:
+            self.assertEqual(int(True), tx_result.status)
+        self._write_precommit_state(prev_block)
+
+        # get main prep
+        response: dict = self.get_main_prep_list()
+        expected_response: dict = {
+            "preps": [],
+            "totalDelegated": 0
+        }
+        self.assertEqual(expected_response, response)
+
+        # set Revision REV_IISS (decentralization)
+        tx: dict = self.create_set_revision_tx(REV_DECENTRALIZATION)
+        prev_block, tx_results = self._make_and_req_block([tx])
+        self._write_precommit_state(prev_block)
+
+        expected_irep_when_decentralized = IISS_INITIAL_IREP
+        response: dict = self.get_iiss_info()
+        self.assertEqual(expected_irep_when_decentralized, response['variable']['irep'])

--- a/tests/integrate_test/iiss/decentralized/test_decentralized.py
+++ b/tests/integrate_test/iiss/decentralized/test_decentralized.py
@@ -272,19 +272,12 @@ class TestIISSDecentralized(TestIISSBase):
             self.assertEqual(int(True), tx_result.status)
         self._write_precommit_state(prev_block)
 
-        # get main prep
-        response: dict = self.get_main_prep_list()
-        expected_response: dict = {
-            "preps": [],
-            "totalDelegated": 0
-        }
-        self.assertEqual(expected_response, response)
-
         # set Revision REV_IISS (decentralization)
         tx: dict = self.create_set_revision_tx(REV_DECENTRALIZATION)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
 
+        # after decentralization, irep should be 50,000
         expected_irep_when_decentralized = IISS_INITIAL_IREP
         response: dict = self.get_iiss_info()
         self.assertEqual(expected_irep_when_decentralized, response['variable']['irep'])

--- a/tests/integrate_test/iiss/prevote/test_prevote.py
+++ b/tests/integrate_test/iiss/prevote/test_prevote.py
@@ -45,7 +45,7 @@ class TestIISS(TestIISSBase):
             'nextCalculation': block_height + calc_period + 1,
             'nextPRepTerm': 0,
             'variable': {
-                "irep": self._config[ConfigKey.INITIAL_IREP],
+                "irep": 0,
                 "rrep": 1200
             }
         }

--- a/tests/integrate_test/iiss/test_iiss_base.py
+++ b/tests/integrate_test/iiss/test_iiss_base.py
@@ -25,7 +25,7 @@ from iconservice.base.address import Address
 from iconservice.base.address import ZERO_SCORE_ADDRESS, GOVERNANCE_SCORE_ADDRESS
 from iconservice.base.type_converter_templates import ConstantKeys
 from iconservice.icon_constant import ConfigKey, PREP_MAIN_AND_SUB_PREPS, REV_IISS, PREP_MAIN_PREPS, ICX_IN_LOOP, \
-    REV_DECENTRALIZATION, IISS_INITIAL_IREP
+    REV_DECENTRALIZATION
 from tests.integrate_test.test_integrate_base import TestIntegrateBase, TOTAL_SUPPLY
 
 
@@ -335,10 +335,6 @@ class TestIISSBase(TestIntegrateBase):
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
 
-        expected_irep_when_rev_iiss = 0
-        response: dict = self.get_iiss_info()
-        self.assertEqual(expected_irep_when_rev_iiss, response['variable']['irep'])
-
         main_preps = self._addr_array[:PREP_MAIN_PREPS]
 
         total_supply = TOTAL_SUPPLY * ICX_IN_LOOP
@@ -385,20 +381,13 @@ class TestIISSBase(TestIntegrateBase):
 
         # register PRep
         tx_list: list = []
-
         for i, address in enumerate(main_preps):
             tx: dict = self.create_register_prep_tx(address, public_key=f"0x{self.public_key_array[i].hex()}")
             tx_list.append(tx)
         prev_block, tx_results = self._make_and_req_block(tx_list)
         for tx_result in tx_results:
             self.assertEqual(int(True), tx_result.status)
-
         self._write_precommit_state(prev_block)
-        # irep of each prep should be 50000 ICX when revision IISS_REV
-        expected_inital_irep_of_prep = IISS_INITIAL_IREP
-        for address in main_preps:
-            response = self.get_prep(address)
-            self.assertEqual(expected_inital_irep_of_prep, response['irep'])
 
         # delegate to PRep
         tx_list: list = []
@@ -428,10 +417,6 @@ class TestIISSBase(TestIntegrateBase):
         tx: dict = self.create_set_revision_tx(REV_DECENTRALIZATION)
         prev_block, tx_results = self._make_and_req_block([tx])
         self._write_precommit_state(prev_block)
-
-        expected_irep_when_decentralized = IISS_INITIAL_IREP
-        response: dict = self.get_iiss_info()
-        self.assertEqual(expected_irep_when_decentralized, response['variable']['irep'])
 
         # get main prep
         response: dict = self.get_main_prep_list()

--- a/tests/prep/test_term.py
+++ b/tests/prep/test_term.py
@@ -79,10 +79,10 @@ def test_save_and_load():
     context.storage.prep.get_term = Mock(return_value=None)
     context.storage.icx.get_total_supply = Mock(return_value=total_supply)
     term._make_main_and_sub_preps = Mock()
-    term.load(context, period, irep)
+    term.load(context, period)
     assert term.period == period
     assert term.total_supply == total_supply
-    assert term.irep == irep
+    assert term.irep == 0
     assert term.sequence == -1
     assert term.main_preps == []
     assert term.sub_preps == []
@@ -108,7 +108,7 @@ def test_save_and_load():
             0, saved_sequence, current_block + 1, term._serialize_preps(PREPS), irep, total_supply])
         term._make_main_and_sub_preps = Mock(return_value=(PREPS[:PREP_MAIN_PREPS],
                                                            PREPS[PREP_MAIN_PREPS:PREP_MAIN_AND_SUB_PREPS]))
-        term.load(context, period, irep)
+        term.load(context, period)
         assert term.sequence == saved_sequence
         assert term.total_supply == total_supply
         assert term.main_preps == PREPS[:PREP_MAIN_PREPS]


### PR DESCRIPTION
1. Move 'is_decentralized' method from icon service engine to icon score context
Reason: this method could be used in many engines

2. Set term's irep to 0 when revision IISS_REV

3. Define '_initial_irep' member variable in prep engine
This variable is used when registering prep in revision IISS_REV. after decentralized, use term.irep (i.e. _initial_irep is only used when revision IISS_REV).

4. When weighted_average_of_irep is 0, return IISS_MIN_IREP.