### PR TITLE
IS-688: add API which returns the previous calc period total i score

### DIFF
--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -1106,7 +1106,7 @@ class IconServiceEngine(ContextContainer):
             return rc_result
 
         iscore, _ = context.storage.rc.get_calc_response_from_rc()
-        if iscore is None:
+        if iscore == -1:
             return rc_result
 
         rc_result['iscore'] = iscore

--- a/iconservice/icx/issue/regulator.py
+++ b/iconservice/icx/issue/regulator.py
@@ -59,7 +59,7 @@ class Regulator:
         current_calc_period_total_issued_icx: int = regulator_variable.current_calc_period_issued_icx
         current_calc_period_total_issued_icx += issue_amount
         if calc_next_block_height == context.block.height:
-            prev_calc_period_issued_iscore: Optional[int] = context.storage.rc.get_prev_calc_period_issued_iscore()
+            prev_calc_period_issued_iscore, _ = context.storage.rc.get_calc_response_from_rc()
             covered_icx_by_fee, covered_icx_by_remain, remain_over_issued_iscore, corrected_icx_issue_amount = \
                 self._correct_issue_amount_on_calc_period(regulator_variable.prev_calc_period_issued_icx,
                                                           prev_calc_period_issued_iscore,

--- a/iconservice/icx/issue/regulator.py
+++ b/iconservice/icx/issue/regulator.py
@@ -155,7 +155,7 @@ class Regulator:
     @classmethod
     def _correct_issue_amount_on_calc_period(cls,
                                              prev_calc_period_issued_icx: int,
-                                             prev_calc_period_issued_iscore: Optional[int],
+                                             prev_calc_period_issued_iscore: int,
                                              remain_over_issued_iscore: int,
                                              icx_issue_amount: int,
                                              prev_block_cumulative_fee: int) -> Tuple[int, int, int, int]:
@@ -163,7 +163,7 @@ class Regulator:
         assert prev_block_cumulative_fee >= 0
 
         # check if RC has sent response about 'CALCULATE' requests. every period should get response
-        if prev_calc_period_issued_iscore is None:
+        if prev_calc_period_issued_iscore == -1:
             raise FatalException("There is no prev_calc_period_iscore")
 
         # get difference between icon_service and reward_calc after set exchange rates

--- a/iconservice/iiss/engine.py
+++ b/iconservice/iiss/engine.py
@@ -101,7 +101,7 @@ class Engine(EngineBase):
         if not cb_data.success:
             raise FatalException(f"Reward calc has failed calculating about block height:{cb_data.block_height}")
 
-        IconScoreContext.storage.rc.put_prev_calc_period_issued_iscore(cb_data.iscore)
+        IconScoreContext.storage.rc.put_calc_response_from_rc(cb_data.iscore, cb_data.block_height)
         Logger.debug(f"calculate callback called with {cb_data}", ICON_SERVICE_LOG_TAG)
 
     def _init_reward_calc_proxy(self, log_dir: str, data_path: str, socket_path: str):

--- a/iconservice/iiss/reward_calc/storage.py
+++ b/iconservice/iiss/reward_calc/storage.py
@@ -62,11 +62,11 @@ class Storage(object):
         response_from_rc = MsgPackForDB.dumps([version, iscore, block_height])
         self._db.put(self._KEY_FOR_CALC_RESPONSE_FROM_RC, response_from_rc)
 
-    def get_calc_response_from_rc(self) -> Optional[Tuple[int, int]]:
-        prev_calc_period_issued_iscore = self._db.get(self._KEY_FOR_CALC_RESPONSE_FROM_RC)
-        if prev_calc_period_issued_iscore is None:
-            return None
-        response_from_rc = MsgPackForDB.loads(prev_calc_period_issued_iscore)
+    def get_calc_response_from_rc(self) -> Tuple[int, int]:
+        response_from_rc = self._db.get(self._KEY_FOR_CALC_RESPONSE_FROM_RC)
+        if response_from_rc is None:
+            return -1, -1
+        response_from_rc: list = MsgPackForDB.loads(response_from_rc)
         version = response_from_rc[0]
         iscore = response_from_rc[1]
         block_height = response_from_rc[2]

--- a/iconservice/iiss/reward_calc/storage.py
+++ b/iconservice/iiss/reward_calc/storage.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 import os
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Tuple
 
 from iconcommons import Logger
 from ..reward_calc.msg_data import TxData
@@ -33,7 +33,7 @@ class Storage(object):
     _IISS_RC_DB_NAME_PREFIX = "iiss_rc_db_"
 
     _KEY_FOR_GETTING_LAST_TRANSACTION_INDEX = b'last_transaction_index'
-    _KEY_FOR_PREV_CALC_PERIOD_ISSUED_ISCORE = b'prev_calc_period_issued_iscore'
+    _KEY_FOR_CALC_RESPONSE_FROM_RC = b'calc_response_from_rc'
 
     def __init__(self):
         self._path: str = ""
@@ -57,19 +57,21 @@ class Storage(object):
             self._db.close()
             self._db = None
 
-    def put_prev_calc_period_issued_iscore(self, iscore: int):
+    def put_calc_response_from_rc(self, iscore: int, block_height: int):
         version = 0
-        value: bytes = MsgPackForDB.dumps([version, iscore])
-        self._db.put(self._KEY_FOR_PREV_CALC_PERIOD_ISSUED_ISCORE, value)
+        response_from_rc = MsgPackForDB.dumps([version, iscore, block_height])
+        self._db.put(self._KEY_FOR_CALC_RESPONSE_FROM_RC, response_from_rc)
 
-    def get_prev_calc_period_issued_iscore(self) -> Optional[int]:
-        value: bytes = self._db.get(self._KEY_FOR_PREV_CALC_PERIOD_ISSUED_ISCORE)
-        if value is None:
+    def get_calc_response_from_rc(self) -> Optional[Tuple[int, int]]:
+        prev_calc_period_issued_iscore = self._db.get(self._KEY_FOR_CALC_RESPONSE_FROM_RC)
+        if prev_calc_period_issued_iscore is None:
             return None
-        data: list = MsgPackForDB.loads(value)
-        version = data[0]
+        response_from_rc = MsgPackForDB.loads(prev_calc_period_issued_iscore)
+        version = response_from_rc[0]
+        iscore = response_from_rc[1]
+        block_height = response_from_rc[2]
 
-        return data[1]
+        return iscore, block_height
 
     @staticmethod
     def put(batch: list, iiss_data: 'Data'):

--- a/iconservice/meta/storage.py
+++ b/iconservice/meta/storage.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Tuple
 
 from ..database.db import ExternalDatabase
 from ..icon_constant import IconScoreContextType
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
 
 class Storage(object):
-    _KEY_LAST_CALC_END_BLOCK = b'last_calc_end_block'
+    _KEY_LAST_CALC_INFO = b'last_calc_info'
     _KEY_LAST_TERM_END_BLOCK = b'last_term_end_block'
 
     def __init__(self):
@@ -42,22 +42,23 @@ class Storage(object):
             self._db.close()
             self._db = None
 
-    def put_last_calc_end_block(self,
-                                batch: 'ExternalBatch',
-                                last_end_block_height: int):
+    def put_last_calc_info(self,
+                           batch: 'ExternalBatch',
+                           last_start_block_height: int,
+                           last_end_block_height: int):
         version = 0
-        value: bytes = MsgPackForDB.dumps([version, last_end_block_height])
-        batch[self._KEY_LAST_CALC_END_BLOCK] = value
+        value: bytes = MsgPackForDB.dumps([version, last_start_block_height, last_end_block_height])
+        batch[self._KEY_LAST_CALC_INFO] = value
 
-    def get_last_calc_end_block(self,
-                                context: 'IconScoreContext') -> int:
-        value: bytes = self._db_get_tmp_data(context, self._KEY_LAST_CALC_END_BLOCK)
+    def get_last_calc_info(self,
+                           context: 'IconScoreContext') -> Tuple[int, int]:
+        value: bytes = self._db_get_tmp_data(context, self._KEY_LAST_CALC_INFO)
         if value is None:
-            return -1
+            return -1, -1
         data: list = MsgPackForDB.loads(value)
         version = data[0]
 
-        return data[1]
+        return data[1], data[2]
 
     def put_last_term_end_block(self,
                                 batch: 'ExternalBatch',

--- a/tests/icx/issue/test_issue_regulator.py
+++ b/tests/icx/issue/test_issue_regulator.py
@@ -212,7 +212,7 @@ class TestIssueRegulator:
         # failure case: when prev issued i score is None, should raise error
 
         prev_calc_period_issued_icx = 1_000
-        prev_calc_period_issued_iscore = None
+        prev_calc_period_issued_iscore = -1
 
         prev_block_cumulative_fee = 0
         icx_issue_amount = 1000

--- a/tests/icx/issue/test_issue_regulator.py
+++ b/tests/icx/issue/test_issue_regulator.py
@@ -395,7 +395,7 @@ class TestIssueRegulator:
         mocked_context_engine.prep.term.sequence = 0
         mocked_context_storage.iiss.get_end_block_height_of_calc = Mock(return_value=block_height)
         mocked_context_storage.issue.get_regulator_variable = Mock(return_value=rv)
-        mocked_context_storage.rc.get_prev_calc_period_issued_iscore = Mock(return_value=0)
+        mocked_context_storage.rc.get_calc_response_from_rc = Mock(return_value=(0, 0))
         regulator = Regulator(self.context, issue_amount)
 
         actual_current_icx = regulator._regulator_variable.current_calc_period_issued_icx

--- a/tests/iiss/test_reward_calc_data_storage.py
+++ b/tests/iiss/test_reward_calc_data_storage.py
@@ -181,8 +181,8 @@ class TestRcDataStorage(unittest.TestCase):
 
     def test_putting_i_score_data_on_current_db(self):
         # success case: If there is no prev_calc_period_issued_i_score, should return None
-        actual_i_score = self.rc_data_storage.get_calc_response_from_rc()
-        assert actual_i_score is None
+        actual_i_score, _ = self.rc_data_storage.get_calc_response_from_rc()
+        assert actual_i_score == -1
 
         # success case: put i score and get i score from the db
         expected_i_score = 10_000

--- a/tests/iiss/test_reward_calc_data_storage.py
+++ b/tests/iiss/test_reward_calc_data_storage.py
@@ -181,17 +181,19 @@ class TestRcDataStorage(unittest.TestCase):
 
     def test_putting_i_score_data_on_current_db(self):
         # success case: If there is no prev_calc_period_issued_i_score, should return None
-        actual_i_score = self.rc_data_storage.get_prev_calc_period_issued_iscore()
+        actual_i_score = self.rc_data_storage.get_calc_response_from_rc()
         assert actual_i_score is None
 
         # success case: put i score and get i score from the db
         expected_i_score = 10_000
         expected_version = 0
-        self.rc_data_storage.put_prev_calc_period_issued_iscore(expected_i_score)
-        i_score_db_data = MsgPackForDB.loads(self.rc_data_storage._db.get(self.rc_data_storage._KEY_FOR_PREV_CALC_PERIOD_ISSUED_ISCORE))
+        expected_block_height = 0
+        self.rc_data_storage.put_calc_response_from_rc(expected_i_score, expected_block_height)
+        i_score_db_data = MsgPackForDB.loads(self.rc_data_storage._db.get(self.rc_data_storage._KEY_FOR_CALC_RESPONSE_FROM_RC))
         assert i_score_db_data[0] == expected_version
         assert i_score_db_data[1] == expected_i_score
+        assert i_score_db_data[2] == expected_block_height
 
-        actual_i_score = self.rc_data_storage.get_prev_calc_period_issued_iscore()
+        actual_i_score, _ = self.rc_data_storage.get_calc_response_from_rc()
         assert actual_i_score == expected_i_score
 

--- a/tests/integrate_test/iiss/prevote/test_prevote.py
+++ b/tests/integrate_test/iiss/prevote/test_prevote.py
@@ -40,11 +40,14 @@ class TestIISS(TestIISSBase):
         # get iiss info
         response: dict = self.get_iiss_info()
         expected_response = {
+            'blockHeight': block_height,
             'nextCalculation': block_height + calc_period + 1,
             'nextPRepTerm': 0,
             'variable': {
                 "irep": 0,
                 "rrep": 1200
+            },
+            'rcResult': {
             }
         }
         self.assertEqual(expected_response, response)
@@ -54,11 +57,18 @@ class TestIISS(TestIISSBase):
         block_height: int = self._block_height
         response: dict = self.get_iiss_info()
         expected_response = {
+            'blockHeight': block_height,
             'nextCalculation': block_height + 1,
             'nextPRepTerm': 0,
             'variable': {
                 "irep": 0,
                 "rrep": 1200
+            },
+            'rcResult': {
+                "iscore": 0,
+                "estimatedICX": 0,
+                "startBlockHeight": block_height - calc_period + 1,
+                "endBlockHeight": block_height
             }
         }
         self.assertEqual(expected_response, response)


### PR DESCRIPTION
1. Improve get_iiss_info API
2. Record block height when getting a response from RC about 'calculate'.