### PR TITLE
IS-977: Fix the bugs that prep term remains unfrozen when open the icon-service

### DIFF
--- a/iconservice/prep/engine.py
+++ b/iconservice/prep/engine.py
@@ -95,6 +95,7 @@ class Engine(EngineBase, IISSEngineListener):
 
         self.preps = self._load_preps(context)
         self.term = context.storage.prep.get_term(context)
+        self.term.freeze()
         self._initial_irep = irep
 
         context.engine.iiss.add_listener(self)


### PR DESCRIPTION
Incase of reopening icon-service, the prep engine's term remains unfrozen. If the prep list is changed before the end of the period on which icon-service has been opened, the changed prep list is reflected directly in the prep engine's term. So fix this bugs