### PR TITLE
IS-639: Fix Bug PRepContainer on Estimate

### DIFF
--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -841,6 +841,7 @@ class IconServiceEngine(ContextContainer):
         context.current_address = to
         context.event_logs: List['EventLog'] = []
         context.traces: List['Trace'] = []
+        context.preps: 'PRepContainer' = context.engine.prep.preps.copy(mutable=True)
 
         # Deposits virtual ICXs to the sender to prevent validation error due to 'out of balance'.
         account = context.storage.icx.get_account(context, from_)

--- a/iconservice/prep/data/prep.py
+++ b/iconservice/prep/data/prep.py
@@ -170,6 +170,7 @@ class PRep(Sortable):
     def status(self, value: 'PRepStatus'):
         assert self._status == PRepStatus.ACTIVE
         self._status = value
+        self._flags |= PRepFlag.DIRTY
         
     @property
     def grade(self) -> 'PRepGrade':
@@ -364,6 +365,8 @@ class PRep(Sortable):
 
         self._irep = irep
         self._irep_block_height = block_height
+
+        self._flags |= PRepFlag.DIRTY
 
     def __gt__(self, other: 'PRep') -> bool:
         return self.order() > other.order()

--- a/iconservice/prep/data/prep_container.py
+++ b/iconservice/prep/data/prep_container.py
@@ -118,7 +118,11 @@ class PRepContainer(object):
             raise InvalidParamsException("P-Rep is not active")
 
         self._active_prep_list.remove(prep)
-        prep.status = status
+
+        if prep.is_frozen():
+            prep: 'PRep' = prep.copy(PRepFlag.NONE)
+            prep.status = status
+            self._prep_dict[address] = prep
 
         self._total_prep_delegated -= prep.delegated
         assert self._total_prep_delegated >= 0

--- a/tests/integrate_test/iiss/prevote/test_prevote.py
+++ b/tests/integrate_test/iiss/prevote/test_prevote.py
@@ -94,6 +94,8 @@ class TestIISS(TestIISSBase):
         tx: dict = self.create_unregister_prep_tx(from_=self._accounts[0])
         self.estimate_step(tx)
 
+        self.unregister_prep(from_=self._accounts[0])
+
     def test_query_prevote(self):
         self.update_governance()
 


### PR DESCRIPTION
when it changes prep object on estimate case, it shares same memory object(prep).
so it fixed.