### PR TITLE
IS-854: Optimize context.term duplication

### DIFF
--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -782,9 +782,6 @@ class IconServiceEngine(ContextContainer):
 
         if main_prep_as_dict is not None:
             Logger.info(tag="TERM", msg=f"{main_prep_as_dict}")
-        context.preps.freeze()
-        if context.term:
-            context.term.freeze()
 
         return main_prep_as_dict, term, rc_state_hash
 

--- a/iconservice/iconscore/icon_score_context.py
+++ b/iconservice/iconscore/icon_score_context.py
@@ -240,16 +240,6 @@ class IconScoreContext(object):
 
         self._tx_dirty_preps.clear()
 
-    def _replace_prep(self, dirty_prep: 'PRep'):
-        """Replace the old P-Rep instance in self._preps with a new one(=dirty prep)
-
-        Assume that this method should be called on invoke process
-
-        :param dirty_prep: changed P-Rep instance
-        :return:
-        """
-        self._preps.replace(dirty_prep)
-
     def _update_term(self, dirty_prep: 'PRep'):
         """Update term info with dirty_prep
 

--- a/iconservice/iconscore/icon_score_context.py
+++ b/iconservice/iconscore/icon_score_context.py
@@ -24,7 +24,7 @@ from iconcommons.logger import Logger
 from .icon_score_mapper import IconScoreMapper
 from .icon_score_trace import Trace
 from ..base.block import Block
-from ..base.exception import FatalException
+from ..base.exception import FatalException, AccessDeniedException
 from ..base.message import Message
 from ..base.transaction import Transaction
 from ..database.batch import BlockBatch, TransactionBatch
@@ -230,12 +230,9 @@ class IconScoreContext(object):
         Caution: call update_dirty_prep_batch before update_state_db_batch()
         """
         for dirty_prep in self._tx_dirty_preps.values():
-            # If dirty_prep is an invalid elected P-Rep,
-            # we should update P-Reps in this term
-            self._update_elected_preps_in_term(dirty_prep)
-
-            if self.revision >= Revision.REALTIME_P2P_ENDPOINT_UPDATE.value:
-                self._update_main_preps_in_term(dirty_prep)
+            # if dirty_prep is an elected P-Rep(=main or sub P-Rep) in the current term
+            if self._term is not None and dirty_prep.address in self._term:
+                self._update_term(dirty_prep)
 
             self._preps.replace(dirty_prep)
             # Write serialized dirty_prep data into tx_batch
@@ -244,22 +241,48 @@ class IconScoreContext(object):
 
         self._tx_dirty_preps.clear()
 
-    def _update_elected_preps_in_term(self, dirty_prep: 'PRep'):
-        """Collect main and sub preps which cannot serve as a main and sub prep
-        to update the current term at the end of invoke
+    def _replace_prep(self, dirty_prep: 'PRep'):
+        """Replace the old P-Rep instance in self._preps with a new one(=dirty prep)
+
+        Assume that this method should be called on invoke process
+
+        :param dirty_prep: changed P-Rep instance
+        :return:
+        """
+        self._preps.replace(dirty_prep)
+
+    def _update_term(self, dirty_prep: 'PRep'):
+        """Update term info with dirty_prep
+
+        :param dirty_prep:
+        :return:
+        """
+        self._duplicate_term()
+
+        if dirty_prep.is_electable():
+            self._change_main_prep_p2p_endpoint(dirty_prep)
+        else:
+            self._remove_invalid_elected_prep_from_term(dirty_prep)
+
+    def _change_main_prep_p2p_endpoint(self, dirty_prep: 'PRep'):
+        """Notify the term that p2p_endpoint of a main P-Rep is changed
 
         :param dirty_prep: dirty prep
         """
-        if self._term is None:
+        if self.revision < Revision.REALTIME_P2P_ENDPOINT_UPDATE.value:
             return
 
-        if dirty_prep.is_electable():
-            return
+        if dirty_prep.is_flags_on(PRepFlag.P2P_ENDPOINT) and \
+                self._term.is_main_prep(dirty_prep.address):
+            self._term.on_main_prep_p2p_endpoint_changed()
 
-        # If dirty_prep is not in term, no need to update elected P-Reps
-        if dirty_prep.address not in self._term:
-            return
+        Logger.info(tag=self.TAG, msg=f"_update_main_prep_endpoint_in_term: {dirty_prep}")
 
+    def _remove_invalid_elected_prep_from_term(self, dirty_prep: 'PRep'):
+        """Remove an invalidated elected P-Rep from the current term
+
+        :param dirty_prep: dirty prep
+        """
         # Just in case, reset the P-Rep grade one to CANDIDATE
         dirty_prep.grade = PRepGrade.CANDIDATE
 
@@ -267,19 +290,14 @@ class IconScoreContext(object):
 
         Logger.info(tag=self.TAG, msg=f"Invalid main and sub prep: {dirty_prep}")
 
-    def _update_main_preps_in_term(self, dirty_prep: 'PRep'):
-        """
+    def _duplicate_term(self) -> Optional['Term']:
+        if self.type not in (IconScoreContextType.INVOKE, IconScoreContextType.ESTIMATION):
+            raise AccessDeniedException(f"Method not allowed: context={self.type.name}")
 
