### PR TITLE
IS-638: PRep.grade management

### DIFF
--- a/iconservice/inner_call/__init__.py
+++ b/iconservice/inner_call/__init__.py
@@ -19,10 +19,12 @@ from ..base.type_converter import TypeConverter
 if TYPE_CHECKING:
     from ..iconscore.icon_score_context import IconScoreContext
     from ..base.block import Block
+    from ..prep.term import Term
 
 
-def get_main_preps(context: 'IconScoreContext', **kwargs):
-    preps: dict = context.engine.prep.get_main_preps_in_term()
+def get_main_preps(context: 'IconScoreContext', **_kwargs):
+    term: 'Term' = context.engine.prep.term
+    preps: dict = context.engine.prep.get_main_preps_in_dict(term.main_preps)
     if preps is None:
         preps = {}
 

--- a/iconservice/precommit_data_manager.py
+++ b/iconservice/precommit_data_manager.py
@@ -51,6 +51,7 @@ class PrecommitData(object):
                  block_result: list,
                  rc_block_batch: list,
                  preps: 'PRepContainer',
+                 term: Optional['Term'],
                  prev_block_generator: Optional['Address'],
                  prev_block_validators: Optional[List['Address']],
                  score_mapper: Optional['IconScoreMapper'] = None,
@@ -69,6 +70,7 @@ class PrecommitData(object):
         self.rc_block_batch = rc_block_batch
         # Snapshot of preps
         self.preps = preps
+        self.term = term
         self.prev_block_generator = prev_block_generator
         self.prev_block_validators = prev_block_validators
         self.score_mapper = score_mapper

--- a/iconservice/prep/engine.py
+++ b/iconservice/prep/engine.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 import hashlib
-from collections import OrderedDict
-from typing import TYPE_CHECKING, Any, Optional, List, Dict
+from typing import TYPE_CHECKING, Any, Optional, List, Dict, Tuple
 
 from iconcommons.logger import Logger
 
@@ -126,20 +125,33 @@ class Engine(EngineBase, IISSEngineListener):
         :param precommit_data:
         :return:
         """
+        # Updated every block
         self.preps = precommit_data.preps
+
+        # Updated every term
+        if precommit_data.term is not None:
+            self.term: 'Term' = precommit_data.term
 
     def rollback(self):
         pass
 
-    def _on_term_ended(self):
-        """The term has been ended
+    def on_term_ended(self, context: 'IconScoreContext') -> Tuple[dict, 'Term']:
+        """Called in IconServiceEngine.invoke() every time when a term is ended
 
         Update P-Rep grades according to PRep.delegated
         """
-        new_preps: 'PRepContainer' = self.preps
+        self._update_prep_grades(context)
+        main_preps_as_dict: dict = self.get_next_main_preps(context)
+        next_term: 'Term' = self._create_next_term(context)
+        next_term.save(context)
+
+        return main_preps_as_dict, next_term
+
+    def _update_prep_grades(self, context: 'IconScoreContext'):
+        new_preps: 'PRepContainer' = context.preps
         prep_grades: Dict['Address', 'PRepGrade'] = {}
 
-        # Put address and old grade pair to prep_grades dict
+        # Put the address and grade of a old P-Rep to prep_grades dict
         for prep in self.term.preps:
             prep_grades[prep.address] = prep.grade
 
@@ -147,7 +159,7 @@ class Engine(EngineBase, IISSEngineListener):
         for i in range(PREP_MAIN_AND_SUB_PREPS):
             prep: 'PRep' = new_preps.get_by_index(i, mutable=False)
             if prep is None:
-                # Not enough P-Rep candidates
+                Logger.warning(tag="PREP", msg=f"Not enough P-Reps: {len(new_preps)}")
                 break
 
             prep_address: 'Address' = prep.address
@@ -161,7 +173,10 @@ class Engine(EngineBase, IISSEngineListener):
 
         # Update the grades of P-Reps for the next term
         for address, new_grade in prep_grades.items():
-            prep: 'PRep' = self.preps.get_by_address(address, mutable=True)
+            prep: 'PRep' = new_preps.get_by_address(address, mutable=True)
+            if prep is None:
+                prep: 'PRep' = new_preps.get_inactive_prep_by_address(address)
+
             assert prep is not None
             prep.grade = new_grade
 
@@ -254,53 +269,69 @@ class Engine(EngineBase, IISSEngineListener):
         """
         return self.term.end_block_height == context.block.height
 
-    def make_prep_tx_result(self) -> Optional[dict]:
-        """Returns dict containing main preps which is appended to invoke result
+    def get_next_main_preps(self, context: 'IconScoreContext') -> Optional[dict]:
+        """Returns preps which will run as main preps during the next term in dict format
 
         :return:
         """
-        prep_as_dict = self.get_main_preps_in_term()
+        prep_as_dict: Optional[dict] = \
+            self.get_main_preps_in_dict(context.preps.get_preps(0, PREP_MAIN_PREPS))
+
         if prep_as_dict:
             prep_as_dict['irep'] = self.term.irep
             prep_as_dict['state'] = PrepResultState.NORMAL.value
