### PR TITLE
IS-668: Fix API that raises error due to `get_main_preps_in_dict` method changed

### DIFF
--- a/iconservice/inner_call/__init__.py
+++ b/iconservice/inner_call/__init__.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 def get_main_preps(context: 'IconScoreContext', **_kwargs):
     term: 'Term' = context.engine.prep.term
-    preps: dict = context.engine.prep.get_main_preps_in_dict(context, term.main_preps)
+    preps: dict = context.engine.prep.get_main_preps_in_dict(context.main_prep_count, term.main_preps)
     if preps is None:
         preps = {}
 

--- a/tests/integrate_test/iiss/test_inner_call.py
+++ b/tests/integrate_test/iiss/test_inner_call.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019 ICON Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from iconservice.icon_constant import ConfigKey
+from tests.integrate_test.iiss.test_iiss_base import TestIISSBase
+
+
+class TestIISSBaseTransactionValidation(TestIISSBase):
+    def _make_init_config(self) -> dict:
+        config: dict = super()._make_init_config()
+        config[ConfigKey.PREP_REGISTRATION_FEE] = 0
+        return config
+
+    def setUp(self):
+        super().setUp()
+
+    def test_inner_call(self):
+        inner_call_request = {"method": "ise_getPRepList"}
+        inner_call_response: dict = self.inner_call(inner_call_request)
+        self.assertNotIn("preps", inner_call_response)
+
+        self.init_decentralized()
+        inner_call_response: dict = self.inner_call(inner_call_request)
+        self.assertEqual(len(inner_call_response['result']['preps']), 22)

--- a/tests/integrate_test/test_integrate_base.py
+++ b/tests/integrate_test/test_integrate_base.py
@@ -380,6 +380,10 @@ class TestIntegrateBase(TestCase):
         response = self.icon_service_engine.query(method, request)
         return response
 
+    def inner_call(self, request: dict) -> Any:
+        response = self.icon_service_engine.inner_call(request)
+        return response
+
     def _create_invalid_block(self, block_height: int = None) -> 'Block':
         if block_height is None:
             block_height: int = self._block_height


### PR DESCRIPTION
* modify the wrong argument
* add tests for innerCall