-        :param dirty_prep: dirty prep
-        """
-        if self._term is None:
-            return
+        if self._term is not None and self._term.is_frozen():
+            self._term = self._term.copy()
 
-        if dirty_prep.is_flags_on(PRepFlag.P2P_ENDPOINT) and \
-                self._term.is_main_prep(dirty_prep.address):
-            self._term.on_main_prep_p2p_endpoint_updated()
-
-        Logger.info(tag=self.TAG, msg=f"_update_main_prep_endpoint_in_term: {dirty_prep}")
+        return self._term
 
     def clear_batch(self):
         if self.tx_batch:
@@ -358,9 +376,8 @@ class IconScoreContextFactory(object):
             # For PRep management
             context._preps = context.engine.prep.preps.copy(mutable=True)
             context._tx_dirty_preps = OrderedDict()
-            if context.engine.prep.term:
-                context._term = context.engine.prep.term.copy()
         else:
             # Readonly
             context._preps = context.engine.prep.preps
-            context._term = context.engine.prep.term
+
+        context._term = context.engine.prep.term

--- a/iconservice/precommit_data_manager.py
+++ b/iconservice/precommit_data_manager.py
@@ -137,6 +137,12 @@ class PrecommitData(object):
         # To prevent redundant precommit data logging
         self.already_exists = False
 
+        # Make preps and term immutable
+        if preps:
+            preps.freeze()
+        if term:
+            term.freeze()
+
     def __str__(self):
         lines = [
             f"revision: {self.revision}",

--- a/iconservice/prep/data/prep_container.py
+++ b/iconservice/prep/data/prep_container.py
@@ -81,6 +81,7 @@ class PRepContainer(object):
             if not prep.is_frozen():
                 prep.freeze()
 
+        self._flags = PRepContainerFlag.NONE
         self._is_frozen: bool = True
 
     def add(self, prep: 'PRep'):

--- a/iconservice/prep/data/term.py
+++ b/iconservice/prep/data/term.py
@@ -93,7 +93,8 @@ class Term(object):
     def is_dirty(self):
         return utils.is_any_flag_on(self._flags, TermFlag.ALL)
 
-    def on_main_prep_p2p_endpoint_updated(self):
+    def on_main_prep_p2p_endpoint_changed(self):
+        self._check_access_permission()
         self._flags |= TermFlag.MAIN_PREP_P2P_ENDPOINT
 
     def is_frozen(self) -> bool:
@@ -124,6 +125,11 @@ class Term(object):
             f"root_hash={bytes_to_hex(self._merkle_root_hash)}"
 
     def __contains__(self, address: 'Address') -> bool:
+        """Check whether the given address is an elected P-Rep
+
+        :param address: P-Rep address
+        :return: True(elected P-Rep), False(non-elected P-Rep)
+        """
         return address in self._preps_dict
 
     def __len__(self) -> int:
@@ -192,15 +198,6 @@ class Term(object):
         """Total amount of delegation which all active P-Reps got when this term is started
         """
         return self._total_delegated
-
-    # @total_delegated.setter
-    # def total_delegated(self, value: int):
-    #     """Called on PRepEngine._on_term_updated()
-    #
-    #     :param value:
-    #     :return:
-    #     """
-    #     self._total_delegated = value
 
     @property
     def total_elected_prep_delegated(self) -> int:

--- a/tests/icon_score/test_icon_score_context.py
+++ b/tests/icon_score/test_icon_score_context.py
@@ -1,0 +1,322 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 ICON Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import random
+import unittest
+from unittest.mock import Mock
+
+from iconservice.icon_constant import IconScoreContextType, PRepFlag, TermFlag, Revision, PRepGrade, PenaltyReason, \
+    PRepStatus
+from iconservice.iconscore.icon_score_context import IconScoreContext, IconScoreContextFactory
+from iconservice.iconscore.icon_score_step import IconScoreStepCounterFactory
+from iconservice.prep.data import Term, PRep
+from iconservice.prep.data.prep_container import PRepContainer
+from iconservice.prep.engine import Engine as PRepEngine
+from iconservice.utils import icx_to_loop
+from .. import utils
+
+
+def _impose_penalty_on_prep(prep: 'PRep', penalty: 'PenaltyReason'):
+    assert not prep.is_frozen()
+
+    prep.penalty = penalty
+    prep.grade = PRepGrade.CANDIDATE
+    prep.status = PRepStatus.ACTIVE if penalty == PenaltyReason.BLOCK_VALIDATION else PRepStatus.DISQUALIFIED
+
+
+class TestIconScoreContext(unittest.TestCase):
+    MAIN_PREPS = 22
+    ELECTED_PREPS = 100
+    TOTAL_PREPS = 110
+    TERM_PERIOD = 43120
+
+    def setUp(self) -> None:
+        IconScoreContext.engine = Mock()
+        IconScoreContext.storage = Mock()
+
+        preps = utils.create_dummy_preps(
+            size=self.TOTAL_PREPS, main_preps=self.MAIN_PREPS, elected_preps=self.ELECTED_PREPS)
+        preps.freeze()
+        assert preps.is_frozen()
+        assert not preps.is_dirty()
+
+        term = Term(sequence=0,
+                    start_block_height=100,
+                    period=self.TERM_PERIOD,
+                    irep=icx_to_loop(50000),
+                    total_supply=preps.total_delegated,
+                    total_delegated=preps.total_delegated)
+        term.set_preps(preps, self.MAIN_PREPS, self.ELECTED_PREPS)
+        term.freeze()
+        assert term.is_frozen()
+        assert not term.is_dirty()
+
+        prep_engine = PRepEngine()
+        prep_engine.preps = preps
+        prep_engine.term = term
+
+        IconScoreContext.engine.prep = prep_engine
+
+        step_counter_factory = IconScoreStepCounterFactory()
+        context_factory = IconScoreContextFactory(step_counter_factory)
+
+        self.context_factory = context_factory
+        self.preps = preps
+        self.term = term
+
+    def test_update_dirty_prep_batch_with_p2p_endpoint_changed_main_prep(self):
+        old_preps: 'PRepContainer' = self.preps
+        old_term: 'Term' = self.term
+
+        block = utils.create_dummy_block()
+        context: 'IconScoreContext' = self.context_factory.create(IconScoreContextType.INVOKE, block)
+        context.revision = Revision.REALTIME_P2P_ENDPOINT_UPDATE.value
+        assert isinstance(context.preps, PRepContainer)
+
+        # Case 1: the p2p_endpoint of a main P-Rep is changed
+        index = random.randint(0, self.MAIN_PREPS - 1)
+        dirty_prep: 'PRep' = old_preps.get_by_index(index).copy()
+        dirty_prep.set(p2p_endpoint=f"new_address_{index}:1234")
+        assert dirty_prep.is_dirty()
+        assert dirty_prep.flags == PRepFlag.P2P_ENDPOINT
+        assert dirty_prep.grade == PRepGrade.MAIN
+        context.put_dirty_prep(dirty_prep)
+
+        context.update_dirty_prep_batch()
+
+        assert id(context.term) != id(old_term)
+        assert not context.term.is_frozen()
+        assert context.term.flags & TermFlag.MAIN_PREP_P2P_ENDPOINT
+        assert len(context.term.main_preps) == len(old_term.main_preps)
+        assert context.term.sub_preps == old_term.sub_preps
+
+        # Check for preps attributes
+        assert id(context.preps) != id(old_preps)
+        assert not context.preps.is_frozen()
+        assert context.preps.is_dirty()
+        assert context.preps.get_by_index(index) == dirty_prep
+
+        # Check for the changed P-Rep
+        old_prep = old_preps.get_by_index(index)
+        new_prep = context.preps.get_by_index(index)
+
+        assert new_prep == dirty_prep
+        assert new_prep != old_prep
+        assert dirty_prep.address == new_prep.address == old_prep.address
+
+    def test_update_dirty_prep_batch_with_p2p_endpoint_changed_sub_prep_and_candidate(self):
+        old_preps: 'PRepContainer' = self.preps
+        old_term: 'Term' = self.term
+
+        block = utils.create_dummy_block()
+        context: 'IconScoreContext' = self.context_factory.create(IconScoreContextType.INVOKE, block)
+        context.revision = Revision.REALTIME_P2P_ENDPOINT_UPDATE.value
+        assert isinstance(context.preps, PRepContainer)
+
+        assert id(context.preps) == id(old_preps)
+        assert id(context.term) == id(old_term)
+
+        # Case the p2p_endpoint of a sub P-Rep is changed
+        sub_index = random.randint(self.MAIN_PREPS, self.ELECTED_PREPS - 1)
+        dirty_sub_prep: 'PRep' = old_preps.get_by_index(sub_index).copy()
+        dirty_sub_prep.set(p2p_endpoint=f"new_address_{sub_index}:1234")
+        assert dirty_sub_prep.is_dirty()
+        assert dirty_sub_prep.flags == PRepFlag.P2P_ENDPOINT
+        assert dirty_sub_prep.grade == PRepGrade.SUB
+        context.put_dirty_prep(dirty_sub_prep)
+
+        candidate_index = random.randint(self.ELECTED_PREPS, old_preps.size(active_prep_only=True) - 1)
+        dirty_prep_candidate: 'PRep' = old_preps.get_by_index(candidate_index).copy()
+        dirty_prep_candidate.set(p2p_endpoint=f"new_address_{candidate_index}:1234")
+        assert dirty_prep_candidate.is_dirty()
+        assert dirty_prep_candidate.flags == PRepFlag.P2P_ENDPOINT
+        assert dirty_prep_candidate.grade == PRepGrade.CANDIDATE
+        context.put_dirty_prep(dirty_prep_candidate)
+
+        context.update_dirty_prep_batch()
+
+        # Check for term attributes
+        assert id(context.term) != id(old_term)
+        assert not context.term.is_frozen()
+        assert not context.term.flags & TermFlag.MAIN_PREP_P2P_ENDPOINT
+        assert len(context.term.main_preps) == len(old_term.main_preps)
+        assert context.term.sub_preps == old_term.sub_preps
+
+        # Check for preps attributes
+        assert id(context.preps) != id(old_preps)
+        assert not context.preps.is_frozen()
+        assert context.preps.is_dirty()
+        assert context.preps.get_by_index(sub_index) == dirty_sub_prep
+        assert context.preps.get_by_index(candidate_index) == dirty_prep_candidate
+
+    def test_update_dirty_prep_batch_with_penalized_main_prep(self):
+        block = utils.create_dummy_block()
+        context: 'IconScoreContext' = self.context_factory.create(IconScoreContextType.INVOKE, block)
+        context.revision = Revision.REALTIME_P2P_ENDPOINT_UPDATE.value
+        assert isinstance(context.preps, PRepContainer)
+        assert context.preps.is_frozen()
+        assert context.term.is_frozen()
+
+        penalties = [
+            PenaltyReason.LOW_PRODUCTIVITY,
+            PenaltyReason.PREP_DISQUALIFICATION,
+            PenaltyReason.BLOCK_VALIDATION
+        ]
+
+        sub_prep_count = self.ELECTED_PREPS - self.MAIN_PREPS
+
+        # Check for 3 penalties
+        for i, penalty in enumerate(penalties):
+            # Choose a main P-Rep
+            address = context.term.main_preps[i].address
+
+            # Duplicate a main P-Rep indicated by address to dirty_prep
+            dirty_prep: 'PRep' = context.get_prep(address, mutable=True)
+            assert dirty_prep.address == address
+            assert dirty_prep.grade == PRepGrade.MAIN
+            assert not dirty_prep.is_frozen()
+            assert not dirty_prep.is_dirty()
+
+            # Impose low productivity penalty on the main P-Rep chosen above
+            _impose_penalty_on_prep(dirty_prep, penalty)
+            assert dirty_prep.is_flags_on(PRepFlag.GRADE | PRepFlag.PENALTY)
+            assert dirty_prep.is_flags_on(PRepFlag.STATUS) == (penalty != PenaltyReason.BLOCK_VALIDATION)
+
+            context.put_dirty_prep(dirty_prep)
+            context.update_dirty_prep_batch()
+
+            # context.preps and context.term should be mutable and dirty
+            # because main P-Rep substitution happened by penalty
+            assert not context.preps.is_frozen()
+            assert not context.term.is_frozen()
+            assert context.preps.is_dirty()
+            assert context.term.is_dirty()
+
+            # The penalized main P-Rep should be replaced with the first sub P-Rep
+            assert not context.term.is_main_prep(dirty_prep.address)
+            assert len(context.term.main_preps) == self.MAIN_PREPS
+            assert len(context.term.sub_preps) == sub_prep_count - 1
+            sub_prep_count -= 1
+
+            assert id(dirty_prep) == id(context.preps.get_by_address(address))
+
+            address = context.term.main_preps[i].address
+            new_main_prep: 'PRep' = context.preps.get_by_address(address)
+
+            # The grade update for a new main P-Rep will be batched
+            # in iconservice.prep.engine.Engine._update_prep_grades()
+            assert new_main_prep.grade == PRepGrade.SUB
+            assert not new_main_prep.is_dirty()
+
+    def test_update_dirty_prep_batch_by_elected_prep_unregistration(self):
+        items = [
+            (random.randint(0, self.MAIN_PREPS - 1), PRepGrade.MAIN),
+            (random.randint(self.MAIN_PREPS, self.ELECTED_PREPS - 1), PRepGrade.SUB),
+        ]
+
+        for index, grade in items:
+            block = utils.create_dummy_block()
+            context: 'IconScoreContext' = self.context_factory.create(IconScoreContextType.INVOKE, block)
+            context.revision = Revision.REALTIME_P2P_ENDPOINT_UPDATE.value
+            assert isinstance(context.preps, PRepContainer)
+            assert context.preps.is_frozen()
+            assert context.term.is_frozen()
+
+            prep: 'PRep' = context.preps.get_by_index(index)
+            assert prep.grade == grade
+
+            # Duplicate the P-Rep specified by address to dirty_prep
+            dirty_prep = context.get_prep(prep.address, mutable=True)
+            assert dirty_prep.address == prep.address
+            assert dirty_prep.grade == grade
+            assert not dirty_prep.is_frozen()
+            assert not dirty_prep.is_dirty()
+
+            # Unregister the P-Rep
+            dirty_prep.status = PRepStatus.UNREGISTERED
+            dirty_prep.grade = PRepGrade.CANDIDATE
+            dirty_prep.penalty = PenaltyReason.NONE
+            # The status and grade of the P-Rep are changed
+            assert dirty_prep.is_flags_on(PRepFlag.STATUS | PRepFlag.GRADE)
+            # The penalty of the P-Rep is not changed
+            assert not dirty_prep.is_flags_on(PRepFlag.PENALTY)
+
+            context.put_dirty_prep(dirty_prep)
+            context.update_dirty_prep_batch()
+
+            # context.preps and context.term should be mutable and dirty
+            assert not context.preps.is_frozen()
+            assert not context.term.is_frozen()
+            assert context.preps.is_dirty()
+            assert context.term.is_dirty()
+
+            assert dirty_prep.address not in context.term
+            assert dirty_prep == context.preps.get_by_address(dirty_prep.address)
+
+    def test_update_dirty_prep_batch_by_prep_candidate_unregistration(self):
+        for i in range(3):
+            index = self.ELECTED_PREPS + i
+            grade = PRepGrade.CANDIDATE
+
+            block = utils.create_dummy_block()
+            context: 'IconScoreContext' = self.context_factory.create(IconScoreContextType.INVOKE, block)
+            context.revision = Revision.REALTIME_P2P_ENDPOINT_UPDATE.value
+            assert isinstance(context.preps, PRepContainer)
+            assert context.preps.is_frozen()
+            assert context.term.is_frozen()
+
+            old_active_prep_count: int = context.preps.size(active_prep_only=True)
+            old_total_prep_count: int = context.preps.size(active_prep_only=False)  # active + inactive
+            # There is no inactive P-Rep at this moment
+            assert old_active_prep_count == old_total_prep_count
+
+            prep: 'PRep' = context.preps.get_by_index(index)
+            assert prep.grade == grade
+
+            # Duplicate the P-Rep specified by address to dirty_prep
+            dirty_prep = context.get_prep(prep.address, mutable=True)
+            assert dirty_prep.address == prep.address
+            assert dirty_prep.grade == grade
+            assert not dirty_prep.is_frozen()
+            assert not dirty_prep.is_dirty()
+
+            # Unregister the P-Rep
+            dirty_prep.status = PRepStatus.UNREGISTERED
+            dirty_prep.grade = PRepGrade.CANDIDATE
+            dirty_prep.penalty = PenaltyReason.NONE
+            # The status of the P-Rep is changed
+            assert dirty_prep.is_flags_on(PRepFlag.STATUS)
+            # The penalty and grade of the P-Rep are not changed
+            assert not dirty_prep.is_flags_on(PRepFlag.PENALTY | PRepFlag.GRADE)
+
+            # A P-Rep candidate unregistration will be applied to context
+            context.put_dirty_prep(dirty_prep)
+            context.update_dirty_prep_batch()
+
+            # context.preps should become mutable and dirty
+            assert not context.preps.is_frozen()
+            assert context.preps.is_dirty()
+
+            # As the unregistered P-Rep is not an elected P-Rep, nothing happens to context.term
+            assert context.term.is_frozen()
+            assert not context.term.is_dirty()
+
+            # A P-Rep candidate unregistration do not affect context.term
+            assert dirty_prep.address not in context.term
+            assert dirty_prep == context.preps.get_by_address(dirty_prep.address)
+
+            # The number of active P-Reps will be decreased by one compared to the previous one
+            assert context.preps.size(active_prep_only=True) == old_active_prep_count - 1
+            assert context.preps.size(active_prep_only=False) == old_total_prep_count