-            return prep_as_dict
-        return None
 
-    def get_main_preps_in_term(self) -> Optional[dict]:
-        main_preps = self.term.main_preps
-        prep_as_dict = None
-        if len(main_preps) > 0:
-            prep_as_dict = OrderedDict()
-            preps_as_list = []
-            prep_addresses_for_roothash = b''
-            for prep in main_preps:
-                prep_info_as_dict = OrderedDict()
-                prep_info_as_dict[ConstantKeys.PREP_ID] = prep.address
-                prep_info_as_dict[ConstantKeys.PUBLIC_KEY] = prep.public_key
-                prep_info_as_dict[ConstantKeys.P2P_ENDPOINT] = prep.p2p_endpoint
-                preps_as_list.append(prep_info_as_dict)
-                prep_addresses_for_roothash += prep.address.to_bytes_including_prefix()
-            prep_as_dict["preps"] = preps_as_list
-            prep_as_dict["rootHash"] = hashlib.sha3_256(prep_addresses_for_roothash).digest()
         return prep_as_dict
 
-    def save_term(self, context: 'IconScoreContext', weighted_average_of_irep: int):
-        self.term.save(context,
-                       context.block.height,
-                       context.preps.get_preps(start_index=0, size=PREP_MAIN_AND_SUB_PREPS),
-                       weighted_average_of_irep,
-                       context.total_supply)
+    @staticmethod
+    def get_main_preps_in_dict(preps: List['PRep']) -> Optional[dict]:
+        count: int = min(len(preps), PREP_MAIN_PREPS)
+        if count == 0:
+            Logger.warning(tag="PREP", msg="No P-Rep candidates")
+            return None
+
+        prep_as_dict = {}
+        preps_as_list = []
+        prep_addresses_for_roothash = b''
+
+        for i in range(count):
+            prep: 'PRep' = preps[i]
+            preps_as_list.append({
+                ConstantKeys.PREP_ID: prep.address,
+                ConstantKeys.PUBLIC_KEY: prep.public_key,
+                ConstantKeys.P2P_ENDPOINT: prep.p2p_endpoint
+            })
+            prep_addresses_for_roothash += prep.address.to_bytes_including_prefix()
+
+        prep_as_dict["preps"] = preps_as_list
+        prep_as_dict["rootHash"]: bytes = hashlib.sha3_256(prep_addresses_for_roothash).digest()
+
+        return prep_as_dict
+
+    def _create_next_term(self, context: 'IconScoreContext') -> 'Term':
+        # The current P-Rep term is over. Prepare the next P-Rep term
+        irep: int = self._calculate_weighted_average_of_irep(context)
+
+        next_term = Term()
+        next_term.update(
+            context.block.height,
+            context.preps.get_preps(start_index=0, size=PREP_MAIN_AND_SUB_PREPS),
+            context.total_supply,
+            self.term.period,
+            irep
+        )
+
+        return next_term
 
     @staticmethod
-    def calculate_weighted_average_of_irep(context: 'IconScoreContext') -> int:
+    def _calculate_weighted_average_of_irep(context: 'IconScoreContext') -> int:
         preps: 'PRepContainer' = context.preps
-        assert len(preps) >= PREP_MAIN_PREPS
 
-        total_delegated = 0  # total delegated of prep
+        total_delegated = 0  # total delegated of top 22 preps
         total_weighted_irep = 0
 
         for i in range(PREP_MAIN_PREPS):
-            prep: 'PRep' = preps.get_by_index(i)
+            prep: 'PRep' = preps.get_by_index(i, mutable=False)
             total_weighted_irep += prep.irep * prep.delegated
             total_delegated += prep.delegated
 

