### PR TITLE
IS-801: Improve calculate communication between iconservice and reward calculator

### DIFF
--- a/iconservice/icon_constant.py
+++ b/iconservice/icon_constant.py
@@ -286,6 +286,13 @@ class RCStatus(IntEnum):
     READY = 1
 
 
+class RCCalculateResult(IntEnum):
+    SUCCESS = 0
+    FAIL = 1
+    IN_PROGRESS = 2
+    INVALID_BLOCK_HEIGHT = 3
+
+
 class PRepStatus(Enum):
     ACTIVE = 0
     UNREGISTERED = auto()

--- a/iconservice/icx/issue/regulator.py
+++ b/iconservice/icx/issue/regulator.py
@@ -59,11 +59,8 @@ class Regulator:
         current_calc_period_total_issued_icx: int = regulator_variable.current_calc_period_issued_icx
         current_calc_period_total_issued_icx += issue_amount
         if end_block_height_of_calc == context.block.height:
-            prev_calc_period_issued_iscore, request_block_height = context.storage.rc.get_calc_response_from_rc()
-            calc_period: int = context.storage.iiss.get_calc_period(context)
-            context.engine.iiss.check_calculate_request_block_height(request_block_height,
-                                                                     end_block_height_of_calc,
-                                                                     calc_period)
+            prev_calc_period_issued_iscore: int = \
+                context.engine.iiss.get_prev_period_iscore(context, end_block_height_of_calc)
 
             if regulator_variable.prev_calc_period_issued_icx == -1:
                 regulator_variable.prev_calc_period_issued_icx, prev_calc_period_issued_iscore = 0, 0
@@ -167,10 +164,7 @@ class Regulator:
                                              prev_block_cumulative_fee: int) -> Tuple[int, int, int, int]:
         assert icx_issue_amount >= 0
         assert prev_block_cumulative_fee >= 0
-
-        # check if RC has sent response about 'CALCULATE' requests. every period should get response
-        if prev_calc_period_issued_iscore == -1:
-            raise FatalException("There is no prev_calc_period_iscore")
+        assert prev_calc_period_issued_iscore >= 0
 
         # get difference between icon_service and reward_calc after set exchange rates
         prev_calc_over_issued_iscore: int = \

--- a/iconservice/iiss/engine.py
+++ b/iconservice/iiss/engine.py
@@ -29,7 +29,7 @@ from ..base.exception import \
 from ..base.type_converter import TypeConverter
 from ..base.type_converter_templates import ConstantKeys, ParamType
 from ..icon_constant import IISS_MAX_DELEGATIONS, ISCORE_EXCHANGE_RATE, IISS_MAX_REWARD_RATE, \
-    IconScoreContextType, IISS_LOG_TAG
+    IconScoreContextType, IISS_LOG_TAG, RCCalculateResult
 from ..iconscore.icon_score_context import IconScoreContext
 from ..iconscore.icon_score_event_log import EventLogEmitter
 from ..icx import Intent
@@ -105,18 +105,55 @@ class Engine(EngineBase):
     def is_reward_calculator_ready(self):
         return self._reward_calc_proxy.is_reward_calculator_ready()
 
-    @staticmethod
-    def check_calculate_request_block_height(response_block_height: int,
-                                             current_end_block_height_of_calc: int,
-                                             calc_period: int):
-        prev_calc_end_block_height = current_end_block_height_of_calc - calc_period
+    def get_prev_period_iscore(self,
+                               context: 'IconScoreContext',
+                               end_block_height_of_calc: Optional[int] = None) -> int:
+        Logger.debug(tag=_TAG, msg=f"get_prev_period_iscore start")
+        iscore, rc_latest_calculate_bh = context.storage.rc.get_calc_response_from_rc()
+        if end_block_height_of_calc is None:
+            end_block_height_of_calc: int = context.storage.iiss.get_end_block_height_of_calc(context)
+        calc_period: int = context.storage.iiss.get_calc_period(context)
+        latest_calculate_bh: int = end_block_height_of_calc - calc_period
 
