### PR TITLE
IS-672: Fix missed P-Rep attributes recording

### DIFF
--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -19,7 +19,6 @@ from copy import deepcopy
 from typing import TYPE_CHECKING, List, Any, Optional, Tuple
 
 from iconcommons.logger import Logger
-
 from .base.address import Address, generate_score_address, generate_score_address_for_tbears
 from .base.address import ZERO_SCORE_ADDRESS, GOVERNANCE_SCORE_ADDRESS
 from .base.block import Block, EMPTY_BLOCK
@@ -69,7 +68,7 @@ if TYPE_CHECKING:
     from .iconscore.icon_score_event_log import EventLog
     from .builtin_scores.governance.governance import Governance
     from iconcommons.icon_config import IconConfig
-    from .prep.data import PRep, PRepContainer
+    from .prep.data import PRep
     from .iiss.storage import RewardRate
     from .prep.term import Term
 
@@ -80,6 +79,7 @@ class IconServiceEngine(ContextContainer):
     It MUST NOT have any loopchain dependencies.
     It is contained in IconInnerService.
     """
+    TAG = "ISE"
 
     def __init__(self):
         """Constructor
@@ -523,9 +523,9 @@ class IconServiceEngine(ContextContainer):
         main_prep_as_dict: Optional[dict] = None
         next_term: Optional['Term'] = None
 
-        if self._is_prep_term_over(context):
+        if self._is_prep_term_ended(context):
             if base_tx_result is not None:
-                self._update_preps_apply_low_productivity_penalty(context, base_tx_result)
+                self._impose_low_productivity_penalty_on_main_preps(context, base_tx_result)
 
             # The current P-Rep term is over. Prepare the next P-Rep term
             main_prep_as_dict, next_term = context.engine.prep.on_term_ended(context)
@@ -548,18 +548,24 @@ class IconServiceEngine(ContextContainer):
 
         return main_prep_as_dict, next_term
 
-    def _update_preps_apply_low_productivity_penalty(self,
-                                                     context: 'IconScoreContext',
-                                                     base_tx_result: 'TransactionResult'):
-        low_productivities: list = []
+    def _impose_low_productivity_penalty_on_main_preps(
+            self, context: 'IconScoreContext', base_tx_result: 'TransactionResult'):
+        """Check the P-Reps to impose low productivity penalty on every block
+
+        :param context:
+        :param base_tx_result:
+        :return:
+        """
+
+        lazy_preps: list = []
         for main_prep in context.engine.prep.term.main_preps:
-            prep = context.preps.get_by_address(main_prep.address)
+            prep: 'PRep' = context.get_prep(main_prep.address)
             assert prep is not None
 
             if prep.is_low_productivity():
-                low_productivities.append(prep)
+                lazy_preps.append(prep)
 
-        for prep in low_productivities:
+        for prep in lazy_preps:
             dirty_prep: 'PRep' = prep.copy()
             dirty_prep.status = PRepStatus.LOW_PRODUCTIVITY
             context.put_dirty_prep(dirty_prep)
@@ -570,15 +576,12 @@ class IconServiceEngine(ContextContainer):
 
         base_tx_result.event_logs.extend(context.event_logs)
         base_tx_result.logs_bloom = self._generate_logs_bloom(base_tx_result.event_logs)
+        context.update_dirty_prep_batch()
 