--- a/iconservice/prep/engine.py
+++ b/iconservice/prep/engine.py
@@ -136,21 +136,21 @@ class Engine(EngineBase, IISSEngineListener):
 
         Update P-Rep grades according to PRep.delegated
         """
+        new_preps: 'PRepContainer' = self.preps
         prep_grades: Dict['Address', 'PRepGrade'] = {}
-        old_preps: List['PRep'] = self.term.main_preps + self.term.sub_preps
 
         # Put address and old grade pair to prep_grades dict
-        for prep in old_preps:
+        for prep in self.term.preps:
             prep_grades[prep.address] = prep.grade
 
         # Remove the P-Reps which preserve the same grade in the next term from prep_grades dict
         for i in range(PREP_MAIN_AND_SUB_PREPS):
-            prep: 'PRep' = self.preps.get_by_index(i, mutable=False)
+            prep: 'PRep' = new_preps.get_by_index(i, mutable=False)
             if prep is None:
                 # Not enough P-Rep candidates
                 break
 
-            prep_address: 'Address' = prep_address
+            prep_address: 'Address' = prep.address
             old_grade: 'PRepGrade' = prep_grades.get(prep_address, PRepGrade.CANDIDATE)
             new_grade: 'PRepGrade' = PRepGrade.MAIN if i < PREP_MAIN_PREPS else PRepGrade.SUB
 
@@ -255,6 +255,10 @@ class Engine(EngineBase, IISSEngineListener):
         return self.term.end_block_height == context.block.height
 
     def make_prep_tx_result(self) -> Optional[dict]:
+        """Returns dict containing main preps which is appended to invoke result
+
+        :return:
+        """
         prep_as_dict = self.get_main_preps_in_term()
         if prep_as_dict:
             prep_as_dict['irep'] = self.term.irep

--- a/iconservice/prep/term.py
+++ b/iconservice/prep/term.py
@@ -126,33 +126,48 @@ class Term(object):
 
         return prep_list
 
-    def save(self,
-             context: 'IconScoreContext',
-             current_block_height: int,
-             preps: List['PRep'],
-             irep: int,
-             total_supply: int):
-        """Save term data to stateDB
+    def update(
+            self, current_block_height: int, preps: List['PRep'],
+            total_supply: int, term_period: int, irep: int):
+        """
 
-        :param context:
         :param current_block_height:
-        :param preps: P-Rep list including main P-Reps and sub P-Reps
+        :param preps:
         :param irep:
         :param total_supply:
+        :param term_period: P-Rep term period in block
         :return:
         """
         self._sequence += 1
         self._start_block_height = current_block_height + 1
-        self._end_block_height = current_block_height + self._period
+        self._end_block_height = current_block_height + term_period
+        self._period = term_period
         self._preps = preps[:PREP_MAIN_AND_SUB_PREPS]  # shallow copy
-        self._irep = irep
         self._total_supply = total_supply
+        self._irep = irep
 
+    # def _calculate_weighted_average_of_irep(self) -> int:
+    #     total_delegated = 0  # total delegated of top 22 preps
+    #     total_weighted_irep = 0
+    #
+    #     for i in range(PREP_MAIN_PREPS):
+    #         prep: 'PRep' = self._preps[i]
+    #         total_weighted_irep += prep.irep * prep.delegated
+    #         total_delegated += prep.delegated
+    #
+    #     return total_weighted_irep // total_delegated if total_delegated > 0 else 0
+
+    def save(self, context: 'IconScoreContext'):
+        """Save term data to stateDB
+
+        :param context:
+        :return:
+        """
         data: list = [
             self._VERSION,
             self._sequence,
             self._start_block_height,
-            self._serialize_preps(preps),
+            self._serialize_preps(self.preps),
             self._irep,
             self._total_supply
         ]

--- a/tests/prep/test_term.py
+++ b/tests/prep/test_term.py
@@ -106,8 +106,7 @@ def test_save_and_load():
 
         context.storage.prep.get_term = Mock(return_value=[
             0, saved_sequence, current_block + 1, term._serialize_preps(PREPS), irep, total_supply])
-        term._make_main_and_sub_preps = Mock(return_value=(PREPS[:PREP_MAIN_PREPS],
-                                                           PREPS[PREP_MAIN_PREPS:PREP_MAIN_AND_SUB_PREPS]))
+        term._make_main_and_sub_preps = Mock(return_value=PREPS)
         term.load(context, period)
         assert term.sequence == saved_sequence
         assert term.total_supply == total_supply

--- a/tests/prep/test_term.py
+++ b/tests/prep/test_term.py
@@ -35,8 +35,10 @@ context.storage.prep.put_term = Mock()
 
 def test_save():
     current_block = random.randint(10, 100)
-    irep = random.randint(10, 100)
+    # irep = random.randint(10, 100)
     total_supply = random.randint(10, 100)
+    term_period = random.randint(10, 100)
+    irep = random.randint(10, 100)
 
     term = Term()
     assert term.sequence == -1
@@ -50,7 +52,8 @@ def test_save():
     for i in range(random.randint(1, 5)):
         sequence = term.sequence
         current_block += 1
-        term.save(context, current_block, PREPS, irep, total_supply)
+        term.update(current_block, PREPS, total_supply, term_period, irep)
+        term.save(context)
         assert term.sequence == sequence + 1
         assert term.total_supply == total_supply
         assert term.main_preps == PREPS[:PREP_MAIN_PREPS]
@@ -94,7 +97,8 @@ def test_save_and_load():
         sequence = term.sequence
         current_block += 1
         term._period = period
-        term.save(context, current_block, PREPS, irep, total_supply)
+        term.update(current_block, PREPS, total_supply, period, irep)
+        term.save(context)
         assert term.sequence == sequence + 1
         assert term.total_supply == total_supply
         assert term.main_preps == PREPS[:PREP_MAIN_PREPS]


### PR DESCRIPTION
* Update PRep.grade every term in PRepEngine.on_term_ended()
* Update the next_term in PRepEngine.commit()
* Unify main_preps and sub_preps into preps in Term class
* Add term field to PrecommitData class
* Move term-related logic to PRepEngine
* Split Term.save() into Term.update() and Term.save()
* Update some unittests