-        if response_block_height != prev_calc_end_block_height:
+        # Check if the response has been received
+        if iscore == -1:
+            iscore: int = self._query_calculate_result(latest_calculate_bh)
+        else:
+            context.engine.iiss.check_calculate_request_block_height(rc_latest_calculate_bh,
+                                                                     latest_calculate_bh)
+        Logger.debug(tag=_TAG, msg=f"get_prev_period_iscore end with {iscore}")
+        return iscore
+
+    def _query_calculate_result(self, calc_bh: int) -> int:
+        Logger.debug(tag=_TAG, msg=f"_query_calculate_result start")
+        calc_result_status, calc_result_bh, iscore, state_hash = \
+            self._reward_calc_proxy.query_calculate_result(calc_bh)
+
+        if calc_result_status != RCCalculateResult.SUCCESS and calc_result_status in RCCalculateResult:
+            FatalException(f'RC has a problem about calculating: {calc_result_status}')
+
+        if calc_result_bh != calc_bh:
+            FatalException(f'Unexpected calculate result response '
+                           f'(reward calc: {calc_result_bh} icon service: {calc_bh}')
+
+        if iscore < 0:
+            FatalException(f'Invalid I-SCORE value: {iscore}')
+        Logger.debug(tag=_TAG, msg=f"_query_calculate_result end with "
+                                   f"status:{calc_result_status} calc_result_bh: {calc_result_bh} iscore: {iscore}")
+
+        return iscore
+
+    @staticmethod
+    def check_calculate_request_block_height(reward_calc_bh: int,
+                                             icon_service_bh: int):
+
+        if reward_calc_bh != icon_service_bh:
             raise FatalException(f"request block height is not matched: "
-                                 f"response from RC:{response_block_height} "
-                                 f"request:{prev_calc_end_block_height} ")
+                                 f"response from RC:{reward_calc_bh} "
+                                 f"request:{reward_calc_bh} ")
 
     def calculate_done_callback(self, cb_data: 'CalculateDoneNotification'):
+        Logger.debug(tag=_TAG, msg=f"calculate_done_callback start")
         # cb_data.success == False: RC has reset the state to before 'CALCULATE' request
         if not cb_data.success:
             raise FatalException(f"Reward calc has failed calculating about block height:{cb_data.block_height}")
@@ -125,7 +162,9 @@ class Engine(EngineBase):
         context: 'IconScoreContext' = IconScoreContext(IconScoreContextType.QUERY)
         end_block_height_of_calc: int = context.storage.iiss.get_end_block_height_of_calc(context)
         calc_period: int = context.storage.iiss.get_calc_period(context)
-        self.check_calculate_request_block_height(cb_data.block_height, end_block_height_of_calc, calc_period)
+
+        latest_calculate_bh: int = end_block_height_of_calc - calc_period
+        self.check_calculate_request_block_height(cb_data.block_height, latest_calculate_bh)
 
         IconScoreContext.storage.rc.put_calc_response_from_rc(cb_data.iscore, cb_data.block_height)
         Logger.debug(tag=_TAG, msg=f"calculate done callback called with {cb_data}")

--- a/tests/icx/issue/test_issue_regulator.py
+++ b/tests/icx/issue/test_issue_regulator.py
@@ -208,22 +208,23 @@ class TestIssueRegulator:
         assert covered_icx_by_fee == 0
         assert corrected_icx_issue_amount == icx_issue_amount
 
-    def test_correct_issue_amount_on_calc_period_invalid_scenario(self):
-        # failure case: when prev issued i score is None, should raise error
-
-        prev_calc_period_issued_icx = 1_000
-        prev_calc_period_issued_iscore = -1
-
-        prev_block_cumulative_fee = 0
-        icx_issue_amount = 1000
-        over_issued_i_score = 0
-
-        with pytest.raises(FatalException):
-            Regulator._correct_issue_amount_on_calc_period(prev_calc_period_issued_icx,
-                                                           prev_calc_period_issued_iscore,
-                                                           over_issued_i_score,
-                                                           icx_issue_amount,
-                                                           prev_block_cumulative_fee)
+    # Before, there were case that prev_calc_period_issued_iscore is -1, but now, removed this case
+    # def test_correct_issue_amount_on_calc_period_invalid_scenario(self):
+    #     # failure case: when prev issued i score is None, should raise error
+    #
+    #     prev_calc_period_issued_icx = 1_000
+    #     prev_calc_period_issued_iscore = -1
+    #
+    #     prev_block_cumulative_fee = 0
+    #     icx_issue_amount = 1000
+    #     over_issued_i_score = 0
+    #
+    #     with pytest.raises(FatalException):
+    #         Regulator._correct_issue_amount_on_calc_period(prev_calc_period_issued_icx,
+    #                                                        prev_calc_period_issued_iscore,
+    #                                                        over_issued_i_score,
+    #                                                        icx_issue_amount,
+    #                                                        prev_block_cumulative_fee)
 
     def test_correct_issue_amount_on_calc_period_prev_icx_is_more_than_prev_i_score(self):
         # success case: when remain over issued icx + prev calc over issued icx < icx_issue amount
