### PR TITLE
IS-923: Add P-Rep candidates to the result of getPRepTerm API

### DIFF
--- a/iconservice/prep/data/prep_container.py
+++ b/iconservice/prep/data/prep_container.py
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Optional, Iterator
+from typing import List, Optional
 
 from iconcommons import Logger
 
-from .prep import PRep, PRepFlag, PRepStatus, PenaltyReason
+from .prep import PRep, PRepFlag, PRepStatus
 from .sorted_list import SortedList
 from ... import utils
 from ...base.address import Address
@@ -195,13 +195,6 @@ class PRepContainer(object):
         """
         return self._active_prep_list[start_index:start_index + size]
 
-    def get_inactive_preps(self) -> Iterator['PRep']:
-        """Returns inactive P-Reps including P-Reps receiving a block validation penalty
-
-        :return: iterator including invalid preps
-        """
-        return filter(self._is_inactive, self._prep_dict.values())
-
     def index(self, address: 'Address') -> int:
         """Returns the index of a given address in active_prep_list
 
@@ -234,12 +227,3 @@ class PRepContainer(object):
     def _check_access_permission(self):
         if self.is_frozen():
             raise AccessDeniedException("PRepContainer access denied")
-
-    @staticmethod
-    def _is_inactive(prep: 'PRep'):
-        """
-        Return bool value if the P-Rep is inactive including the P-Rep receiving a block validation penalty
-
-        :return: bool
-        """
-        return prep.status != PRepStatus.ACTIVE or prep.penalty == PenaltyReason.BLOCK_VALIDATION

--- a/iconservice/prep/data/prep_container.py
+++ b/iconservice/prep/data/prep_container.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Optional
+from typing import List, Optional, Iterator
 
 from iconcommons import Logger
 
@@ -195,15 +195,12 @@ class PRepContainer(object):
         """
         return self._active_prep_list[start_index:start_index + size]
 
-    def get_inactive_preps(self) -> List['PRep']:
+    def get_inactive_preps(self) -> Iterator['PRep']:
         """Returns inactive P-Reps including P-Reps receiving a block validation penalty
 
-        :return: inactive P-Reps sorted by penalty value and delegated amount
+        :return: iterator including invalid preps
         """
-        inactive_prep_list = [prep for prep in self._prep_dict.values() if self._is_inactive(prep)]
-        sorted_inactive_prep_list = sorted(inactive_prep_list, key=lambda x: (x.penalty.value, x.delegated),
-                                           reverse=True)
-        return sorted_inactive_prep_list
+        return filter(self._is_inactive, self._prep_dict.values())
 
     def index(self, address: 'Address') -> int:
         """Returns the index of a given address in active_prep_list

--- a/iconservice/prep/data/prep_container.py
+++ b/iconservice/prep/data/prep_container.py
@@ -20,9 +20,9 @@ from iconcommons import Logger
 
 from .prep import PRep, PRepFlag, PRepStatus
 from .sorted_list import SortedList
+from ... import utils
 from ...base.address import Address
 from ...base.exception import InvalidParamsException, AccessDeniedException
-from ... import utils
 
 
 class PRepContainer(object):
@@ -194,6 +194,20 @@ class PRepContainer(object):
         :return: P-Rep list
         """
         return self._active_prep_list[start_index:start_index + size]
+
+    def get_inactive_preps(self) -> List['PRep']:
+        """Returns inactive P-Reps which status is in UNREGISTERED or DISQUALIFIED
+
+        :return: inactive P-Rep list sorted by penalty value and delegated amount
+        """
+        inactive_prep_list = []
+        for prep in self._prep_dict.values():
+            if prep not in self._active_prep_list:
+                inactive_prep_list.append(prep)
+
+        sorted_inactive_prep_list = sorted(inactive_prep_list, key=lambda x: (x.penalty.value, x.delegated),
+                                           reverse=True)
+        return sorted_inactive_prep_list
 
     def index(self, address: 'Address') -> int:
         """Returns the index of a given address in active_prep_list

--- a/iconservice/prep/engine.py
+++ b/iconservice/prep/engine.py
@@ -15,6 +15,7 @@
 from typing import TYPE_CHECKING, Any, Optional, List, Dict, Tuple
 
 from iconcommons.logger import Logger
