### PR TITLE
IS-936: Fix score data corruption on score query call

### DIFF
--- a/iconservice/iconscore/icon_score_engine.py
+++ b/iconservice/iconscore/icon_score_engine.py
@@ -111,7 +111,10 @@ class IconScoreEngine(object):
         context.current_address: 'Address' = icon_score_address
 
         score_func = getattr(icon_score, ATTR_SCORE_CALL)
-        return score_func(func_name=func_name, kw_params=converted_params)
+        ret = score_func(func_name=func_name, kw_params=converted_params)
+
+        # No problem even though ret is None
+        return deepcopy(ret)
 
     @staticmethod
     def _convert_score_params_by_annotations(icon_score: 'IconScoreBase', func_name: str, kw_params: dict) -> dict:

--- a/tests/integrate_test/samples/sample_scores/sample_global_variable_score/global_variable_score.py
+++ b/tests/integrate_test/samples/sample_scores/sample_global_variable_score/global_variable_score.py
@@ -1,0 +1,38 @@
+from iconservice import *
+
+
+GLOBAL_DICT = {"a": 1, "b": [2, 3], "c": {"d": 4}}
+GLOBAL_LIST = [1, {"a": 1}, ["c", 2]]
+GLOBAL_TUPLE = ({"a": 1}, 2, ["c", 2])
+
+
+class GlobalVariableScore(IconScoreBase):
+    """Used to check if global score data is corrupted by calling score query api
+    """
+
+    def __init__(self, db: IconScoreDatabase) -> None:
+        super().__init__(db)
+
+    def on_install(self) -> None:
+        super().on_install()
+
+    def on_update(self) -> None:
+        super().on_update()
+
+    @external(readonly=True)
+    def hello(self) -> str:
+        return "hello"
+
+    @external(readonly=True)
+    def getGlobalDict(self) -> dict:
+        return GLOBAL_DICT
+
+    @external(readonly=True)
+    def getGlobalList(self) -> list:
+        return GLOBAL_LIST
+
+    @external(readonly=True)
+    def getGlobalTuple(self) -> list:
+        """The mismatch of return value type hint is intended for test_integrate_global_variable_score unittest
+        """
+        return GLOBAL_TUPLE

--- a/tests/integrate_test/samples/sample_scores/sample_global_variable_score/package.json
+++ b/tests/integrate_test/samples/sample_scores/sample_global_variable_score/package.json
@@ -1,0 +1,5 @@
+{
+    "version": "0.0.1",
+    "main_file": "global_variable_score",
+    "main_score": "GlobalVariableScore"
+}

--- a/tests/integrate_test/test_integrate_global_variable_score.py
+++ b/tests/integrate_test/test_integrate_global_variable_score.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 ICON Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""IconScoreEngine testcase
+"""
+
+from typing import TYPE_CHECKING, List
+
+from iconservice.icon_inner_service import MakeResponse
+from tests.integrate_test.test_integrate_base import TestIntegrateBase
+
+if TYPE_CHECKING:
+    from iconservice.base.address import Address
+    from iconservice.iconscore.icon_score_result import TransactionResult
+
+
+def _create_query_request(from_: 'Address', to_: 'Address', method: str):
+    return {
+        "version": 3,
+        "from": from_,
+        "to": to_,
+        "dataType": "call",
+        "data": {"method": method}
+    }
+
+
+class TestScoreGlobalVariable(TestIntegrateBase):
+
+    def setUp(self):
+        super().setUp()
+
+        sender: 'Address' = self._accounts[0].address
+
+        tx_results: List['TransactionResult'] = self.deploy_score(
+            score_root="sample_scores",
+            score_name="sample_global_variable_score",
+            from_=sender,
+            expected_status=True)
+        score_address: 'Address' = tx_results[0].score_address
+
+        request = _create_query_request(sender, score_address, "hello")
+        response = self._query(request)
+        self.assertEqual(response, "hello")
+
+        self.sender = sender
+        self.score_address = score_address
+
+    def _create_query_request(self, method: str):
+        return _create_query_request(self.sender, self.score_address, method)
+
+    def test_global_dict(self):
+        expected_response = {"a": 1, "b": [2, 3], "c": {"d": 4}}
+        expected_converted_response = {"a": "0x1", "b": ["0x2", "0x3"], "c": {"d": "0x4"}}
+        request: dict = self._create_query_request("getGlobalDict")
+
+        # First score call for query
+        response_0 = self._query(request)
+        assert isinstance(response_0, dict)
+        assert response_0 == expected_response
+
+        # make_response() does in-place value type conversion in response_0
+        converted_response = MakeResponse.make_response(response_0)
+        assert converted_response == expected_converted_response
+        assert response_0 != expected_response
+        assert id(converted_response) == id(response_0)
+
+        # Check if the response is deeply copied on every query call
+        response_1: dict = self._query(request)
+        assert isinstance(response_1, dict)
+        assert id(response_1) != id(response_0)
+        assert response_1 == expected_response
+
+    def test_global_list(self):
+        expected_response = [1, {"a": 1}, ["c", 2]]
+        expected_converted_response = ["0x1", {"a": "0x1"}, ["c", "0x2"]]
+        request: dict = self._create_query_request("getGlobalList")
+
+        # First score call for query
+        response_0: list = self._query(request)
+        assert isinstance(response_0, list)
+        assert response_0 == expected_response
+
+        # Check if the response is deeply copied on every query call
+        converted_response = MakeResponse.make_response(response_0)
+        assert converted_response == expected_converted_response
+        assert id(converted_response) == id(response_0)
+
+        response_1 = self._query(request)
+        assert isinstance(response_1, list)
+        assert id(response_1) != id(response_0)
+        assert response_1 == expected_response
+
+    def test_global_tuple(self):
+        expected_response = ({"a": 1}, 2, ["c", 2])
+        request: dict = self._create_query_request("getGlobalTuple")
+
+        # First score call for query
+        response_0: tuple = self._query(request)
+        assert isinstance(response_0, tuple)
+        assert response_0 == expected_response
+
+        converted_response = MakeResponse.make_response(response_0)
+        assert converted_response == expected_response
+        assert response_0 == expected_response
+        assert id(converted_response) == id(response_0)
+
+        response_1 = self._query(request)
+        assert isinstance(response_1, tuple)
+        assert id(response_1) != id(response_0)
+        assert response_1 == expected_response


### PR DESCRIPTION
* Deepcopy the return value of score query call to prevent score data corruption
* Add a unittest for global score data corruption