@@ -393,9 +394,9 @@ class TestIssueRegulator:
         issue_amount = 10_000
         mocked_context_storage.icx.last_block.cumulative_fee = cumulative_fee
         mocked_context_engine.prep.term.sequence = 0
+        mocked_context_engine.iiss.get_prev_period_iscore = Mock(return_value=0)
         mocked_context_storage.iiss.get_end_block_height_of_calc = Mock(return_value=block_height)
         mocked_context_storage.issue.get_regulator_variable = Mock(return_value=rv)
-        mocked_context_storage.rc.get_calc_response_from_rc = Mock(return_value=(0, 0))
         regulator = Regulator(self.context, issue_amount)
 
         actual_current_icx = regulator._regulator_variable.current_calc_period_issued_icx
@@ -429,9 +430,9 @@ class TestIssueRegulator:
 
         mocked_context_storage.icx.last_block.cumulative_fee = cumulative_fee
         mocked_context_engine.prep.term.sequence = 0
+        mocked_context_engine.iiss.get_prev_period_iscore = Mock(return_value=prev_calc_period_issued_iscore)
         mocked_context_storage.iiss.get_end_block_height_of_calc = Mock(return_value=block_height)
         mocked_context_storage.issue.get_regulator_variable = Mock(return_value=rv)
-        mocked_context_storage.rc.get_calc_response_from_rc = Mock(return_value=(prev_calc_period_issued_iscore, 0))
         regulator = Regulator(self.context, issue_amount)
 
         assert regulator._regulator_variable.prev_calc_period_issued_icx == issue_amount + current_calc_preiod_issued_icx

--- a/tests/integrate_test/iiss/decentralized/test_base_transaction_validation.py
+++ b/tests/integrate_test/iiss/decentralized/test_base_transaction_validation.py
@@ -386,9 +386,9 @@ class TestIISSBaseTransactionValidation(TestIISSBase):
             end_block_height_of_calc: int = context.storage.iiss.get_end_block_height_of_calc(context)
             calc_period: int = context.storage.iiss.get_calc_period(context)
             response = CalculateDoneNotification(0, True,
-                                         end_block_height_of_calc - calc_period,
-                                         calculate_response_iscore_of_last_calc_period,
-                                         b'mocked_response')
+                                                 end_block_height_of_calc - calc_period,
+                                                 calculate_response_iscore_of_last_calc_period,
+                                                 b'mocked_response')
             print(f"calculate request block height: {end_block_height_of_calc - calc_period}")
             _self._calculate_done_callback(response)
 
@@ -417,7 +417,7 @@ class TestIISSBaseTransactionValidation(TestIISSBase):
                 end_block_height_of_calc: int = context.storage.iiss.get_end_block_height_of_calc(context)
                 calc_period: int = context.storage.iiss.get_calc_period(context)
                 response = CalculateDoneNotification(0, True, end_block_height_of_calc - calc_period, response_iscore,
-                                             b'mocked_response')
+                                                     b'mocked_response')
                 print(f"calculate request block height: {end_block_height_of_calc - calc_period}")
                 _self._calculate_done_callback(response)
 
@@ -465,9 +465,9 @@ class TestIISSBaseTransactionValidation(TestIISSBase):
         def mock_calculated(_self, _path, _block_height):
             invalid_block_height: int = 0
             response = CalculateDoneNotification(0, True,
-                                         invalid_block_height,
-                                         0,
-                                         b'mocked_response')
+                                                 invalid_block_height,
+                                                 0,
+                                                 b'mocked_response')
             _self._calculate_done_callback(response)
 
         self._mock_ipc(mock_calculated)
@@ -478,9 +478,9 @@ class TestIISSBaseTransactionValidation(TestIISSBase):
     def test_calculate_response_fails(self):
         def mock_calculated(_self, _path, _block_height):
             response = CalculateDoneNotification(0, False,
-                                         0,
-                                         0,
-                                         b'mocked_response')
+                                                 0,
+                                                 0,
+                                                 b'mocked_response')
             _self._calculate_done_callback(response)
 
         self._mock_ipc(mock_calculated)


### PR DESCRIPTION
Implement get_prev_iscore method on iiss engine.
this method check and return the iscore (from RC)

Fix the unit tests
As the logic has been changed, the unit test also has been changed. The point is making logic no difference in the first calculate period. (i.e. do not check the prev_calc_issued_icx == -1)
