### PR TITLE
IS-773 : Syncronize iconservice with reward Calculator

### DIFF
--- a/iconservice/icon_inner_service.py
+++ b/iconservice/icon_inner_service.py
@@ -65,7 +65,13 @@ class IconScoreInnerTask(object):
 
     @message_queue_task
     async def hello(self):
-        Logger.info('icon_score_hello', ICON_INNER_LOG_TAG)
+        Logger.info('icon_score_hello_start', ICON_INNER_LOG_TAG)
+
+        ready_future = self._icon_service_engine.get_ready_future()
+        await ready_future
+
+        Logger.info('icon_score_hello_end', ICON_INNER_LOG_TAG)
+
         return {}
 
     def _close(self):

--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -252,6 +252,9 @@ class IconServiceEngine(ContextContainer):
         IconScoreContext.storage.meta.close(context)
         IconScoreContext.storage.rc.close()
 
+    def get_ready_future(self):
+        return IconScoreContext.engine.iiss.get_ready_future()
+
     @staticmethod
     def _make_service_flag(flag_table: dict) -> int:
         make_flag = 0

--- a/iconservice/iiss/engine.py
+++ b/iconservice/iiss/engine.py
@@ -98,6 +98,9 @@ class Engine(EngineBase):
     def ready_callback(cb_data: 'ReadyNotification'):
         Logger.debug(tag=_TAG, msg=f"ready callback called with {cb_data}")
 
+    def get_ready_future(self):
+        return self._reward_calc_proxy.get_ready_future()
+
     @staticmethod
     def check_calculate_request_block_height(response_block_height: int,
                                              current_end_block_height_of_calc: int,


### PR DESCRIPTION
* The RewardCalculatorProxy has ready_future, so when ready comes, it sets the ready_future's set_result to True
* Waiting for RCProxy's ready_future in hello in icon_inner_service, then exit hello when it returns.