### PR TITLE
IS-786: Add revision field to header data of RC DB 

### DIFF
--- a/iconservice/icon_constant.py
+++ b/iconservice/icon_constant.py
@@ -115,12 +115,12 @@ RC_DB_VERSION_0 = 0
 RC_DB_VERSION_2 = 2
 
 
-# The case that version is updated but not revision append the version info to the list of the latest revision
+# The case that version is updated but not revision, set the version to the current revision
 # The case that both version and revision is updated, add revision field to the version table
 # The case that only revision is changed, do not update this table
 RC_DATA_VERSION_TABLE = {
-    REV_IISS: [RC_DB_VERSION_0],
-    REV_DECENTRALIZATION: [RC_DB_VERSION_2]
+    REV_IISS: RC_DB_VERSION_0,
+    REV_DECENTRALIZATION: RC_DB_VERSION_2
 }
 
 IISS_DB = 'iiss'

--- a/iconservice/icon_constant.py
+++ b/iconservice/icon_constant.py
@@ -115,9 +115,9 @@ RC_DB_VERSION_0 = 0
 RC_DB_VERSION_2 = 2
 
 
-# If version is changed but revision not being changed, append to the list of same revision
-# If both version and revision is changed, update table
-# If only revision is changed, do not update this table
+# The case that version is updated but not revision append the version info to the list of the latest revision
+# The case that both version and revision is updated, add revision field to the version table
+# The case that only revision is changed, do not update this table
 RC_DATA_VERSION_TABLE = {
     REV_IISS: [RC_DB_VERSION_0],
     REV_DECENTRALIZATION: [RC_DB_VERSION_2]

--- a/iconservice/icon_constant.py
+++ b/iconservice/icon_constant.py
@@ -111,6 +111,18 @@ LATEST_REVISION = REVISION_4
 REV_IISS = REVISION_5
 REV_DECENTRALIZATION = REV_IISS + 1
 
+RC_DB_VERSION_0 = 0
+RC_DB_VERSION_2 = 2
+
+
+# If version is changed but revision not being changed, append to the list of same revision
+# If both version and revision is changed, update table
+# If only revision is changed, do not update this table
+RC_DATA_VERSION_TABLE = {
+    REV_IISS: [RC_DB_VERSION_0],
+    REV_DECENTRALIZATION: [RC_DB_VERSION_2]
+}
+
 IISS_DB = 'iiss'
 RC_SOCKET = 'iiss.sock'
 

--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -1650,6 +1650,7 @@ class IconServiceEngine(ContextContainer):
             context.engine.prep.commit(context, precommit_data)
             context.storage.rc.commit(precommit_data.rc_block_batch)
             context.engine.iiss.send_ipc(context, precommit_data)
+            # todo: consider case when error being raised in send ipc
             context.storage.rc.put_version_and_revision(precommit_data.revision)
 
     def rollback(self, block_height: int, instant_block_hash: bytes) -> None:

--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -151,7 +151,11 @@ class IconServiceEngine(ContextContainer):
         self._precommit_data_manager.last_block: 'Block' = IconScoreContext.storage.icx.last_block
         context.block: 'Block' = self._get_last_block()
 
-        self._set_revision_to_context(context)
+        # set revision (if governance SCORE does not exist, remain revision to default).
+        try:
+            self._set_revision_to_context(context)
+        except ScoreNotFoundException:
+            pass
 
         self._open_component_context(context,
                                      log_dir,

--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -233,7 +233,7 @@ class IconServiceEngine(ContextContainer):
                                            prep_reg_fee)
         IconScoreContext.storage.issue.open(context)
         IconScoreContext.storage.meta.open(context)
-        IconScoreContext.storage.rc.open(context, rc_data_path)
+        IconScoreContext.storage.rc.open(context.revision, rc_data_path)
 
     def _close_component_context(self, context: 'IconScoreContext'):
         IconScoreContext.engine.deploy.close()

--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -151,6 +151,8 @@ class IconServiceEngine(ContextContainer):
         self._precommit_data_manager.last_block: 'Block' = IconScoreContext.storage.icx.last_block
         context.block: 'Block' = self._get_last_block()
 
+        self._set_revision_to_context(context)
+
         self._open_component_context(context,
                                      log_dir,
                                      rc_data_path,
@@ -227,7 +229,7 @@ class IconServiceEngine(ContextContainer):
                                            prep_reg_fee)
         IconScoreContext.storage.issue.open(context)
         IconScoreContext.storage.meta.open(context)
-        IconScoreContext.storage.rc.open(rc_data_path)
+        IconScoreContext.storage.rc.open(context, rc_data_path)
 
     def _close_component_context(self, context: 'IconScoreContext'):
         IconScoreContext.engine.deploy.close()
@@ -1644,6 +1646,7 @@ class IconServiceEngine(ContextContainer):
             context.engine.prep.commit(context, precommit_data)
             context.storage.rc.commit(precommit_data.rc_block_batch)
             context.engine.iiss.send_ipc(context, precommit_data)
+            context.storage.rc.put_version_and_revision(precommit_data.revision)
 
     def rollback(self, block_height: int, instant_block_hash: bytes) -> None:
         """Throw away a precommit state

--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -1651,7 +1651,6 @@ class IconServiceEngine(ContextContainer):
             context.storage.rc.commit(precommit_data.rc_block_batch)
             context.engine.iiss.send_ipc(context, precommit_data)
             # todo: consider case when error being raised in send ipc
-            context.storage.rc.put_version_and_revision(precommit_data.revision)
 
     def rollback(self, block_height: int, instant_block_hash: bytes) -> None:
         """Throw away a precommit state

--- a/iconservice/iiss/engine.py
+++ b/iconservice/iiss/engine.py
@@ -39,7 +39,8 @@ from ..precommit_data_manager import PrecommitFlag
 
 if TYPE_CHECKING:
     from ..precommit_data_manager import PrecommitData
-    from .reward_calc.msg_data import TxData, DelegationInfo, DelegationTx, Header, BlockProduceInfoData, PRepsData
+    from .reward_calc.msg_data import TxData, DelegationInfo, DelegationTx, Header, BlockProduceInfoData, PRepsData, \
+    get_rc_version
     from .reward_calc.msg_data import GovernanceVariable
     from ..iiss.storage import RewardRate
     from ..icx import IcxStorage
@@ -673,7 +674,8 @@ class Engine(EngineBase):
     @classmethod
     def _put_header_to_rc_db(cls,
                              context: 'IconScoreContext'):
-        data: 'Header' = RewardCalcDataCreator.create_header(0, context.block.height)
+        version: int = get_rc_version(context.revision)
+        data: 'Header' = RewardCalcDataCreator.create_header(version, context.block.height, context.revision)
         context.storage.rc.put(context.rc_block_batch, data)
 
     @classmethod
@@ -705,7 +707,9 @@ class Engine(EngineBase):
         calculated_irep: int = IssueFormula.calculate_irep_per_block_contributor(irep)
 
         reward_prep_for_rc = IssueFormula.calculate_temporary_reward_prep(reward_prep)
-        data: 'GovernanceVariable' = RewardCalcDataCreator.create_gv_variable(context.block.height,
+        version: int = get_rc_version(context.revision)
+        data: 'GovernanceVariable' = RewardCalcDataCreator.create_gv_variable(version,
+                                                                              context.block.height,
                                                                               calculated_irep,
                                                                               reward_prep_for_rc,
                                                                               context.main_prep_count,

--- a/iconservice/iiss/engine.py
+++ b/iconservice/iiss/engine.py
@@ -629,6 +629,7 @@ class Engine(EngineBase):
             return
 
         path: str = context.storage.rc.create_db_for_calc(block_height)
+        context.storage.rc.put_version_and_revision(precommit_data.revision)
         self._reward_calc_proxy.calculate(path, block_height)
 
     @classmethod

--- a/iconservice/iiss/engine.py
+++ b/iconservice/iiss/engine.py
@@ -39,8 +39,7 @@ from ..precommit_data_manager import PrecommitFlag
 
 if TYPE_CHECKING:
     from ..precommit_data_manager import PrecommitData
-    from .reward_calc.msg_data import TxData, DelegationInfo, DelegationTx, Header, BlockProduceInfoData, PRepsData, \
-    get_rc_version
+    from .reward_calc.msg_data import TxData, DelegationInfo, DelegationTx, Header, BlockProduceInfoData, PRepsData
     from .reward_calc.msg_data import GovernanceVariable
     from ..iiss.storage import RewardRate
     from ..icx import IcxStorage
@@ -674,8 +673,9 @@ class Engine(EngineBase):
     @classmethod
     def _put_header_to_rc_db(cls,
                              context: 'IconScoreContext'):
-        version: int = get_rc_version(context.revision)
-        data: 'Header' = RewardCalcDataCreator.create_header(version, context.block.height, context.revision)
+        version: int = context.storage.rc.current_version
+        revision: int = context.storage.rc.current_revision
+        data: 'Header' = RewardCalcDataCreator.create_header(version, context.block.height, revision)
         context.storage.rc.put(context.rc_block_batch, data)
 
     @classmethod
@@ -707,7 +707,9 @@ class Engine(EngineBase):
         calculated_irep: int = IssueFormula.calculate_irep_per_block_contributor(irep)
 
         reward_prep_for_rc = IssueFormula.calculate_temporary_reward_prep(reward_prep)
-        version: int = get_rc_version(context.revision)
+
+        # todo: versioning at this point?
+        version: int = context.storage.rc.current_version
         data: 'GovernanceVariable' = RewardCalcDataCreator.create_gv_variable(version,
                                                                               context.block.height,
                                                                               calculated_irep,

--- a/iconservice/iiss/reward_calc/data_creator.py
+++ b/iconservice/iiss/reward_calc/data_creator.py
@@ -17,6 +17,8 @@
 from typing import TYPE_CHECKING, List
 
 from iconcommons import Logger
+
+from iconservice.icon_constant import RC_DB_VERSION_2
 from ..reward_calc.msg_data import Header, GovernanceVariable, PRepsData, TxData, \
     DelegationTx, DelegationInfo, PRepRegisterTx, PRepUnregisterTx, BlockProduceInfoData
 
@@ -27,25 +29,34 @@ if TYPE_CHECKING:
 
 
 class DataCreator:
+
     @staticmethod
-    def create_header(version: int, block_height: int) -> 'Header':
+    def create_header(version: int, block_height: int, revision: int) -> 'Header':
         data = Header()
         data.version: int = version
         data.block_height: int = block_height
+
+        if version >= RC_DB_VERSION_2:
+            data.revision: int = revision
+
         return data
 
     @staticmethod
-    def create_gv_variable(block_height: int,
+    def create_gv_variable(version: int,
+                           block_height: int,
                            calculated_irep: int,
                            reward_rep: int,
                            config_main_prep_count: int,
                            config_main_and_sub_prep_count: int) -> 'GovernanceVariable':
         data = GovernanceVariable()
+        data.version: int = version
         data.block_height: int = block_height
         data.calculated_irep: int = calculated_irep
         data.reward_rep: int = reward_rep
-        data.config_main_prep_count: int = config_main_prep_count
-        data.config_sub_prep_count: int = config_main_and_sub_prep_count - config_main_prep_count
+
+        if version >= RC_DB_VERSION_2:
+            data.config_main_prep_count: int = config_main_prep_count
+            data.config_sub_prep_count: int = config_main_and_sub_prep_count - config_main_prep_count
         return data
 
     @staticmethod

--- a/iconservice/iiss/reward_calc/data_creator.py
+++ b/iconservice/iiss/reward_calc/data_creator.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, List
 
 from iconcommons import Logger
 
-from iconservice.icon_constant import RC_DB_VERSION_2
+from ...icon_constant import RC_DB_VERSION_2
 from ..reward_calc.msg_data import Header, GovernanceVariable, PRepsData, TxData, \
     DelegationTx, DelegationInfo, PRepRegisterTx, PRepUnregisterTx, BlockProduceInfoData
 

--- a/iconservice/iiss/reward_calc/data_creator.py
+++ b/iconservice/iiss/reward_calc/data_creator.py
@@ -35,10 +35,7 @@ class DataCreator:
         data = Header()
         data.version: int = version
         data.block_height: int = block_height
-
-        if version >= RC_DB_VERSION_2:
-            data.revision: int = revision
-
+        data.revision: int = revision
         return data
 
     @staticmethod
@@ -53,10 +50,8 @@ class DataCreator:
         data.block_height: int = block_height
         data.calculated_irep: int = calculated_irep
         data.reward_rep: int = reward_rep
-
-        if version >= RC_DB_VERSION_2:
-            data.config_main_prep_count: int = config_main_prep_count
-            data.config_sub_prep_count: int = config_main_and_sub_prep_count - config_main_prep_count
+        data.config_main_prep_count: int = config_main_prep_count
+        data.config_sub_prep_count: int = config_main_and_sub_prep_count - config_main_prep_count
         return data
 
     @staticmethod

--- a/iconservice/iiss/reward_calc/msg_data.py
+++ b/iconservice/iiss/reward_calc/msg_data.py
@@ -64,6 +64,7 @@ class Header(Data):
             self.block_height
         ]
         if self.version >= RC_DB_VERSION_2:
+            # Added value in version 2
             data.append(self.revision)
 
         return MsgPackForIpc.dumps(data)
@@ -113,6 +114,7 @@ class GovernanceVariable(Data):
             self.reward_rep,
         ]
         if self.version >= RC_DB_VERSION_2:
+            # Added value in version 2
             data.append(self.config_main_prep_count)
             data.append(self.config_sub_prep_count)
 

--- a/iconservice/iiss/reward_calc/msg_data.py
+++ b/iconservice/iiss/reward_calc/msg_data.py
@@ -128,6 +128,7 @@ class GovernanceVariable(Data):
         obj.reward_rep: int = data_list[1]
         # need to be refactor
         if len(data_list) > 2:
+            obj.version: int = RC_DB_VERSION_2
             obj.config_main_prep_count: int = data_list[2]
             obj.config_sub_prep_count: int = data_list[3]
         return obj

--- a/iconservice/iiss/reward_calc/msg_data.py
+++ b/iconservice/iiss/reward_calc/msg_data.py
@@ -33,14 +33,6 @@ class TxType(IntEnum):
     INVALID = 99
 
 
-def get_rc_version(revision: int) -> int:
-    version: Optional[list] = RC_DATA_VERSION_TABLE.get(revision)
-    if version is None:
-        return get_rc_version(revision - 1)
-    latest_version: int = version[-1]
-    return latest_version
-
-
 class Data:
     @abstractmethod
     def make_key(self, *args, **kwargs) -> bytes:

--- a/iconservice/iiss/reward_calc/msg_data.py
+++ b/iconservice/iiss/reward_calc/msg_data.py
@@ -16,10 +16,10 @@
 
 from abc import ABCMeta, abstractmethod
 from enum import IntEnum
-from typing import Any, TYPE_CHECKING, List, Optional, Tuple
+from typing import Any, TYPE_CHECKING, List, Optional
 
 from ...base.exception import InvalidParamsException
-from ...icon_constant import DATA_BYTE_ORDER, RC_DATA_VERSION_TABLE, RC_DB_VERSION_2
+from ...icon_constant import DATA_BYTE_ORDER, RC_DB_VERSION_2
 from ...utils.msgpack_for_ipc import MsgPackForIpc, TypeTag
 
 if TYPE_CHECKING:

--- a/iconservice/iiss/reward_calc/msg_data.py
+++ b/iconservice/iiss/reward_calc/msg_data.py
@@ -70,17 +70,23 @@ class Header(Data):
 
     @staticmethod
     def from_bytes(value: bytes) -> 'Header':
-        # todo: code refactoring
+        # Method for debugging
         data_list: list = MsgPackForIpc.loads(value)
         obj = Header()
         obj.version: int = data_list[0]
         obj.block_height: int = data_list[1]
+
+        if obj.version >= RC_DB_VERSION_2:
+            obj.revision: int = data_list[2]
+
         return obj
 
     def __str__(self):
-        # todo: code refactoring
-        return f"[{self._PREFIX}] " \
-               f"version: {self.version}, block_height: {self.block_height}"
+        info: str = f"[{self._PREFIX}] version: {self.version}, block_height: {self.block_height} "
+
+        if self.version >= RC_DB_VERSION_2:
+            info += f"revision: {self.revision} "
+        return info
 
 
 class GovernanceVariable(Data):
@@ -114,22 +120,25 @@ class GovernanceVariable(Data):
 
     @staticmethod
     def from_bytes(key: bytes, value: bytes) -> 'GovernanceVariable':
-        # todo: code refactoring
+        # Method for debugging
         data_list: list = MsgPackForIpc.loads(value)
         obj = GovernanceVariable()
         obj.block_height: int = int.from_bytes(key[2:], DATA_BYTE_ORDER)
         obj.calculated_irep: int = data_list[0]
         obj.reward_rep: int = data_list[1]
-        obj.config_main_prep_count: int = data_list[2]
-        obj.config_sub_prep_count: int = data_list[3]
+        # need to be refactor
+        if len(data_list) > 2:
+            obj.config_main_prep_count: int = data_list[2]
+            obj.config_sub_prep_count: int = data_list[3]
         return obj
 
     def __str__(self):
-        # todo: code refactoring
-        return f"[{self._PREFIX}] key: {self.block_height}," \
-               f"config_main_prep_count: {self.config_main_prep_count}, " \
-               f"config_sub_prep_count: {self.config_sub_prep_count}" \
-               f" calculated_irep: {self.calculated_irep}, reward_rep: {self.reward_rep}"
+        info: str = f"[{self._PREFIX}] key: {self.block_height}," \
+                    f" calculated_irep: {self.calculated_irep}, reward_rep: {self.reward_rep}"
+        if self.version >= RC_DB_VERSION_2:
+            info += f"config_main_prep_count: {self.config_main_prep_count}, " \
+                    f"config_sub_prep_count: {self.config_sub_prep_count}"
+        return info
 
 
 class BlockProduceInfoData(Data):
@@ -156,6 +165,7 @@ class BlockProduceInfoData(Data):
 
     @staticmethod
     def from_bytes(key: bytes, value: bytes) -> 'BlockProduceInfoData':
+        # Method for debugging
         data_list: list = MsgPackForIpc.loads(value)
         obj = BlockProduceInfoData()
         obj.block_height: int = int.from_bytes(key[2:], DATA_BYTE_ORDER)
@@ -198,6 +208,7 @@ class PRepsData(Data):
 
     @staticmethod
     def from_bytes(key: bytes, value: bytes) -> 'PRepsData':
+        # Method for debugging
         data_list: list = MsgPackForIpc.loads(value)
         obj = PRepsData()
         obj.prep_list = []
@@ -257,6 +268,7 @@ class TxData(Data):
 
     @staticmethod
     def from_bytes(value: bytes) -> 'TxData':
+        # Method for debugging
         data_list: list = MsgPackForIpc.loads(value)
         obj = TxData()
         obj.address: 'Address' = MsgPackForIpc.decode(TypeTag.ADDRESS, data_list[0])

--- a/iconservice/iiss/reward_calc/storage.py
+++ b/iconservice/iiss/reward_calc/storage.py
@@ -34,11 +34,10 @@ def get_rc_version(revision: int) -> int:
     if revision < REV_IISS:
         return RC_DB_VERSION_0
 
-    version: Optional[list] = RC_DATA_VERSION_TABLE.get(revision)
+    version: Optional[int] = RC_DATA_VERSION_TABLE.get(revision)
     if version is None:
         return get_rc_version(revision - 1)
-    latest_version: int = version[-1]
-    return latest_version
+    return version
 
 
 class Storage(object):

--- a/iconservice/iiss/reward_calc/storage.py
+++ b/iconservice/iiss/reward_calc/storage.py
@@ -58,7 +58,7 @@ class Storage(object):
         self.current_version: Optional[int] = None
         self.current_revision: Optional[int] = None
 
-    def open(self, context: 'IconScoreContext', path: str):
+    def open(self, revision: int, path: str):
         if not os.path.exists(path):
             raise DatabaseException(f"Invalid IISS DB path: {path}")
         self._path = path
@@ -68,8 +68,8 @@ class Storage(object):
         self._db_iiss_tx_index = self._load_last_transaction_index()
 
         self.current_version, self.current_revision = self._load_version_and_revision()
-        if context.revision >= REV_IISS and self.current_version == -1:
-            self.put_version_and_revision(context.revision)
+        if revision >= REV_IISS and self.current_version == -1:
+            self.put_version_and_revision(revision)
 
     def close(self):
         """Close the embedded database.

--- a/iconservice/iiss/reward_calc/storage.py
+++ b/iconservice/iiss/reward_calc/storage.py
@@ -23,7 +23,7 @@ from ...iconscore.icon_score_context import IconScoreContext
 from ..reward_calc.msg_data import TxData
 from ...base.exception import DatabaseException
 from ...database.db import KeyValueDatabase
-from ...icon_constant import DATA_BYTE_ORDER, REV_IISS, RC_DATA_VERSION_TABLE
+from ...icon_constant import DATA_BYTE_ORDER, REV_IISS, RC_DATA_VERSION_TABLE, RC_DB_VERSION_0
 from ...utils.msgpack_for_db import MsgPackForDB
 
 if TYPE_CHECKING:
@@ -31,6 +31,9 @@ if TYPE_CHECKING:
 
 
 def get_rc_version(revision: int) -> int:
+    if revision < REV_IISS:
+        return RC_DB_VERSION_0
+
     version: Optional[list] = RC_DATA_VERSION_TABLE.get(revision)
     if version is None:
         return get_rc_version(revision - 1)

--- a/iconservice/iiss/reward_calc/storage.py
+++ b/iconservice/iiss/reward_calc/storage.py
@@ -54,8 +54,8 @@ class Storage(object):
         # 'None' if open() is not called else 'int'
         self._db_iiss_tx_index: Optional[int] = None
 
-        self.current_version: Optional[int] = None
-        self.current_revision: Optional[int] = None
+        self._current_version: Optional[int] = None
+        self._current_revision: Optional[int] = None
 
     def open(self, revision: int, path: str):
         if not os.path.exists(path):
@@ -66,9 +66,17 @@ class Storage(object):
         self._db = KeyValueDatabase.from_path(current_db_path, create_if_missing=True)
         self._db_iiss_tx_index = self._load_last_transaction_index()
 
-        self.current_version, self.current_revision = self._load_version_and_revision()
-        if revision >= REV_IISS and self.current_version == -1:
+        self._current_version, self._current_revision = self._load_version_and_revision()
+        if revision >= REV_IISS and self._current_version == -1:
             self.put_version_and_revision(revision)
+
+    @property
+    def current_version(self) -> int:
+        return self._current_version if self._current_version != -1 else 0
+
+    @property
+    def current_revision(self) -> int:
+        return self._current_revision if self._current_version != -1 else 0
 
     def close(self):
         """Close the embedded database.
@@ -124,8 +132,8 @@ class Storage(object):
         version_and_revision: bytes = MsgPackForDB.dumps([version, revision])
         self._db.put(self._KEY_FOR_VERSION_AND_REVISION, version_and_revision)
 
-        self.current_version = version
-        self.current_revision = revision
+        self._current_version = version
+        self._current_revision = revision
 
     def _load_version_and_revision(self) -> Tuple[int, int]:
         version_and_revision: Optional[bytes] = self._db.get(self._KEY_FOR_VERSION_AND_REVISION)

--- a/tests/iiss/test_iiss_data_using_level_db.py
+++ b/tests/iiss/test_iiss_data_using_level_db.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING
 
 import plyvel
 
+from iconservice.icon_constant import RC_DB_VERSION_2, RC_DB_VERSION_0
 from iconservice.iiss.reward_calc.msg_data import Header, GovernanceVariable, PRepsData, TxData, TxType, \
     DelegationTx, DelegationInfo, PRepRegisterTx, PRepUnregisterTx, BlockProduceInfoData
 from tests import create_address, rmtree
@@ -35,15 +36,29 @@ class TestIissDataUsingLevelDB(unittest.TestCase):
         self.debug = True
 
         self.iiss_header: 'Header' = Header()
-        self.iiss_header.version = 10
+        self.iiss_header.version = RC_DB_VERSION_0
         self.iiss_header.block_height = 20
+        # in version 0, revision must not be set
+        self.iiss_header.revision = 5
+
+        self.iiss_header_v2: 'Header' = Header()
+        self.iiss_header_v2.version = RC_DB_VERSION_2
+        self.iiss_header_v2.block_height = 20
+        self.iiss_header_v2.revision = 5
 
         self.iiss_gv: 'GovernanceVariable' = GovernanceVariable()
+        self.iiss_gv.version = RC_DB_VERSION_0
         self.iiss_gv.block_height = 20
-        self.iiss_gv.config_main_prep_count = 22
-        self.iiss_gv.config_sub_prep_count = 100
         self.iiss_gv.calculated_irep = 30
         self.iiss_gv.reward_rep = 10_000
+
+        self.iiss_gv_v2: 'GovernanceVariable' = GovernanceVariable()
+        self.iiss_gv_v2.version = RC_DB_VERSION_2
+        self.iiss_gv_v2.block_height = 22
+        self.iiss_gv_v2.config_main_prep_count = 22
+        self.iiss_gv_v2.config_sub_prep_count = 100
+        self.iiss_gv_v2.calculated_irep = 30
+        self.iiss_gv_v2.reward_rep = 10_000
 
         self.iiss_block_produce_info: 'BlockProduceInfoData' = BlockProduceInfoData()
         self.iiss_block_produce_info.block_height = 20
@@ -110,6 +125,16 @@ class TestIissDataUsingLevelDB(unittest.TestCase):
 
         self.assertEqual(self.iiss_header.version, ret_h.version)
         self.assertEqual(self.iiss_header.block_height, ret_h.block_height)
+        # default value
+        self.assertEqual(0, ret_h.revision)
+
+    def test_iiss_header_v2_data(self):
+        value: bytes = self.iiss_header_v2.make_value()
+        ret_h: 'Header' = self.iiss_header_v2.from_bytes(value)
+
+        self.assertEqual(self.iiss_header_v2.version, ret_h.version)
+        self.assertEqual(self.iiss_header_v2.block_height, ret_h.block_height)
+        self.assertEqual(self.iiss_header_v2.revision, ret_h.revision)
 
     def test_iiss_governance_variable_data(self):
         key: bytes = self.iiss_gv.make_key()
@@ -117,10 +142,22 @@ class TestIissDataUsingLevelDB(unittest.TestCase):
         ret_gv: 'GovernanceVariable' = self.iiss_gv.from_bytes(key, value)
 
         self.assertEqual(self.iiss_gv.block_height, ret_gv.block_height)
-        self.assertEqual(self.iiss_gv.config_main_prep_count, ret_gv.config_main_prep_count)
-        self.assertEqual(self.iiss_gv.config_sub_prep_count, ret_gv.config_sub_prep_count)
+        # default value
+        self.assertEqual(0, ret_gv.config_main_prep_count)
+        self.assertEqual(0, ret_gv.config_sub_prep_count)
         self.assertEqual(self.iiss_gv.calculated_irep, ret_gv.calculated_irep)
         self.assertEqual(self.iiss_gv.reward_rep, ret_gv.reward_rep)
+
+    def test_iiss_governance_variable_v2_data(self):
+        key: bytes = self.iiss_gv_v2.make_key()
+        value: bytes = self.iiss_gv_v2.make_value()
+        ret_gv: 'GovernanceVariable' = self.iiss_gv_v2.from_bytes(key, value)
+
+        self.assertEqual(self.iiss_gv_v2.block_height, ret_gv.block_height)
+        self.assertEqual(self.iiss_gv_v2.config_main_prep_count, ret_gv.config_main_prep_count)
+        self.assertEqual(self.iiss_gv_v2.config_sub_prep_count, ret_gv.config_sub_prep_count)
+        self.assertEqual(self.iiss_gv_v2.calculated_irep, ret_gv.calculated_irep)
+        self.assertEqual(self.iiss_gv_v2.reward_rep, ret_gv.reward_rep)
 
     def test_iiss_block_produce_info_data(self):
         key: bytes = self.iiss_block_produce_info.make_key()
@@ -206,6 +243,21 @@ class TestIissDataUsingLevelDB(unittest.TestCase):
             print(f"value: {value}")
             print("")
 
+        key: bytes = self.iiss_gv_v2.make_key()
+        value: bytes = self.iiss_gv_v2.make_value()
+        self.db.put(key, value)
+
+        if self.debug:
+            print("===IISS_GOVERNANCE_VARIABLE_V2===")
+            print(f"block_height: {self.iiss_gv_v2.block_height}")
+            print(f"calculated irep: {self.iiss_gv_v2.calculated_irep}")
+            print(f"reward_rep: {self.iiss_gv_v2.reward_rep}")
+            print(f"main prep count: {self.iiss_gv_v2.config_main_prep_count}")
+            print(f"sub prep count: {self.iiss_gv_v2.config_sub_prep_count}")
+            print(f"key: {key}")
+            print(f"value: {value}")
+            print("")
+
         key: bytes = self.iiss_block_produce_info.make_key()
         value: bytes = self.iiss_block_produce_info.make_value()
         self.db.put(key, value)
@@ -283,19 +335,30 @@ class TestIissDataUsingLevelDB(unittest.TestCase):
         key: bytes = self.iiss_header.make_key()
         value = self.db.get(key)
         ret_h: 'Header' = self.iiss_header.from_bytes(value)
-
         self.assertEqual(self.iiss_header.version, ret_h.version)
         self.assertEqual(self.iiss_header.block_height, ret_h.block_height)
+        self.assertEqual(0, ret_h.revision)
 
         key: bytes = self.iiss_gv.make_key()
         value = self.db.get(key)
         ret_gv: 'GovernanceVariable' = self.iiss_gv.from_bytes(key, value)
 
         self.assertEqual(self.iiss_gv.block_height, ret_gv.block_height)
-        self.assertEqual(self.iiss_gv.config_main_prep_count, ret_gv.config_main_prep_count)
-        self.assertEqual(self.iiss_gv.config_sub_prep_count, ret_gv.config_sub_prep_count)
+        # default value
+        self.assertEqual(0, ret_gv.config_main_prep_count)
+        self.assertEqual(0, ret_gv.config_sub_prep_count)
         self.assertEqual(self.iiss_gv.calculated_irep, ret_gv.calculated_irep)
         self.assertEqual(self.iiss_gv.reward_rep, ret_gv.reward_rep)
+
+        key: bytes = self.iiss_gv_v2.make_key()
+        value = self.db.get(key)
+        ret_gv: 'GovernanceVariable' = self.iiss_gv_v2.from_bytes(key, value)
+
+        self.assertEqual(self.iiss_gv_v2.block_height, ret_gv.block_height)
+        self.assertEqual(self.iiss_gv_v2.config_main_prep_count, ret_gv.config_main_prep_count)
+        self.assertEqual(self.iiss_gv_v2.config_sub_prep_count, ret_gv.config_sub_prep_count)
+        self.assertEqual(self.iiss_gv_v2.calculated_irep, ret_gv.calculated_irep)
+        self.assertEqual(self.iiss_gv_v2.reward_rep, ret_gv.reward_rep)
 
         key: bytes = self.iiss_block_produce_info.make_key()
         value = self.db.get(key)

--- a/tests/iiss/test_reward_calc_data_storage.py
+++ b/tests/iiss/test_reward_calc_data_storage.py
@@ -37,10 +37,8 @@ class TestRcDataStorage(unittest.TestCase):
     def setUp(self, _, mocked_rc_db_from_path) -> None:
         self.path = ""
         mocked_rc_db_from_path.side_effect = MockIissDataBase.from_path
-        self.context: 'IconScoreContext' = IconScoreContext(IconScoreContextType.INVOKE)
-        self.context.revision = REV_DECENTRALIZATION
         self.rc_data_storage = RewardCalcStorage()
-        self.rc_data_storage.open(self.context, self.path)
+        self.rc_data_storage.open(REV_DECENTRALIZATION, self.path)
 
         dummy_block_height = 1
 
@@ -73,14 +71,12 @@ class TestRcDataStorage(unittest.TestCase):
     @patch('os.path.exists')
     def test_rc_storage_check_data_format_by_revision(self, _, mocked_rc_db_from_path):
         mocked_rc_db_from_path.side_effect = MockIissDataBase.from_path
-        context: 'IconScoreContext' = IconScoreContext(IconScoreContextType.INVOKE)
         for revision in range(REV_DECENTRALIZATION):
-            context.revision = revision
-            current_version = get_rc_version(context.revision)
+            current_version = get_rc_version(revision)
             rc_data_storage = RewardCalcStorage()
-            rc_data_storage.open(context, self.path)
+            rc_data_storage.open(revision, self.path)
             self.dummy_header.version = current_version
-            self.dummy_header.revision = context.revision
+            self.dummy_header.revision = revision
             self.dummy_gv.version = current_version
             iiss_data = [self.dummy_header, self.dummy_gv]
             rc_data_storage.commit(iiss_data)
@@ -97,12 +93,12 @@ class TestRcDataStorage(unittest.TestCase):
             self.assertEqual(0, gv.config_main_prep_count)
             self.assertEqual(0, gv.config_sub_prep_count)
 
-        context.revision = REV_DECENTRALIZATION
-        current_version = get_rc_version(context.revision)
+        revision = REV_DECENTRALIZATION
+        current_version = get_rc_version(revision)
         rc_data_storage = RewardCalcStorage()
-        rc_data_storage.open(context, self.path)
+        rc_data_storage.open(revision, self.path)
         self.dummy_header.version = current_version
-        self.dummy_header.revision = context.revision
+        self.dummy_header.revision = revision
         self.dummy_gv.version = current_version
         iiss_data = [self.dummy_header, self.dummy_gv]
         rc_data_storage.commit(iiss_data)
@@ -141,7 +137,7 @@ class TestRcDataStorage(unittest.TestCase):
             db = MockPlyvelDB(MockPlyvelDB.make_db())
             return MockIissDataBase(db)
         mocked_rc_db_from_path.side_effect = from_path
-        rc_data_storage.open(self.context, test_db_path)
+        rc_data_storage.open(REV_DECENTRALIZATION, test_db_path)
         mocked_path_exists.assert_called()
 
         expected_tx_index = -1

--- a/tests/integrate_test/iiss/decentralized/test_rc_db_data.py
+++ b/tests/integrate_test/iiss/decentralized/test_rc_db_data.py
@@ -56,8 +56,8 @@ class TestRCDatabase(TestIISSBase):
                 gv: 'GovernanceVariable' = GovernanceVariable.from_bytes(rc_data[0], rc_data[1])
                 expected_block_height = self._block_height
                 expected_irep = 0
-                expected_main_prep_count = 22
-                expected_sub_prep_count = 100 - expected_main_prep_count
+                expected_main_prep_count = 0
+                expected_sub_prep_count = 0
                 expected_rrep = 1200 * 3
                 self.assertEqual(expected_block_height, gv.block_height)
                 self.assertEqual(expected_main_prep_count, gv.config_main_prep_count)
@@ -116,8 +116,8 @@ class TestRCDatabase(TestIISSBase):
                 gv: 'GovernanceVariable' = GovernanceVariable.from_bytes(rc_data[0], rc_data[1])
                 expected_block_height = block_height
                 expected_irep = 0
-                expected_main_prep_count = 22
-                expected_sub_prep_count = 100 - expected_main_prep_count
+                expected_main_prep_count = 0
+                expected_sub_prep_count = 0
                 expected_rrep = 1078 * 3
                 self.assertEqual(expected_block_height, gv.block_height)
                 self.assertEqual(expected_main_prep_count, gv.config_main_prep_count)


### PR DESCRIPTION
1. Add revision field to header data of RC DB
2. Add version field to governance variable of RC DB
3. Define version and revision on reward calc storage
These variables are recorded on current RC DB. all data in this DB will be formatted according to this version information.

