### PR TITLE
IS-755: setting prep config from icon-config

### DIFF
--- a/iconservice/icon_config.py
+++ b/iconservice/icon_config.py
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from .icon_constant import ConfigKey, ICX_IN_LOOP, IISS_DAY_BLOCK
+from .icon_constant import ConfigKey, ICX_IN_LOOP, \
+    IISS_DAY_BLOCK, PREP_MAIN_PREPS, PREP_MAIN_AND_SUB_PREPS, \
+    PENALTY_GRACE_PERIOD, MIN_PRODUCTIVITY_PERCENTAGE, \
+    MAX_UNVALIDATED_SEQUENCE_BLOCKS
 
 default_icon_config = {
     "log": {
@@ -40,7 +43,10 @@ default_icon_config = {
     ConfigKey.TERM_PERIOD: IISS_DAY_BLOCK,
     ConfigKey.INITIAL_IREP: 50_000 * ICX_IN_LOOP,
     ConfigKey.PREP_REGISTRATION_FEE: 2_000 * ICX_IN_LOOP,
-    ConfigKey.PREP_MAIN_PREPS: 22,
-    ConfigKey.PREP_MAIN_AND_SUB_PREPS: 100,
-    ConfigKey.DECENTRALIZE_TRIGGER: 0.002
+    ConfigKey.PREP_MAIN_PREPS: PREP_MAIN_PREPS,
+    ConfigKey.PREP_MAIN_AND_SUB_PREPS: PREP_MAIN_AND_SUB_PREPS,
+    ConfigKey.DECENTRALIZE_TRIGGER: 0.002,
+    ConfigKey.PENALTY_GRACE_PERIOD: PENALTY_GRACE_PERIOD,
+    ConfigKey.MIN_PRODUCTIVITY_PERCENTAGE: MIN_PRODUCTIVITY_PERCENTAGE,
+    ConfigKey.MAX_UNVALIDATED_SEQUENCE_BLOCKS: MAX_UNVALIDATED_SEQUENCE_BLOCKS
 }

--- a/iconservice/icon_constant.py
+++ b/iconservice/icon_constant.py
@@ -151,6 +151,9 @@ class ConfigKey:
     PREP_REGISTRATION_FEE = "prepRegistrationFee"
 
     DECENTRALIZE_TRIGGER = "decentralizeTrigger"
+    PENALTY_GRACE_PERIOD = "penaltyGracePeriod"
+    MIN_PRODUCTIVITY_PERCENTAGE = "minProductivityPercentage"
+    MAX_UNVALIDATED_SEQUENCE_BLOCKS = "maxUnvalidatedSequenceBlocks"
 
 
 class EnableThreadFlag(IntFlag):

--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -156,7 +156,10 @@ class IconServiceEngine(ContextContainer):
                                      conf[ConfigKey.IISS_CALCULATE_PERIOD],
                                      conf[ConfigKey.TERM_PERIOD],
                                      conf[ConfigKey.INITIAL_IREP],
-                                     conf[ConfigKey.PREP_REGISTRATION_FEE])
+                                     conf[ConfigKey.PREP_REGISTRATION_FEE],
+                                     conf[ConfigKey.PENALTY_GRACE_PERIOD],
+                                     conf[ConfigKey.MIN_PRODUCTIVITY_PERCENTAGE],
+                                     conf[ConfigKey.MAX_UNVALIDATED_SEQUENCE_BLOCKS])
 
         self._load_builtin_scores(
             context, Address.from_string(conf[ConfigKey.BUILTIN_SCORE_OWNER]))
@@ -191,7 +194,10 @@ class IconServiceEngine(ContextContainer):
                                 calc_period: int,
                                 term_period: int,
                                 irep: int,
-                                prep_reg_fee: int):
+                                prep_reg_fee: int,
+                                penalty_grace_period: int,
+                                min_productivity_percentage: int,
+                                max_unvalidated_sequence_blocks: int):
 
         IconScoreContext.engine.deploy.open(context)
         IconScoreContext.engine.fee.open(context)
@@ -202,7 +208,10 @@ class IconServiceEngine(ContextContainer):
                                           rc_socket_path)
         IconScoreContext.engine.prep.open(context,
                                           term_period,
-                                          irep)
+                                          irep,
+                                          penalty_grace_period,
+                                          min_productivity_percentage,
+                                          max_unvalidated_sequence_blocks)
         IconScoreContext.engine.issue.open(context)
 
         IconScoreContext.storage.deploy.open(context)

--- a/iconservice/prep/data/prep.py
+++ b/iconservice/prep/data/prep.py
@@ -46,6 +46,19 @@ class PRep(Sortable):
     _VERSION: int = 1
     _UNKNOWN_COUNTRY = iso3166.Country(u"Unknown", "ZZ", "ZZZ", "000", u"Unknown")
 
