### PR TITLE
IS-801: Improve calculate related communication between IS and RC

### DIFF
--- a/iconservice/icon_constant.py
+++ b/iconservice/icon_constant.py
@@ -288,7 +288,7 @@ class RCStatus(IntEnum):
 class RCCalculateResult(IntEnum):
     SUCCESS = 0
     FAIL = 1
-    CALCULATING = 2
+    IN_PROGRESS = 2
     INVALID_BLOCK_HEIGHT = 3
 
 

--- a/iconservice/icon_constant.py
+++ b/iconservice/icon_constant.py
@@ -285,7 +285,7 @@ class RCStatus(IntEnum):
     READY = 1
 
 
-class RCCalculateResult(Enum):
+class RCCalculateResult(IntEnum):
     SUCCESS = 0
     FAIL = 1
     CALCULATING = 2

--- a/iconservice/icon_constant.py
+++ b/iconservice/icon_constant.py
@@ -285,6 +285,13 @@ class RCStatus(IntEnum):
     READY = 1
 
 
+class RCCalculateResult(Enum):
+    SUCCESS = 0
+    FAIL = 1
+    CALCULATING = 2
+    INVALID_BLOCK_HEIGHT = 3
+
+
 class PRepStatus(Enum):
     ACTIVE = 0
     UNREGISTERED = auto()

--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -1126,6 +1126,7 @@ class IconServiceEngine(ContextContainer):
         if start_block < 0 or end_block < 0:
             return rc_result
 
+        # todo: use get_prev_iscore?
         iscore, request_block_height = context.storage.rc.get_calc_response_from_rc()
         if iscore == -1:
             return rc_result

--- a/iconservice/icx/issue/regulator.py
+++ b/iconservice/icx/issue/regulator.py
@@ -59,7 +59,8 @@ class Regulator:
         current_calc_period_total_issued_icx: int = regulator_variable.current_calc_period_issued_icx
         current_calc_period_total_issued_icx += issue_amount
         if end_block_height_of_calc == context.block.height:
-            prev_calc_period_issued_iscore: int = context.engine.iiss.get_prev_iscore(context, end_block_height_of_calc)
+            prev_calc_period_issued_iscore: int = \
+                context.engine.iiss.get_prev_period_iscore(context, end_block_height_of_calc)
 
             covered_icx_by_fee, covered_icx_by_remain, remain_over_issued_iscore, corrected_icx_issue_amount = \
                 self._correct_issue_amount_on_calc_period(regulator_variable.prev_calc_period_issued_icx,

--- a/iconservice/icx/issue/regulator.py
+++ b/iconservice/icx/issue/regulator.py
@@ -59,14 +59,8 @@ class Regulator:
         current_calc_period_total_issued_icx: int = regulator_variable.current_calc_period_issued_icx
         current_calc_period_total_issued_icx += issue_amount
         if end_block_height_of_calc == context.block.height:
-            prev_calc_period_issued_iscore, request_block_height = context.storage.rc.get_calc_response_from_rc()
-            calc_period: int = context.storage.iiss.get_calc_period(context)
-            context.engine.iiss.check_calculate_request_block_height(request_block_height,
-                                                                     end_block_height_of_calc,
-                                                                     calc_period)
+            prev_calc_period_issued_iscore: int = context.engine.iiss.get_prev_iscore(context, end_block_height_of_calc)
 
-            if regulator_variable.prev_calc_period_issued_icx == -1:
-                regulator_variable.prev_calc_period_issued_icx, prev_calc_period_issued_iscore = 0, 0
             covered_icx_by_fee, covered_icx_by_remain, remain_over_issued_iscore, corrected_icx_issue_amount = \
                 self._correct_issue_amount_on_calc_period(regulator_variable.prev_calc_period_issued_icx,
                                                           prev_calc_period_issued_iscore,
@@ -167,10 +161,7 @@ class Regulator:
                                              prev_block_cumulative_fee: int) -> Tuple[int, int, int, int]:
         assert icx_issue_amount >= 0
         assert prev_block_cumulative_fee >= 0
-
-        # check if RC has sent response about 'CALCULATE' requests. every period should get response
-        if prev_calc_period_issued_iscore == -1:
-            raise FatalException("There is no prev_calc_period_iscore")
+        assert prev_calc_period_issued_iscore >= 0
 
         # get difference between icon_service and reward_calc after set exchange rates
         prev_calc_over_issued_iscore: int = \

--- a/iconservice/icx/issue/storage.py
+++ b/iconservice/icx/issue/storage.py
@@ -31,7 +31,7 @@ class Storage(StorageBase):
         if regulator_variable:
             return RegulatorVariable.from_bytes(regulator_variable)
         return RegulatorVariable(current_calc_period_issued_icx=0,
-                                 prev_calc_period_issued_icx=-1,
+                                 prev_calc_period_issued_icx=0,
                                  over_issued_iscore=0)
 
     def put_regulator_variable(self, context: 'IconScoreContext', rv: 'RegulatorVariable'):

--- a/iconservice/iiss/engine.py
+++ b/iconservice/iiss/engine.py
@@ -125,16 +125,13 @@ class Engine(EngineBase):
         calc_result_status, calc_result_bh, iscore, state_hash = \
             self._reward_calc_proxy.query_calculate_result(calc_bh)
 
-        # todo: consider when status == 2
         if calc_result_status != RCCalculateResult.SUCCESS and calc_result_status in RCCalculateResult:
             FatalException(f'RC has a problem about calculating: {calc_result_status}')
 
-        # todo: should i consider this condition?
         if calc_result_bh != calc_bh:
             FatalException(f'Unexpected calculate result response '
                            f'(reward calc: {calc_result_bh} icon service: {calc_bh}')
 
-        # todo: should i consider this condition?
         if iscore < 0:
             FatalException(f'Invalid I-SCORE value: {iscore}')
 

--- a/tests/integrate_test/iiss/decentralized/test_base_transaction_validation.py
+++ b/tests/integrate_test/iiss/decentralized/test_base_transaction_validation.py
@@ -376,8 +376,7 @@ class TestIISSBaseTransactionValidation(TestIISSBase):
                          after_treasury_icx_amount - tx_results[-1].cumulative_step_used * tx_results[-1].step_price)
 
     def test_validate_base_transaction_value_corrected_issue_amount(self):