--- a/tests/integrate_test/iiss/decentralized/test_rc_db_data.py
+++ b/tests/integrate_test/iiss/decentralized/test_rc_db_data.py
@@ -398,7 +398,7 @@ class TestRCDatabase(TestIISSBase):
             if rc_data[0][:2] == PRepsData.PREFIX:
                 preps: 'PRepsData' = PRepsData.from_bytes(rc_data[0], rc_data[1])
                 self.assertEqual(expected_prep_block, preps.block_height)
-                prep_addresses: list = [del_info.address for del_info in preps.prep_list]
+                prep_addresses: list = [delegation_info.address for delegation_info in preps.prep_list]
                 if expected_gv_block == expected_prep_block:
                     # In case of term change
                     expected_prep_address = main_preps_address

--- a/tests/prep/test_term.py
+++ b/tests/prep/test_term.py
@@ -270,6 +270,6 @@ class TestTerm(unittest.TestCase):
         assert not term.is_dirty()
         assert term.flags == TermFlag.NONE
 
-        term.on_main_prep_p2p_endpoint_updated()
+        term.on_main_prep_p2p_endpoint_changed()
         assert term.is_dirty()
         assert term.flags == TermFlag.MAIN_PREP_P2P_ENDPOINT

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 ICON Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import random
+import time
+from typing import Optional
+
+from iconservice.base.address import Address, AddressPrefix
+from iconservice.base.block import Block
+from iconservice.icon_constant import PRepStatus, PRepGrade
+from iconservice.prep.data import PRep, PRepContainer
+from iconservice.utils import icx_to_loop
+
+
+def create_dummy_prep(
+        index: int,
+        address: Optional['Address'] = None,
+        status: 'PRepStatus' = PRepStatus.ACTIVE) -> 'PRep':
+    address = address if address else Address(AddressPrefix.EOA, os.urandom(20))
+
+    return PRep(
+        address=address,
+        status=status,
+        name=f"node{index}",
+        country="KOR",
+        city="Seoul",
+        email=f"node{index}@example.com",
+        website=f"https://node{index}.example.com",
+        details=f"https://node{index}.example.com/details",
+        p2p_endpoint=f"node{index}.example.com:7100",
+        delegated=random.randint(0, 1000),
+        irep=10_000,
+        irep_block_height=index,
+        block_height=index
+    )
+
+
+def create_dummy_preps(size: int, main_preps: int, elected_preps: int) -> 'PRepContainer':
+    assert elected_preps <= size <= 1000
+
+    preps = PRepContainer()
+
+    # Create dummy preps
+    for i in range(size):
+        address = Address.from_prefix_and_int(AddressPrefix.EOA, i)
+        delegated = icx_to_loop(1000 - i)
+
+        if i < main_preps:
+            grade = PRepGrade.MAIN
+        elif i < elected_preps:
+            grade = PRepGrade.SUB
+        else:
+            grade = PRepGrade.CANDIDATE
+
+        prep = PRep(address, grade=grade, block_height=i, delegated=delegated)
+        prep.freeze()
+
+        assert prep.grade == grade
+        assert prep.delegated == delegated
+        assert prep.block_height == i
+        preps.add(prep)
+
+    assert preps.size(active_prep_only=True) == size
+    assert preps.size(active_prep_only=False) == size
+
+    return preps
+
+
+def get_timestamp_us() -> int:
+    return int(time.time() * 1_000_000)
+
+
+def create_dummy_block(block_height: int = -1) -> 'Block':
+    block_height: int = block_height if block_height >= 0 else random.randint(100, 10000)
+    block_hash: bytes = os.urandom(32)
+    timestamp_us: int = get_timestamp_us()
+    prev_hash: bytes = os.urandom(32)
+
+    return Block(block_height, block_hash, timestamp_us, prev_hash)


### PR DESCRIPTION
* Duplicate context.term only when it is needed to modify context.term on invoke process.
* Fix a bug that does not reset the flags when calling PRepContainer.freeze()
* Add some unittests