+
 from .data import Term
 from .data.prep import PRep, PRepDictType
 from .data.prep_container import PRepContainer
@@ -839,6 +840,9 @@ class Engine(EngineBase, IISSEngineListener):
             #         "p2pEndpoint": prep.p2p_endpoint
             #     }
             # )
+
+        for inactive_prep in self.preps.get_inactive_preps():
+            preps_data.append(inactive_prep.to_dict(PRepDictType.FULL))
 
         return {
             "blockHeight": context.block.height,

--- a/iconservice/prep/engine.py
+++ b/iconservice/prep/engine.py
@@ -830,18 +830,9 @@ class Engine(EngineBase, IISSEngineListener):
             prep = self.preps.get_by_address(prep_snapshot.address)
             preps_data.append(prep.to_dict(PRepDictType.FULL))
 
-            # preps_data.append(
-            #     {
-            #         "name": prep.name,
-            #         "country": prep.country,
-            #         "city": prep.city,
-            #         "grade": prep.grade.value,
-            #         "address": prep.address,
-            #         "p2pEndpoint": prep.p2p_endpoint
-            #     }
-            # )
-
-        for inactive_prep in self.preps.get_inactive_preps():
+        sorted_inactive_preps: List['PRep'] = \
+            sorted(self.preps.get_inactive_preps(), key=lambda x: x.name)
+        for inactive_prep in sorted_inactive_preps:
             preps_data.append(inactive_prep.to_dict(PRepDictType.FULL))
 
         return {

--- a/tests/integrate_test/iiss/decentralized/test_in_term_prep_replacement.py
+++ b/tests/integrate_test/iiss/decentralized/test_in_term_prep_replacement.py
@@ -74,7 +74,7 @@ class TestPreps(TestIISSBase):
     LOW_PRODUCTIVITY_PENALTY_THRESHOLD = 80
     PENALTY_GRACE_PERIOD = CALCULATE_PERIOD * 2 + BLOCK_VALIDATION_PENALTY_THRESHOLD
 
-    def _check_preps_on_get_prep_term(self, added_inactive_preps: list):
+    def _check_preps_on_get_prep_term(self, added_inactive_preps: List[Dict[str, str]]):
         """
         Return bool value
         checking if not only main P-Reps and sub ones but input added inactive preps are preps of 'getPRepTerm' API
@@ -89,7 +89,9 @@ class TestPreps(TestIISSBase):
         expected_preps = []
         for prep in tmp_preps:
             expected_preps.append(self.get_prep(prep["address"]))
-        expected_preps.extend(added_inactive_preps)
+
+        sorted_inactive_preps = sorted(added_inactive_preps, key=lambda x: x["name"])
+        expected_preps.extend(sorted_inactive_preps)
         assert expected_preps == preps
 
     def _make_init_config(self) -> dict:
@@ -224,6 +226,7 @@ class TestPreps(TestIISSBase):
         assert term_4["sequence"] == 4
         preps = term_4["preps"]
 
+        # A main P-Rep got penalized for consecutive 660 block validation failure
         _check_elected_prep_grades(preps, main_prep_count, elected_prep_count - 1)
         main_preps_4: List['Address'] = _get_main_preps(preps, main_prep_count)
 
@@ -236,8 +239,8 @@ class TestPreps(TestIISSBase):
         assert prep_on_penalty["penalty"] == PenaltyReason.BLOCK_VALIDATION.value
         assert prep_on_penalty["unvalidatedSequenceBlocks"] == self.BLOCK_VALIDATION_PENALTY_THRESHOLD + 1
         assert prep_on_penalty["totalBlocks"] == \
-               prep_on_penalty["validatedBlocks"] + \
-               prep_on_penalty["unvalidatedSequenceBlocks"]
+            prep_on_penalty["validatedBlocks"] + \
+            prep_on_penalty["unvalidatedSequenceBlocks"]
 
         # checks if adding the prep receiving a block validation penalty on preps of getPRepTerm API
         self._check_preps_on_get_prep_term([prep_on_penalty])
@@ -332,7 +335,7 @@ class TestPreps(TestIISSBase):
         assert prep_on_penalty["unvalidatedSequenceBlocks"] == 2
         assert prep_on_penalty["grade"] == PRepGrade.CANDIDATE.value
         assert prep_on_penalty["validatedBlocks"] * 100 // prep_on_penalty["totalBlocks"] < \
-               self.LOW_PRODUCTIVITY_PENALTY_THRESHOLD
+            self.LOW_PRODUCTIVITY_PENALTY_THRESHOLD
 
         term_6 = self.get_prep_term()
         preps = term_6["preps"]

--- a/tests/integrate_test/iiss/decentralized/test_in_term_prep_replacement.py
+++ b/tests/integrate_test/iiss/decentralized/test_in_term_prep_replacement.py
@@ -14,7 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""IconScoreEngine testcase
+"""
+IconScoreEngine Test Cases
+Added checking if getPRepTerm API returns not only main and sub P-Reps but inactive ones.
+
 """
 from enum import Enum
 from typing import TYPE_CHECKING, List, Dict
@@ -70,6 +73,24 @@ class TestPreps(TestIISSBase):
     BLOCK_VALIDATION_PENALTY_THRESHOLD = 10
     LOW_PRODUCTIVITY_PENALTY_THRESHOLD = 80
     PENALTY_GRACE_PERIOD = CALCULATE_PERIOD * 2 + BLOCK_VALIDATION_PENALTY_THRESHOLD
+
+    def _check_preps_on_get_prep_term(self, added_inactive_preps: list):
+        """
+        Return bool value
+        checking if not only main P-Reps and sub ones but input added inactive preps are preps of 'getPRepTerm' API
+
+        :param added_inactive_preps: expected added inactive prep list
+        :return: bool
+        """
+        preps = self.get_prep_term()["preps"]
+        main_preps = self.get_main_prep_list()["preps"]
+        sub_preps = self.get_sub_prep_list()["preps"]
+        tmp_preps = main_preps + sub_preps
+        expected_preps = []
+        for prep in tmp_preps:
+            expected_preps.append(self.get_prep(prep["address"]))
+        expected_preps.extend(added_inactive_preps)
+        assert expected_preps == preps
 
     def _make_init_config(self) -> dict:
         return {
@@ -157,6 +178,7 @@ class TestPreps(TestIISSBase):
         term_3: dict = self.get_prep_term()
         assert term_3["sequence"] == 3
         preps = term_3["preps"]
+
         _check_elected_prep_grades(preps, main_prep_count, elected_prep_count)
         main_preps_3: List['Address'] = _get_main_preps(preps, main_prep_count)
 
@@ -184,6 +206,7 @@ class TestPreps(TestIISSBase):
         term_4: dict = self.get_prep_term()
         assert term_4["sequence"] == 4
         preps = term_4["preps"]
+
         _check_elected_prep_grades(preps, main_prep_count, elected_prep_count)
         main_preps_4: List['Address'] = _get_main_preps(preps, main_prep_count)
         assert main_preps_3 == main_preps_4
@@ -200,20 +223,24 @@ class TestPreps(TestIISSBase):
         term_4: dict = self.get_prep_term()
         assert term_4["sequence"] == 4
         preps = term_4["preps"]
-        _check_elected_prep_grades(preps, main_prep_count, elected_prep_count)
+
+        _check_elected_prep_grades(preps, main_prep_count, elected_prep_count - 1)
         main_preps_4: List['Address'] = _get_main_preps(preps, main_prep_count)
 
         # The first sub P-Rep replaced the the second main P-Rep
         assert main_preps_4[1] == accounts[main_prep_count].address
         assert main_preps_4[1] != account_on_block_validation_penalty
-
         prep_on_penalty: dict = self.get_prep(account_on_block_validation_penalty.address)
+
         assert prep_on_penalty["status"] == PRepStatus.ACTIVE.value
         assert prep_on_penalty["penalty"] == PenaltyReason.BLOCK_VALIDATION.value
         assert prep_on_penalty["unvalidatedSequenceBlocks"] == self.BLOCK_VALIDATION_PENALTY_THRESHOLD + 1
         assert prep_on_penalty["totalBlocks"] == \
-            prep_on_penalty["validatedBlocks"] + \
-            prep_on_penalty["unvalidatedSequenceBlocks"]
+               prep_on_penalty["validatedBlocks"] + \
+               prep_on_penalty["unvalidatedSequenceBlocks"]
+
+        # checks if adding the prep receiving a block validation penalty on preps of getPRepTerm API
+        self._check_preps_on_get_prep_term([prep_on_penalty])
 
         count = term_4["endBlockHeight"] - term_4["blockHeight"] + 1
         self.make_empty_blocks(
@@ -227,6 +254,7 @@ class TestPreps(TestIISSBase):
         term_5 = self.get_prep_term()
         assert term_5["sequence"] == 5
         preps = term_5["preps"]
+
         _check_elected_prep_grades(preps, main_prep_count, elected_prep_count)
         main_preps_5: List['Address'] = _get_main_preps(preps, main_prep_count)
         assert main_preps_5[1] == account_on_block_validation_penalty.address
@@ -261,7 +289,11 @@ class TestPreps(TestIISSBase):
 
         term_5 = self.get_prep_term()
         preps = term_5["preps"]
-        _check_elected_prep_grades(preps, main_prep_count, elected_prep_count)
+
+        # checks if adding the unregistered prep on preps of getPRepTerm API (1)
+        self._check_preps_on_get_prep_term([unregistered_prep])
+
+        _check_elected_prep_grades(preps, main_prep_count, elected_prep_count - 1)
         main_preps_5: List['Address'] = _get_main_preps(preps, main_prep_count)
 
         assert preps[index]["address"] != unregistered_account.address
@@ -278,6 +310,10 @@ class TestPreps(TestIISSBase):
         term_6 = self.get_prep_term()
         assert term_6["sequence"] == 6
         preps = term_6["preps"]
+
+        # checks if adding the unregistered prep on preps of getPRepTerm API (2)
+        self._check_preps_on_get_prep_term([unregistered_prep])
+
         _check_elected_prep_grades(preps, main_prep_count, elected_prep_count)
         main_preps_6: List['Address'] = _get_main_preps(preps, main_prep_count)
 
@@ -296,11 +332,15 @@ class TestPreps(TestIISSBase):
         assert prep_on_penalty["unvalidatedSequenceBlocks"] == 2
         assert prep_on_penalty["grade"] == PRepGrade.CANDIDATE.value
         assert prep_on_penalty["validatedBlocks"] * 100 // prep_on_penalty["totalBlocks"] < \
-            self.LOW_PRODUCTIVITY_PENALTY_THRESHOLD
+               self.LOW_PRODUCTIVITY_PENALTY_THRESHOLD
 
         term_6 = self.get_prep_term()
         preps = term_6["preps"]
-        _check_elected_prep_grades(preps, main_prep_count, elected_prep_count)
+
+        # checks if adding the prep receiving a low productivity penalty on preps of getPRepTerm API
+        self._check_preps_on_get_prep_term([prep_on_penalty, unregistered_prep])
+
+        _check_elected_prep_grades(preps, main_prep_count, elected_prep_count - 1)
         main_preps_6: List['Address'] = _get_main_preps(preps, main_prep_count)
         assert main_preps_6[1] != account_on_low_productivity_penalty.address
         assert main_preps_6[1] == accounts[main_prep_count + 1].address
@@ -316,6 +356,7 @@ class TestPreps(TestIISSBase):
         term_7 = self.get_prep_term()
         assert term_7["sequence"] == 7
         preps = term_7["preps"]
+
         _check_elected_prep_grades(preps, main_prep_count, elected_prep_count)
         main_preps_7: List['Address'] = _get_main_preps(preps, main_prep_count)
 
@@ -343,15 +384,19 @@ class TestPreps(TestIISSBase):
         )
         assert tx_results[-1].status == TransactionResult.FAILURE
 
-        prep_on_penalty = self.get_prep(account_on_disqualification)
-        assert prep_on_penalty["status"] == PRepStatus.DISQUALIFIED.value
-        assert prep_on_penalty["grade"] == PRepGrade.CANDIDATE.value
-        assert prep_on_penalty["penalty"] == PenaltyReason.PREP_DISQUALIFICATION.value
+        prep_on_disqualification_penalty = self.get_prep(account_on_disqualification)
+        assert prep_on_disqualification_penalty["status"] == PRepStatus.DISQUALIFIED.value
+        assert prep_on_disqualification_penalty["grade"] == PRepGrade.CANDIDATE.value
+        assert prep_on_disqualification_penalty["penalty"] == PenaltyReason.PREP_DISQUALIFICATION.value
 
         term_7_1 = self.get_prep_term()
         assert term_7_1["sequence"] == 7
         preps = term_7_1["preps"]
-        _check_elected_prep_grades(preps, main_prep_count, elected_prep_count)
+
+        # checks if adding the prep receiving a disqualification penalty on preps of getPRepTerm API
+        self._check_preps_on_get_prep_term([prep_on_penalty, prep_on_disqualification_penalty, unregistered_prep])
+
+        _check_elected_prep_grades(preps, main_prep_count, elected_prep_count - 1)
         main_preps_7: List['Address'] = _get_main_preps(preps, main_prep_count)
         assert main_preps_7[-1] != account_on_disqualification.address
         # The first sub P-Rep replaces the main P-Rep which is disqualified by network proposal

--- a/tests/integrate_test/iiss/decentralized/test_in_term_prep_replacement.py
+++ b/tests/integrate_test/iiss/decentralized/test_in_term_prep_replacement.py
@@ -90,8 +90,10 @@ class TestPreps(TestIISSBase):
         for prep in tmp_preps:
             expected_preps.append(self.get_prep(prep["address"]))
 
-        sorted_inactive_preps = sorted(added_inactive_preps, key=lambda x: x["name"])
-        expected_preps.extend(sorted_inactive_preps)
+        preps_on_block_validation_penalty = \
+            sorted(added_inactive_preps,
+                   key=lambda x: (-x["delegated"], x["blockHeight"], x["txIndex"]))
+        expected_preps.extend(preps_on_block_validation_penalty)
         assert expected_preps == preps
 
     def _make_init_config(self) -> dict:
@@ -294,7 +296,7 @@ class TestPreps(TestIISSBase):
         preps = term_5["preps"]
 
         # checks if adding the unregistered prep on preps of getPRepTerm API (1)
-        self._check_preps_on_get_prep_term([unregistered_prep])
+        self._check_preps_on_get_prep_term([])
 
         _check_elected_prep_grades(preps, main_prep_count, elected_prep_count - 1)
         main_preps_5: List['Address'] = _get_main_preps(preps, main_prep_count)
@@ -315,7 +317,7 @@ class TestPreps(TestIISSBase):
         preps = term_6["preps"]
 
         # checks if adding the unregistered prep on preps of getPRepTerm API (2)
-        self._check_preps_on_get_prep_term([unregistered_prep])
+        self._check_preps_on_get_prep_term([])
 
         _check_elected_prep_grades(preps, main_prep_count, elected_prep_count)
         main_preps_6: List['Address'] = _get_main_preps(preps, main_prep_count)
@@ -341,7 +343,7 @@ class TestPreps(TestIISSBase):
         preps = term_6["preps"]
 
         # checks if adding the prep receiving a low productivity penalty on preps of getPRepTerm API
-        self._check_preps_on_get_prep_term([prep_on_penalty, unregistered_prep])
+        self._check_preps_on_get_prep_term([])
 
         _check_elected_prep_grades(preps, main_prep_count, elected_prep_count - 1)
         main_preps_6: List['Address'] = _get_main_preps(preps, main_prep_count)
@@ -397,7 +399,7 @@ class TestPreps(TestIISSBase):
         preps = term_7_1["preps"]
 
         # checks if adding the prep receiving a disqualification penalty on preps of getPRepTerm API
-        self._check_preps_on_get_prep_term([prep_on_penalty, prep_on_disqualification_penalty, unregistered_prep])
+        self._check_preps_on_get_prep_term([])
 
         _check_elected_prep_grades(preps, main_prep_count, elected_prep_count - 1)
         main_preps_7: List['Address'] = _get_main_preps(preps, main_prep_count)


### PR DESCRIPTION
- Add get_inactive_preps on PrepContainer to return inactive P-Rep list sorted by penalty value and delegated amount