-        # arbitrary iscore date
-        calculate_response_iscore_of_last_calc_period = 5000000000000000000000000000
+        calculate_response_iscore_of_last_calc_period = 0
 
         prev_cumulative_fee = 1000000000000000
 
@@ -386,9 +385,9 @@ class TestIISSBaseTransactionValidation(TestIISSBase):
             end_block_height_of_calc: int = context.storage.iiss.get_end_block_height_of_calc(context)
             calc_period: int = context.storage.iiss.get_calc_period(context)
             response = CalculateDoneNotification(0, True,
-                                         end_block_height_of_calc - calc_period,
-                                         calculate_response_iscore_of_last_calc_period,
-                                         b'mocked_response')
+                                                 end_block_height_of_calc - calc_period,
+                                                 calculate_response_iscore_of_last_calc_period,
+                                                 b'mocked_response')
             print(f"calculate request block height: {end_block_height_of_calc - calc_period}")
             _self._calculate_done_callback(response)
 
@@ -417,7 +416,7 @@ class TestIISSBaseTransactionValidation(TestIISSBase):
                 end_block_height_of_calc: int = context.storage.iiss.get_end_block_height_of_calc(context)
                 calc_period: int = context.storage.iiss.get_calc_period(context)
                 response = CalculateDoneNotification(0, True, end_block_height_of_calc - calc_period, response_iscore,
-                                             b'mocked_response')
+                                                     b'mocked_response')
                 print(f"calculate request block height: {end_block_height_of_calc - calc_period}")
                 _self._calculate_done_callback(response)
 
@@ -465,9 +464,9 @@ class TestIISSBaseTransactionValidation(TestIISSBase):
         def mock_calculated(_self, _path, _block_height):
             invalid_block_height: int = 0
             response = CalculateDoneNotification(0, True,
-                                         invalid_block_height,
-                                         0,
-                                         b'mocked_response')
+                                                 invalid_block_height,
+                                                 0,
+                                                 b'mocked_response')
             _self._calculate_done_callback(response)
 
         self._mock_ipc(mock_calculated)
@@ -478,9 +477,9 @@ class TestIISSBaseTransactionValidation(TestIISSBase):
     def test_calculate_response_fails(self):
         def mock_calculated(_self, _path, _block_height):
             response = CalculateDoneNotification(0, False,
-                                         0,
-                                         0,
-                                         b'mocked_response')
+                                                 0,
+                                                 0,
+                                                 b'mocked_response')
             _self._calculate_done_callback(response)
 
         self._mock_ipc(mock_calculated)


### PR DESCRIPTION
1. Implement get_prev_iscore method on iiss engine.
this method check and return the iscore (from RC)

2. Fix the unit tests
As the logic has been changed, the unit test also has been changed. The point is making logic no difference in the first calculate period. (i.e. do not check the prev_calc_issued_icx == -1)