+    _penalty_grace_period: int = PENALTY_GRACE_PERIOD
+    _min_productivity_percentage: int = MIN_PRODUCTIVITY_PERCENTAGE
+    _max_unvalidated_sequence_blocks: int = MAX_UNVALIDATED_SEQUENCE_BLOCKS
+
+    @classmethod
+    def init_prep_config(cls,
+                         penalty_grace_period: int,
+                         min_productivity_percentage: int,
+                         max_unvalidated_sequence_block: int):
+        cls._penalty_grace_period: int = penalty_grace_period
+        cls._min_productivity_percentage: int = min_productivity_percentage
+        cls._max_unvalidated_sequence_blocks: int = max_unvalidated_sequence_block
+
     class Index(IntEnum):
         VERSION = 0
 
@@ -247,10 +260,10 @@ class PRep(Sortable):
 
     def is_low_productivity(self) -> bool:
         # A grace period without measuring productivity
-        if self._total_blocks < PENALTY_GRACE_PERIOD:
+        if self._total_blocks < self._penalty_grace_period:
             return False
 
-        return self.productivity < MIN_PRODUCTIVITY_PERCENTAGE
+        return self.productivity < self._min_productivity_percentage
 
     def release_suspend(self):
         if self._status == PRepStatus.SUSPENDED:
@@ -259,10 +272,10 @@ class PRep(Sortable):
 
     def is_over_unvalidated_sequence_blocks(self) -> bool:
         # A grace period without measuring productivity
-        if self._total_blocks < PENALTY_GRACE_PERIOD:
+        if self._total_blocks < self._penalty_grace_period:
             return False
 
-        return self._unvalidated_sequence_blocks >= MAX_UNVALIDATED_SEQUENCE_BLOCKS
+        return self._unvalidated_sequence_blocks >= self._max_unvalidated_sequence_blocks
 
     @property
     def total_blocks(self) -> int:

--- a/iconservice/prep/engine.py
+++ b/iconservice/prep/engine.py
@@ -72,7 +72,19 @@ class Engine(EngineBase, IISSEngineListener):
 
         Logger.debug("PRepEngine.__init__() end")
 
-    def open(self, context: 'IconScoreContext', term_period: int, irep: int):
+    def open(self,
+             context: 'IconScoreContext',
+             term_period: int,
+             irep: int,
+             penalty_grace_period: int,
+             min_productivity_percentage: int,
+             max_unvalidated_sequence_block: int):
+
+        # this logic doesn't need to save to DB yet
+        PRep.init_prep_config(penalty_grace_period,
+                              min_productivity_percentage,
+                              max_unvalidated_sequence_block)
+
         self._load_preps(context)
         self.term.load(context, term_period)
         self._initial_irep = irep

--- a/tests/integrate_test/iiss/decentralized/test_preps_replace_in_term.py
+++ b/tests/integrate_test/iiss/decentralized/test_preps_replace_in_term.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, List
 from unittest.mock import patch
 
 from iconservice.icon_constant import ICX_IN_LOOP, PREP_MAIN_PREPS, PREP_MAIN_AND_SUB_PREPS, PREP_PENALTY_SIGNATURE
+from iconservice.prep.data import PRep
 from tests.integrate_test.iiss.test_iiss_base import TestIISSBase
 from tests.integrate_test.test_integrate_base import EOAAccount
 
@@ -36,8 +37,8 @@ class TestPreps(TestIISSBase):
         super().setUp()
         self.init_decentralized()
 
-    @patch('iconservice.prep.data.prep.PENALTY_GRACE_PERIOD', 40)
     def test_prep_replace_in_term1(self):
+        PRep._penalty_grace_period = 40
         """
         scenario 1
             when it starts new preps on new term, normal case, while 100 block.
@@ -131,8 +132,8 @@ class TestPreps(TestIISSBase):
             self.assertEqual(block_count, response["totalBlocks"])
             self.assertEqual(block_count, response["validatedBlocks"])
 
-    @patch('iconservice.prep.data.prep.PENALTY_GRACE_PERIOD', 40)
     def test_prep_replace_in_term2(self):
+        PRep._penalty_grace_period = 40
         """
         scenario 2
             when it starts new preps on new term, half count (MAIN_PREPS // 2) preps have done to validate block until GRACE_PERIOD.
@@ -437,9 +438,10 @@ class TestPreps(TestIISSBase):
         }
         self.assertEqual(expected_response, response)
 
-    @patch('iconservice.prep.data.prep.PENALTY_GRACE_PERIOD', 40)
-    @patch('iconservice.prep.data.prep.MAX_UNVALIDATED_SEQUENCE_BLOCKS', 5)
     def test_prep_replace_in_term4(self):
+        PRep._penalty_grace_period: int = 40
+        PRep._max_unvalidated_sequence_blocks: int = 5
+
         """
         scenario 4
             when it starts new preps on new term, half count (MAIN_PREPS // 2) preps have done to validate block continuously.


### PR DESCRIPTION
PRep constant variables:
    penalty_grace_period,
    min_productivity_percentage,
    max_unvalidated_sequence_blocks

we should change those constant variables by using icon-config
but I don't save these variables to DB yet because we don't need to change it dynamically.