-    def _update_productivity(self,
-                             context: 'IconScoreContext',
+    @staticmethod
+    def _update_productivity(context: 'IconScoreContext',
                              prev_block_generator: Optional['Address'] = None,
                              prev_block_validators: Optional[List['Address']] = None):
-
-        if not context.is_decentralized():
-            return
-
         validates: set = set()
         if prev_block_generator:
             validates.add(prev_block_generator)
@@ -594,7 +597,7 @@ class IconServiceEngine(ContextContainer):
                 context.put_dirty_prep(prep)
 
     @staticmethod
-    def _is_prep_term_over(context: 'IconScoreContext') -> bool:
+    def _is_prep_term_ended(context: 'IconScoreContext') -> bool:
         if context.revision < REV_DECENTRALIZATION:
             return False
 
@@ -920,9 +923,10 @@ class IconServiceEngine(ContextContainer):
         context.block_batch = BlockBatch(Block.from_block(context.block))
         context.tx_batch = TransactionBatch()
         context.new_icon_score_mapper = IconScoreMapper()
-        context.preps: 'PRepContainer' = context.engine.prep.preps.copy(mutable=True)
         context.meta_block_batch: 'ExternalBatch' = ExternalBatch()
         context.meta_tx_batch: 'ExternalBatch' = ExternalBatch()
+        context.preps = context.engine.prep.preps.copy(mutable=True)
+        context.tx_dirty_preps = OrderedDict()
 
         self._set_revision_to_context(context)
         # Fills the step_limit as the max step limit to proceed the transaction.

--- a/iconservice/iconscore/icon_score_context.py
+++ b/iconservice/iconscore/icon_score_context.py
@@ -16,6 +16,7 @@
 
 import threading
 import warnings
+from collections import OrderedDict
 from typing import TYPE_CHECKING, Optional, List
 
 from .icon_score_trace import Trace
@@ -35,7 +36,7 @@ if TYPE_CHECKING:
     from .icon_score_mapper import IconScoreMapper
     from .icon_score_step import IconScoreStepCounter
     from ..base.address import Address
-    from ..prep.data.prep_container import PRepContainer
+    from ..prep.data.prep_container import PRep, PRepContainer
     from ..utils import ContextEngine, ContextStorage
     from ..database.batch import ExternalBatch
 
@@ -147,6 +148,7 @@ class IconScoreContext(object):
 
         # PReps to update on invoke
         self.preps: Optional['PRepContainer'] = None
+        self.tx_dirty_preps: Optional[OrderedDict['Address', 'PRep']] = None
 
     @classmethod
     def set_decentralize_trigger(cls, decentralize_trigger: float):
@@ -181,14 +183,35 @@ class IconScoreContext(object):
         self.engine.deploy.deploy(self, tx_hash)
 
     def update_batch(self):
+        # Call update_dirty_prep_batch before update_state_db_batch()
+        self.update_dirty_prep_batch()
+        self.update_state_db_batch()
+        self.update_rc_db_batch()
+
+    def update_state_db_batch(self):
         self.block_batch.update(self.tx_batch)
         self.tx_batch.clear()
 
+    def update_rc_db_batch(self):
         self.rc_block_batch.extend(self.rc_tx_batch)
         self.rc_tx_batch.clear()
 
         self.meta_block_batch.update(self.meta_tx_batch)
         self.meta_tx_batch.clear()
+
+    def update_dirty_prep_batch(self):
+        """Update context.preps and block_dirty_preps when a tx is done
+
+        Caution: call update_dirty_prep_batch before update_state_db_batch()
+        """
+        for dirty_prep in self.tx_dirty_preps.values():
+            dirty_prep.freeze()
+
+            self.preps.replace(dirty_prep)
+            # Write serialized dirty_prep data into tx_batch
+            self.storage.prep.put_prep(self, dirty_prep)
+
+        self.tx_dirty_preps.clear()
 
     def clear_batch(self):
         if self.tx_batch:
@@ -197,3 +220,18 @@ class IconScoreContext(object):
             self.rc_tx_batch.clear()
         if self.meta_tx_batch:
             self.meta_tx_batch.clear()
+        if self.tx_dirty_preps:
+            self.tx_dirty_preps.clear()
+
+    def get_prep(self, address: 'Address', mutable: bool = False):
+        prep: 'PRep' = self.tx_dirty_preps.get(address)
+        if prep is None:
+            prep = self.preps.get_by_address(address)
+
+        if prep and prep.is_frozen() and mutable:
+            prep = prep.copy()
+
+        return prep
+
+    def put_dirty_prep(self, prep: 'PRep'):
+        self.tx_dirty_preps[prep.address] = prep

--- a/iconservice/iconscore/icon_score_context.py
+++ b/iconservice/iconscore/icon_score_context.py
@@ -205,11 +205,10 @@ class IconScoreContext(object):
         Caution: call update_dirty_prep_batch before update_state_db_batch()
         """
         for dirty_prep in self.tx_dirty_preps.values():
-            dirty_prep.freeze()
-
             self.preps.replace(dirty_prep)
             # Write serialized dirty_prep data into tx_batch
             self.storage.prep.put_prep(self, dirty_prep)
+            dirty_prep.freeze()
 
         self.tx_dirty_preps.clear()
 

--- a/iconservice/icx/base_part.py
+++ b/iconservice/icx/base_part.py
@@ -15,7 +15,7 @@
 
 from enum import Flag
 
-from ..utils import toggle_flags
+from ..utils import set_flag
 
 
 class BasePartState(Flag):
@@ -33,7 +33,7 @@ class BasePart(object):
         return self._states
 
     def toggle_state(self, state: 'BasePartState', on: bool):
-        self._states = toggle_flags(self._states, state, on)
+        self._states = set_flag(self._states, state, on)
 
     def is_dirty(self) -> bool:
         return self.is_set(BasePartState.DIRTY)

--- a/iconservice/icx/coin_part.py
+++ b/iconservice/icx/coin_part.py
@@ -22,7 +22,7 @@ from .base_part import BasePart
 from ..base.address import AddressPrefix
 from ..base.exception import InvalidParamsException, OutOfBalanceException
 from ..icon_constant import DEFAULT_BYTE_SIZE, DATA_BYTE_ORDER, REVISION_4
-from ..utils import toggle_flags
+from ..utils import set_flag
 from ..utils.msgpack_for_db import MsgPackForDB
 
 if TYPE_CHECKING:
@@ -119,7 +119,7 @@ class CoinPart(BasePart):
         return self._flags
 
     def toggle_has_unstake(self, on: bool):
-        new_flags = toggle_flags(self._flags, CoinPartFlag.HAS_UNSTAKE, on)
+        new_flags = set_flag(self._flags, CoinPartFlag.HAS_UNSTAKE, on)
 
         if self._flags != new_flags:
             self._flags = new_flags

--- a/iconservice/icx/issue/engine.py
+++ b/iconservice/icx/issue/engine.py
@@ -45,7 +45,7 @@ class Engine(EngineBase):
             IssueDataKey.PREP: {
                 IssueDataKey.IREP: irep,
                 IssueDataKey.RREP: context.storage.iiss.get_reward_rate(context).reward_prep,
-                IssueDataKey.TOTAL_DELEGATION: context.preps.total_prep_delegated
+                IssueDataKey.TOTAL_DELEGATION: context.preps.total_delegated
             }
         }
         total_issue_amount = 0

--- a/iconservice/iiss/engine.py
+++ b/iconservice/iiss/engine.py
@@ -579,7 +579,7 @@ class Engine(EngineBase):
     @classmethod
     def _put_gv(cls, context: 'IconScoreContext'):
         current_total_supply = context.storage.icx.get_total_supply(context)
-        current_total_prep_delegated: int = context.preps.total_prep_delegated
+        current_total_prep_delegated: int = context.preps.total_delegated
 
         reward_rate: 'RewardRate' = context.storage.iiss.get_reward_rate(context)
         reward_prep: int = IssueFormula.calculate_rrep(context.storage.iiss.reward_min,

--- a/iconservice/prep/data/prep.py
+++ b/iconservice/prep/data/prep.py
@@ -155,16 +155,12 @@ class PRep(Sortable):
         self._total_blocks: int = total_blocks
         self._validated_blocks: int = validated_blocks
 
-    def is_dirty(self) -> bool:
-        return bool(self._flags & PRepFlag.DIRTY)
-
     @property
     def status(self) -> 'PRepStatus':
         return self._status
 
     @status.setter
     def status(self, value: 'PRepStatus'):
-        assert self._status == PRepStatus.ACTIVE
         self._status = value
         
     @property

--- a/iconservice/prep/term.py
+++ b/iconservice/prep/term.py
@@ -122,7 +122,7 @@ class Term(object):
             if delegated == frozen_prep.delegated:
                 prep: 'PRep' = frozen_prep
             else:
-                prep: 'PRep' = frozen_prep.copy(PRepFlag.NONE)
+                prep: 'PRep' = frozen_prep.copy()
                 prep.delegated = delegated
                 prep.freeze()
 

--- a/iconservice/utils/__init__.py
+++ b/iconservice/utils/__init__.py
@@ -95,15 +95,15 @@ def is_builtin_score(score_address: str) -> bool:
     return score_address in BUILTIN_SCORE_ADDRESS_MAPPER.values()
 
 
-def is_flags_on(src_flags: int, dest_flags: int) -> bool:
-    return src_flags & dest_flags == dest_flags
+def is_flag_on(src_flags: Flag, flag: Flag) -> bool:
+    return src_flags & flag == flag
 
 
-def toggle_flags(src_flags: Flag, dest_flags: Flag, on: bool) -> Flag:
+def set_flag(src_flags: Flag, flag: Flag, on: bool) -> Flag:
     if on:
-        src_flags |= dest_flags
+        src_flags |= flag
     else:
-        src_flags &= ~dest_flags
+        src_flags &= ~flag
 
     return src_flags
 

--- a/tests/icx/test_coin_part.py
+++ b/tests/icx/test_coin_part.py
@@ -23,7 +23,7 @@ from iconservice.base.exception import InvalidParamsException, OutOfBalanceExcep
 from iconservice.icon_constant import REVISION_4, REVISION_3
 from iconservice.icx.base_part import BasePartState
 from iconservice.icx.coin_part import CoinPartType, CoinPartFlag, CoinPart
-from iconservice.utils import toggle_flags
+from iconservice.utils import set_flag
 from tests import create_address
 
 
@@ -129,10 +129,10 @@ class TestCoinPart(unittest.TestCase):
         part1 = CoinPart()
         self.assertEqual(BasePartState.NONE, part1.states)
 
-        part1._flags = toggle_flags(part1.flags, CoinPartFlag.HAS_UNSTAKE, True)
+        part1._flags = set_flag(part1.flags, CoinPartFlag.HAS_UNSTAKE, True)
         self.assertIn(CoinPartFlag.HAS_UNSTAKE, part1.flags)
 
-        part1._flags = toggle_flags(part1.flags, CoinPartFlag.HAS_UNSTAKE, False)
+        part1._flags = set_flag(part1.flags, CoinPartFlag.HAS_UNSTAKE, False)
         self.assertEqual(CoinPartFlag.NONE, part1.flags)
         self.assertNotIn(CoinPartFlag.HAS_UNSTAKE, part1.flags)
 

--- a/tests/integrate_test/iiss/decentralized/test_base_transaction_validation.py
+++ b/tests/integrate_test/iiss/decentralized/test_base_transaction_validation.py
@@ -28,7 +28,7 @@ from iconservice.icon_constant import ISSUE_CALCULATE_ORDER, ISSUE_EVENT_LOG_MAP
 from iconservice.iconscore.icon_score_context import IconScoreContext
 from iconservice.icx.issue.base_transaction_creator import BaseTransactionCreator
 from iconservice.iiss.reward_calc.ipc.reward_calc_proxy import CalculateResponse
-from iconservice.prep.data import PRepContainer, PRepFlag
+from iconservice.prep.data import PRepFlag
 from tests import create_tx_hash, create_block_hash
 from tests.integrate_test import create_timestamp
 from tests.integrate_test.iiss.test_iiss_base import TestIISSBase
@@ -133,7 +133,7 @@ class TestIISSBaseTransactionValidation(TestIISSBase):
 
     def _make_issue_info(self) -> tuple:
         context = IconScoreContext(IconScoreContextType.DIRECT)
-        context.preps: 'PRepContainer' = context.engine.prep.preps.copy(PRepFlag.NONE)
+        context.preps = context.engine.prep.preps.copy(mutable=True)
         block_height: int = self._block_height
         block_hash = create_block_hash()
         timestamp_us = create_timestamp()
@@ -149,7 +149,7 @@ class TestIISSBaseTransactionValidation(TestIISSBase):
 
     def _create_base_transaction(self):
         context = IconScoreContext(IconScoreContextType.DIRECT)
-        context.preps: 'PRepContainer' = context.engine.prep.preps.copy(PRepFlag.NONE)
+        context.preps = context.engine.prep.preps.copy(mutable=True)
         block_height: int = self._block_height
         block_hash = create_block_hash()
         timestamp_us = create_timestamp()

--- a/tests/prep/test_engine.py
+++ b/tests/prep/test_engine.py
@@ -36,7 +36,7 @@ class TestEngine(unittest.TestCase):
             self.assertEqual(PRepGrade.CANDIDATE, prep.grade)
             self.assertEqual(0, prep.delegated)
 
-            self.new_preps.register(prep)
+            self.new_preps.add(prep)
 
     def tearDown(self) -> None:
         self.new_preps = None
@@ -60,13 +60,15 @@ class TestEngine(unittest.TestCase):
             else:
                 self.assertEqual(PRepGrade.CANDIDATE, prep.grade)
 
-        # Case1: Reorder preps in descending order by prep.order()
+        # Case1: Sort preps in descending order by prep.order()
         for i, prep in enumerate(new_preps):
             delegated: int = random.randint(0, 10_000)
             delegated_list.append((-delegated, i))
 
             old_prep_list.append(prep)
-            new_preps.set_delegated_to_prep(prep.address, delegated)
+            new_preps.remove(prep.address)
+            prep.delegated = delegated
+            new_preps.add(prep)
 
         # Expected list in descending order by (delegated, block_height, tx_index)
         delegated_list.sort()
@@ -87,7 +89,7 @@ class TestEngine(unittest.TestCase):
             prep_in_list: 'PRep' = old_prep_list[index]
 
             self.assertEqual(abs(delegated), prep.delegated)
-            self.assertEqual(prep_in_list, prep)
+            self.assertEqual(prep_in_list.address, prep.address)
 
             if i < PREP_MAIN_PREPS:
                 self.assertEqual(PRepGrade.MAIN, prep.grade)


### PR DESCRIPTION
* Add context.tx_dirty_preps ordered dict
* Add get_prep() and put_dirty_prep() to IconScoreContext
* Apply context.tx_dirty_preps to registerPRep, unregisterPRep, setPRep,
setGovernanceVariables transactions
* Apply context.tx_dirty_preps to update_low_producivity, update_last_generate_block_height, update_block_statistics
* Apply context.tx_dirty_preps to on_set_stake, on_set_delegation
* Clean up deprecated method in PRepContainer
* PRepContainer.total_prep_delegated -> total_delegated