### PR TITLE
IS-914: bugfix query_iscore

### DIFF
--- a/iconservice/iiss/engine.py
+++ b/iconservice/iiss/engine.py
@@ -660,7 +660,7 @@ class Engine(EngineBase):
                             _context: 'IconScoreContext',
                             params: dict) -> dict:
         ret_params: dict = TypeConverter.convert(params, ParamType.IISS_QUERY_ISCORE)
-        address: 'Address' = ret_params[ConstantKeys.ADDRESS]
+        address: 'Address' = ret_params.get(ConstantKeys.ADDRESS)
 
         if not isinstance(address, Address):
             raise InvalidParamsException(f"Invalid address: {address}")

--- a/iconservice/iiss/engine.py
+++ b/iconservice/iiss/engine.py
@@ -662,6 +662,9 @@ class Engine(EngineBase):
         ret_params: dict = TypeConverter.convert(params, ParamType.IISS_QUERY_ISCORE)
         address: 'Address' = ret_params[ConstantKeys.ADDRESS]
 
+        if not isinstance(address, Address):
+            raise InvalidParamsException(f"Invalid address: {address}")
+
         # TODO: error handling
         iscore, block_height = self._reward_calc_proxy.query_iscore(address)
 

--- a/iconservice/iiss/reward_calc/ipc/message.py
+++ b/iconservice/iiss/reward_calc/ipc/message.py
@@ -275,6 +275,9 @@ class QueryCalculateResultResponse(Response):
 
 
 class QueryRequest(Request):
+    """queryIScore
+    """
+
     def __init__(self, address: 'Address'):
         super().__init__(MessageType.QUERY)
 

--- a/iconservice/iiss/reward_calc/ipc/reward_calc_proxy.py
+++ b/iconservice/iiss/reward_calc/ipc/reward_calc_proxy.py
@@ -252,6 +252,8 @@ class RewardCalcProxy(object):
         :return: [i-score(int), block_height(int)]
         :exception TimeoutException: The operation has timed-out
         """
+        assert isinstance(address, Address)
+
         Logger.debug(tag=_TAG, msg="query_iscore() start")
 
         future: concurrent.futures.Future = asyncio.run_coroutine_threadsafe(

--- a/tests/integrate_test/iiss/test_iiss_base.py
+++ b/tests/integrate_test/iiss/test_iiss_base.py
@@ -329,8 +329,8 @@ class TestIISSBase(TestIntegrateBase):
         return self._query(query_request)
 
     def query_iscore(self,
-                     from_: Union['EOAAccount', 'Address', str]) -> dict:
-        address: Optional['Address'] = self._convert_address_from_address_type(from_)
+                     address: Union['EOAAccount', 'Address', str]) -> dict:
+        address: Optional['Address'] = self._convert_address_from_address_type(address)
 
         query_request = {
             "version": self._version,


### PR DESCRIPTION
* Invalid address of queryIScore causes RewardCalcProxy._on_send() to crash
* Add address format sanity check for queryIScore
* Catch exceptions in Server._on_send() to keep ipc sender alive
* Catch exceptions in Server._on_recv() to keep ipc receiver alive
* Add task_done() to MessageQueue
* Add an unittest for queryIScore with invalid params