### PR TITLE
IS-662: Improve getMainPReps and getSubPReps

### DIFF
--- a/iconservice/prep/data/prep.py
+++ b/iconservice/prep/data/prep.py
@@ -493,8 +493,6 @@ class PRep(Sortable):
             data[ConstantKeys.DETAILS] = self.details
             data[ConstantKeys.P2P_ENDPOINT] = self.p2p_endpoint
             data[ConstantKeys.PUBLIC_KEY] = self.public_key
-            data[ConstantKeys.IREP] = self._irep
-            data[ConstantKeys.IREP_BLOCK_HEIGHT] = self._irep_block_height
         else:
             data[ConstantKeys.ADDRESS] = self.address
 

--- a/iconservice/prep/term.py
+++ b/iconservice/prep/term.py
@@ -131,8 +131,8 @@ class Term(object):
 
         return prep_list
 
-    def update( self, sequence: int, main_prep_count: int, main_and_sub_prep_count: int,
-                current_block_height: int, preps: List['PRep'], total_supply: int, term_period: int, irep: int):
+    def update(self, sequence: int, main_prep_count: int, main_and_sub_prep_count: int,
+               current_block_height: int, preps: List['PRep'], total_supply: int, term_period: int, irep: int):
         """
         :param sequence:
         :param main_prep_count

--- a/tests/integrate_test/iiss/decentralized/test_base_transaction_validation.py
+++ b/tests/integrate_test/iiss/decentralized/test_base_transaction_validation.py
@@ -98,7 +98,8 @@ class TestIISSBaseTransactionValidation(TestIISSBase):
         response: dict = self.get_main_prep_list()
         expected_response: dict = {
             "preps": [],
-            "totalDelegated": 0
+            "totalDelegated": 0,
+            "totalStake": 0
         }
         self.assertEqual(expected_response, response)
 

--- a/tests/integrate_test/iiss/decentralized/test_changed_minimum_delegate.py
+++ b/tests/integrate_test/iiss/decentralized/test_changed_minimum_delegate.py
@@ -13,9 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from iconservice import Address
 from iconservice.icon_constant import REV_DECENTRALIZATION, REV_IISS, \
-    PREP_MAIN_PREPS, ICX_IN_LOOP, ConfigKey
+    PREP_MAIN_PREPS, ICX_IN_LOOP, ConfigKey, IISS_INITIAL_IREP
 from tests.integrate_test.iiss.test_iiss_base import TestIISSBase
 
 
@@ -50,13 +49,25 @@ class TestChangedMinimumDelegate(TestIISSBase):
         expected_total_delegated: int = 0
         for account in self._accounts[:PREP_MAIN_PREPS]:
             expected_preps.append({
+                'status': 0,
+                'name': f'node{account.address}',
+                'country': 'KOR',
+                'city': 'Unknown',
+                'stake': 0,
+                'totalBlocks': 0,
+                'validatedBlocks': 0,
+                'irep': IISS_INITIAL_IREP,
+                'irepUpdateBlockHeight': self._block_height - 1,
+                'lastGenerateBlockHeight': -1,
                 'address': account.address,
+                'votingWeight': 0,
                 'delegated': 0
             })
             expected_total_delegated += 0
         expected_response: dict = {
             "preps": expected_preps,
-            "totalDelegated": 0
+            "totalDelegated": 0,
+            "totalStake": 0
         }
         self.assertEqual(expected_response, response)
 

--- a/tests/integrate_test/iiss/decentralized/test_decentralized.py
+++ b/tests/integrate_test/iiss/decentralized/test_decentralized.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from iconservice.base.address import Address
 from iconservice.icon_constant import REV_DECENTRALIZATION, REV_IISS, \
     PREP_MAIN_PREPS, ICX_IN_LOOP, ConfigKey, IISS_MIN_IREP, IISS_INITIAL_IREP, PREP_MAIN_AND_SUB_PREPS
 from tests.integrate_test.iiss.test_iiss_base import TestIISSBase
@@ -80,7 +79,8 @@ class TestIISSDecentralized(TestIISSBase):
         response: dict = self.get_main_prep_list()
         expected_response: dict = {
             "preps": [],
-            "totalDelegated": 0
+            "totalDelegated": 0,
+            "totalStake": 0
         }
         self.assertEqual(expected_response, response)
 
@@ -91,15 +91,28 @@ class TestIISSDecentralized(TestIISSBase):
         response: dict = self.get_main_prep_list()
         expected_preps: list = []
         expected_total_delegated: int = 0
+        irep_updated = self._block_height - 2
         for account in self._accounts[:PREP_MAIN_PREPS]:
             expected_preps.append({
+                'status': 0,
+                'name': f'node{account.address}',
+                'country': 'KOR',
+                'city': 'Unknown',
+                'stake': 0,
+                'totalBlocks': 0,
+                'validatedBlocks': 0,
+                'irep': IISS_INITIAL_IREP,
+                'irepUpdateBlockHeight': irep_updated,
+                'lastGenerateBlockHeight': -1,
                 'address': account.address,
-                'delegated': minimum_delegate_amount_for_decentralization
+                'votingWeight': minimum_delegate_amount_for_decentralization,
+                'delegated': minimum_delegate_amount_for_decentralization,
             })
             expected_total_delegated += minimum_delegate_amount_for_decentralization
         expected_response: dict = {
             "preps": expected_preps,
-            "totalDelegated": expected_total_delegated
+            "totalDelegated": expected_total_delegated,
+            "totalStake": 0
         }
         self.assertEqual(expected_response, response)
 

--- a/tests/integrate_test/iiss/decentralized/test_preps.py
+++ b/tests/integrate_test/iiss/decentralized/test_preps.py
@@ -19,9 +19,9 @@
 from typing import TYPE_CHECKING, List
 from unittest.mock import patch
 
-from iconservice import ZERO_SCORE_ADDRESS, Address
+from iconservice import ZERO_SCORE_ADDRESS
 from iconservice.icon_constant import ICX_IN_LOOP, PREP_MAIN_PREPS, IISS_INITIAL_IREP, ConfigKey, \
-    PREP_PENALTY_SIGNATURE, BASE_TRANSACTION_INDEX, PREP_MAIN_AND_SUB_PREPS
+    PREP_PENALTY_SIGNATURE, BASE_TRANSACTION_INDEX, PREP_MAIN_AND_SUB_PREPS, IISS_MIN_IREP
 from iconservice.icon_constant import PRepStatus, PRepGrade
 from iconservice.iconscore.icon_score_event_log import EventLog
 from tests.integrate_test.iiss.test_iiss_base import TestIISSBase
@@ -102,18 +102,42 @@ class TestPreps(TestIISSBase):
         # get main prep list
         expected_preps: list = []
         for i in range(1, PREP_MAIN_PREPS):
+            account = self._accounts[i]
             expected_preps.append({
-                "address": self._accounts[i].address,
-                "delegated": 0
+                'status': 0,
+                'name': f'node{account.address}',
+                'country': 'KOR',
+                'city': 'Unknown',
+                'stake': 0,
+                'totalBlocks': 40,
+                'validatedBlocks': 0,
+                'irep': IISS_INITIAL_IREP,
+                'irepUpdateBlockHeight': self.irep_updated_block_height,
+                'lastGenerateBlockHeight': -1,
+                'address': account.address,
+                'votingWeight': 0,
+                'delegated': 0
             })
-        expected_preps.insert(0, {"address": self._accounts[PREP_MAIN_PREPS].address,
-                                  "delegated": delegation_amount})
+        expected_preps.insert(0, {'status': 0,
+                                  'name': f'node{self._accounts[PREP_MAIN_PREPS].address}',
+                                  'country': 'KOR',
+                                  'city': 'Unknown',
+                                  'stake': delegation_amount,
+                                  'totalBlocks': 0,
+                                  'validatedBlocks': 0,
+                                  'irep': IISS_MIN_IREP,
+                                  'irepUpdateBlockHeight': self._block_height - 2,
+                                  'lastGenerateBlockHeight': -1,
+                                  'address': self._accounts[PREP_MAIN_PREPS].address,
+                                  'votingWeight': delegation_amount,
+                                  'delegated': delegation_amount})
 
         response: dict = self.get_main_prep_list()
         expected_response: dict = \
             {
                 "preps": expected_preps,
-                "totalDelegated": delegation_amount
+                "totalDelegated": delegation_amount,
+                "totalStake": delegation_amount
             }
         self.assertEqual(expected_response, response)
 

--- a/tests/integrate_test/iiss/test_iiss_base.py
+++ b/tests/integrate_test/iiss/test_iiss_base.py
@@ -22,7 +22,7 @@ from iconservice.base.address import Address
 from iconservice.base.address import ZERO_SCORE_ADDRESS
 from iconservice.base.type_converter_templates import ConstantKeys
 from iconservice.icon_constant import ConfigKey, REV_IISS, PREP_MAIN_PREPS, ICX_IN_LOOP, \
-    REV_DECENTRALIZATION, PREP_MAIN_AND_SUB_PREPS
+    REV_DECENTRALIZATION, PREP_MAIN_AND_SUB_PREPS, IISS_INITIAL_IREP
 from tests.integrate_test.test_integrate_base import TestIntegrateBase, TOTAL_SUPPLY, DEFAULT_STEP_LIMIT
 
 if TYPE_CHECKING:
@@ -407,7 +407,8 @@ class TestIISSBase(TestIntegrateBase):
         response: dict = self.get_main_prep_list()
         expected_response: dict = {
             "preps": [],
-            "totalDelegated": 0
+            "totalDelegated": 0,
+            "totalStake": 0
         }
         self.assertEqual(expected_response, response)
 
@@ -418,16 +419,30 @@ class TestIISSBase(TestIntegrateBase):
         response: dict = self.get_main_prep_list()
         expected_preps: list = []
         expected_total_delegated: int = 0
+        self.irep_updated_block_height = self._block_height - 2
         for account in self._accounts[:PREP_MAIN_PREPS]:
             expected_preps.append({
+                'status': 0,
+                'name': f'node{account.address}',
+                'country': "KOR",
+                'city': 'Unknown',
+                'stake': 0,
+                'totalBlocks': 0,
+                'validatedBlocks': 0,
+                'irep': IISS_INITIAL_IREP,
+                'irepUpdateBlockHeight': self.irep_updated_block_height,
+                'lastGenerateBlockHeight': -1,
                 'address': account.address,
-                'delegated': minimum_delegate_amount_for_decentralization
+                'delegated': minimum_delegate_amount_for_decentralization,
+                'votingWeight': minimum_delegate_amount_for_decentralization
             })
             expected_total_delegated += minimum_delegate_amount_for_decentralization
         expected_response: dict = {
             "preps": expected_preps,
-            "totalDelegated": expected_total_delegated
+            "totalDelegated": expected_total_delegated,
+            "totalStake": 0
         }
+
         self.assertEqual(expected_response, response)
 
         # delegate to PRep 0
@@ -445,12 +460,24 @@ class TestIISSBase(TestIntegrateBase):
         expected_preps: list = []
         for account in self._accounts[:PREP_MAIN_PREPS]:
             expected_preps.append({
+                'status': 0,
+                'name': f'node{account.address}',
+                'country': 'KOR',
+                'city': 'Unknown',
+                'stake': 0,
+                'totalBlocks': 10,
+                'validatedBlocks': 0,
+                'irep': IISS_INITIAL_IREP,
+                'irepUpdateBlockHeight': self.irep_updated_block_height,
+                'lastGenerateBlockHeight': -1,
                 'address': account.address,
-                'delegated': 0
+                'votingWeight': 0,
+                'delegated': 0,
             })
         expected_response: dict = {
             "preps": expected_preps,
-            "totalDelegated": 0
+            "totalDelegated": 0,
+            "totalStake": 0
         }
         self.assertEqual(expected_response, response)
 


### PR DESCRIPTION
* Add some fields to response of APIs
* return current delegate amount of PReps in get PReps methods rather than delegation amount at the beginning of the term