### PR TITLE
IS-982 SCORE intercall support ICX transfer

### DIFF
--- a/docs/api-references/classes.iconscorebase.md
+++ b/docs/api-references/classes.iconscorebase.md
@@ -8,7 +8,7 @@ IconScoreBase
         on_install, 
         on_update, 
         fallback, 
-        call, 
+        call,
         create_interface_score, 
         now, 
         msg, 

--- a/docs/api-references/classes.interfacescore.md
+++ b/docs/api-references/classes.interfacescore.md
@@ -1,0 +1,11 @@
+InterfaceScore
+==============================================
+
+```eval_rst
+.. autoclass:: iconservice.iconscore.icon_score_base2.InterfaceScore
+    :members: 
+        __init__, 
+        addr_to,
+        value,
+        set_transfer_value
+```

--- a/docs/api-references/classes.md
+++ b/docs/api-references/classes.md
@@ -10,6 +10,7 @@ The key class is `IconScoreBase`. You can start writing a SCORE from it.
     classes.arraydb
     classes.dictdb
     classes.iconscorebase
+    classes.interfacescore
     classes.db
     classes.icx
     classes.transaction

--- a/docs/api-references/index.md
+++ b/docs/api-references/index.md
@@ -16,5 +16,5 @@ This document does not describe all APIs of `ICONService`, it contains the speci
 
 ### References
 
-- [SCORE Guide](https://www.icondev.io/docs/overview)
-- [T-Bears](https://www.icondev.io/docs/development-environment)
+- [SCORE Guide](https://www.icondev.io/docs/score-overview)
+- [T-Bears](https://www.icondev.io/docs/tbears-overview)

--- a/docs/dapp_guide.md
+++ b/docs/dapp_guide.md
@@ -1,3 +1,3 @@
 This page has been moved to 
 
-> https://icon-project.github.io/score-guide
+> https://www.icondev.io/docs/score-overview

--- a/iconservice/iconscore/icon_score_base.py
+++ b/iconservice/iconscore/icon_score_base.py
@@ -71,7 +71,6 @@ def interface(func):
         context = ContextContainer._get_context()
         addr_to = calling_obj.addr_to
         amount = calling_obj.value
-        calling_obj.value = 0   # reset to zero
         addr_from: 'Address' = context.current_address
 
         if addr_to is None:

--- a/iconservice/iconscore/icon_score_base.py
+++ b/iconservice/iconscore/icon_score_base.py
@@ -25,7 +25,7 @@ from .icon_score_base2 import InterfaceScore, revert, Block
 from .icon_score_constant import CONST_INDEXED_ARGS_COUNT, FORMAT_IS_NOT_FUNCTION_OBJECT, CONST_BIT_FLAG, \
     ConstBitFlag, FORMAT_DECORATOR_DUPLICATED, FORMAT_IS_NOT_DERIVED_OF_OBJECT, STR_FALLBACK, CONST_CLASS_EXTERNALS, \
     CONST_CLASS_PAYABLES, CONST_CLASS_API, T, BaseType
-from .icon_score_context import ContextGetter, IconScoreContextType
+from .icon_score_context import ContextGetter, IconScoreContextType, ContextContainer
 from .icon_score_context_util import IconScoreContextUtil
 from .icon_score_event_log import EventLogEmitter
 from .icon_score_step import StepType
@@ -47,10 +47,10 @@ INDEXED_ARGS_LIMIT = 3
 
 def interface(func):
     """
-    A decorator for the functions of interface SCORE.
+    A decorator for the functions of InterfaceScore.
 
-    Declaring this decorator to the function can invoke
-    the same form of the function of the external SCORE.
+    If other SCORE has the function whose signature is the same as defined with @interface decorator,
+    the function can be invoked via InterfaceScore class instance
     """
     cls_name, func_name = str(func.__qualname__).split('.')
     if not isfunction(func):
@@ -68,14 +68,16 @@ def interface(func):
             raise InvalidInstanceException(
                 FORMAT_IS_NOT_DERIVED_OF_OBJECT.format(InterfaceScore.__name__))
 
-        context = calling_obj.context
+        context = ContextContainer._get_context()
         addr_to = calling_obj.addr_to
+        amount = calling_obj.value
+        calling_obj.value = 0   # reset to zero
         addr_from: 'Address' = context.current_address
 
         if addr_to is None:
             raise InvalidInterfaceException('Cannot create an interface SCORE with a None address')
 
-        return InternalCall.other_external_call(context, addr_from, addr_to, 0, func_name, args, kwargs)
+        return InternalCall.other_external_call(context, addr_from, addr_to, amount, func_name, args, kwargs)
 
     return __wrapper
 
@@ -638,11 +640,10 @@ class IconScoreBase(IconScoreObject, ContextGetter,
 
         :param addr_to: :class:`.Address` the address of another SCORE
         :param func_name: function name of another SCORE
-        :param kw_dict: Arguments of the external function
-        :param amount: ICX value to enclose with. in loop.
+        :param kw_dict: arguments of the external function
+        :param amount: amount of ICX to transfer in loop
         :return: returning value of the external function
         """
-        warnings.warn('Use create_interface_score() instead.', DeprecationWarning, stacklevel=2)
         return InternalCall.other_external_call(self._context, self.address, addr_to, amount, func_name, (), kw_dict)
 
     @staticmethod

--- a/iconservice/iconscore/icon_score_base2.py
+++ b/iconservice/iconscore/icon_score_base2.py
@@ -45,18 +45,50 @@ class InterfaceScoreMeta(ABCMeta):
 
 
 class InterfaceScore(ABC, metaclass=InterfaceScoreMeta):
+    """
+    An interface class that is used to invoke other SCORE’s external method.
+    """
     def __init__(self, addr_to: 'Address'):
+        """
+        A Python init function. Invoked when the contract call create_interface_score()
+        """
         self.__addr_to = addr_to
+        self.__value = 0
 
     @property
     def addr_to(self) -> 'Address':
+        """
+        The address of SCORE to invoke
+
+        :return: :class:`.Address` SCORE address
+        """
         return self.__addr_to
 
     @property
-    def context(self) -> 'IconScoreContext':
-        context = ContextContainer._get_context()
-        assert context
-        return context
+    def value(self) -> int:
+        """
+        The amount of ICX that the caller SCORE attempts to transfer to the callee SCORE when invoke interface method.
+        After the interface method is invoked, the value is reset to zero.
+
+        :Getter: Returns amount of ICX in loop
+        :Setter: Sets amount of ICX in loop
+        :type: int
+        """
+        return self.__value
+
+    @value.setter
+    def value(self, value: int):
+        self.__value = value
+
+    def set_transfer_value(self, value: int) -> 'InterfaceScore':
+        """
+        Set the value and return instance
+
+        :param value: amount of ICX in loop
+        :return: :class:`.InterfaceScore` Instance of InterfaceScore
+        """
+        self.__value = value
+        return self
 
 
 class Block(object):

--- a/iconservice/iconscore/icon_score_base2.py
+++ b/iconservice/iconscore/icon_score_base2.py
@@ -68,7 +68,7 @@ class InterfaceScore(ABC, metaclass=InterfaceScoreMeta):
     def value(self) -> int:
         """
         The amount of ICX that the caller SCORE attempts to transfer to the callee SCORE when invoke interface method.
-        After the interface method is invoked, the value is reset to zero.
+        The value is retained till setting again. If don't want to transfer ICX, reset the value to zero.
 
         :Getter: Returns amount of ICX in loop
         :Setter: Sets amount of ICX in loop
@@ -79,16 +79,6 @@ class InterfaceScore(ABC, metaclass=InterfaceScoreMeta):
     @value.setter
     def value(self, value: int):
         self.__value = value
-
-    def set_transfer_value(self, value: int) -> 'InterfaceScore':
-        """
-        Set the value and return instance
-
-        :param value: amount of ICX in loop
-        :return: :class:`.InterfaceScore` Instance of InterfaceScore
-        """
-        self.__value = value
-        return self
 
 
 class Block(object):

--- a/tests/integrate_test/samples/sample_internal_call_scores/sample_link_score/sample_link_score.py
+++ b/tests/integrate_test/samples/sample_internal_call_scores/sample_link_score/sample_link_score.py
@@ -11,6 +11,12 @@ class SampleInterface(InterfaceScore):
     @interface
     def get_db(self) -> IconScoreDatabase: pass
 
+    @interface
+    def fallback_via_internal_call(self) -> None: pass
+
+    @interface
+    def fallback_via_not_payable_internal_call(self) -> None: pass
+
 
 class SampleLinkScore(IconScoreBase):
     _SCORE_ADDR = 'score_addr'
@@ -60,3 +66,24 @@ class SampleLinkScore(IconScoreBase):
     def put_data_to_other_score_db(self):
         db = self._get_other_score_db()
         db.put(b'dummy_key', b'dummy_value')
+
+    @external(readonly=False)
+    def transfer_icx_to_other_score(self, value: int) -> None:
+        test_interface = self.create_interface_score(self._addr_score.get(), SampleInterface)
+        test_interface.value = value
+        test_interface.fallback_via_internal_call()
+
+    @external(readonly=False)
+    def transfer_icx_to_other_score_fail(self, value: int) -> None:
+        test_interface = self.create_interface_score(self._addr_score.get(), SampleInterface)
+        test_interface.set_transfer_value(value).fallback_via_not_payable_internal_call()
+
+    @external(readonly=False)
+    @payable
+    def transfer_all_icx_to_other_score(self) -> None:
+        amount: int = self.icx.get_balance(self.address)
+        self.call(self._addr_score.get(), 'fallback_via_internal_call', {}, amount)
+
+    @payable
+    def fallback(self) -> None:
+        pass

--- a/tests/integrate_test/samples/sample_internal_call_scores/sample_link_score/sample_link_score.py
+++ b/tests/integrate_test/samples/sample_internal_call_scores/sample_link_score/sample_link_score.py
@@ -76,7 +76,8 @@ class SampleLinkScore(IconScoreBase):
     @external(readonly=False)
     def transfer_icx_to_other_score_fail(self, value: int) -> None:
         test_interface = self.create_interface_score(self._addr_score.get(), SampleInterface)
-        test_interface.set_transfer_value(value).fallback_via_not_payable_internal_call()
+        test_interface.value = value
+        test_interface.fallback_via_not_payable_internal_call()
 
     @external(readonly=False)
     @payable

--- a/tests/integrate_test/samples/sample_internal_call_scores/sample_link_score/sample_link_score.py
+++ b/tests/integrate_test/samples/sample_internal_call_scores/sample_link_score/sample_link_score.py
@@ -74,6 +74,14 @@ class SampleLinkScore(IconScoreBase):
         test_interface.fallback_via_internal_call()
 
     @external(readonly=False)
+    @payable
+    def transfer_icx_to_other_score_twice(self, value: int) -> None:
+        test_interface = self.create_interface_score(self._addr_score.get(), SampleInterface)
+        test_interface.value = value
+        test_interface.fallback_via_internal_call()
+        test_interface.fallback_via_internal_call()
+
+    @external(readonly=False)
     def transfer_icx_to_other_score_fail(self, value: int) -> None:
         test_interface = self.create_interface_score(self._addr_score.get(), SampleInterface)
         test_interface.value = value

--- a/tests/integrate_test/samples/sample_internal_call_scores/sample_score/sample_score.py
+++ b/tests/integrate_test/samples/sample_internal_call_scores/sample_score/sample_score.py
@@ -30,3 +30,12 @@ class SampleScore(IconScoreBase):
     @external
     def get_db(self):
         return self.db
+
+    @external
+    @payable
+    def fallback_via_internal_call(self) -> None:
+        pass
+
+    @external
+    def fallback_via_not_payable_internal_call(self) -> None:
+        pass

--- a/tests/integrate_test/test_integrate_score_internal_call.py
+++ b/tests/integrate_test/test_integrate_score_internal_call.py
@@ -263,6 +263,18 @@ class TestIntegrateScoreInternalCall(TestIntegrateBase):
         balance = self.get_balance(score_addr2)
         self.assertEqual(0, balance, balance)
 
+        # invoke intercall twice and check balance
+        self.score_call(from_=self._admin,
+                        to_=score_addr2,
+                        value=value * 2,
+                        func_name="transfer_icx_to_other_score_twice",
+                        params={"value": hex(value)})
+
+        balance = self.get_balance(score_addr1)
+        self.assertEqual(value * 4, balance, balance)
+        balance = self.get_balance(score_addr2)
+        self.assertEqual(0, balance, balance)
+
     def test_transfer_via_internal_call_error(self):
         tx1: dict = self.create_deploy_score_tx(score_root="sample_internal_call_scores",
                                                 score_name="sample_score",

--- a/tests/integrate_test/test_integrate_score_internal_call.py
+++ b/tests/integrate_test/test_integrate_score_internal_call.py
@@ -212,3 +212,97 @@ class TestIntegrateScoreInternalCall(TestIntegrateBase):
                         func_name="try_get_other_score_db",
                         params={},
                         expected_status=False)
+
+    def test_transfer_via_internal_call(self):
+        tx1: dict = self.create_deploy_score_tx(score_root="sample_internal_call_scores",
+                                                score_name="sample_score",
+                                                from_=self._accounts[0],
+                                                to_=ZERO_SCORE_ADDRESS)
+
+        tx2: dict = self.create_deploy_score_tx(score_root="sample_internal_call_scores",
+                                                score_name="sample_link_score",
+                                                from_=self._accounts[0],
+                                                to_=ZERO_SCORE_ADDRESS)
+
+        tx_results: List['TransactionResult'] = self.process_confirm_block_tx([tx1, tx2])
+        score_addr1: 'Address' = tx_results[0].score_address
+        score_addr2: 'Address' = tx_results[1].score_address
+
+        # callee SCORE = score_addr1
+        self.score_call(from_=self._accounts[0],
+                        to_=score_addr2,
+                        func_name="add_score_func",
+                        params={"score_addr": str(score_addr1)})
+
+        value = 2 * ICX_IN_LOOP
+
+        # increase balance of score_addr2
+        self.transfer_icx(self._admin, score_addr2, value)
+        balance: int = self.get_balance(score_addr2)
+        self.assertEqual(value, balance)
+
+        # transfer value from score_addr2 to score_addr1
+        self.score_call(from_=self._accounts[0],
+                        to_=score_addr2,
+                        func_name="transfer_icx_to_other_score",
+                        params={"value": hex(value)})
+
+        balance = self.get_balance(score_addr1)
+        self.assertEqual(value, balance, balance)
+        balance = self.get_balance(score_addr2)
+        self.assertEqual(0, balance, balance)
+
+        # transfer fallbacked balance(value) from score_addr2 to score_addr1 in one TX
+        self.score_call(from_=self._admin,
+                        to_=score_addr2,
+                        value=value,
+                        func_name="transfer_all_icx_to_other_score")
+
+        balance = self.get_balance(score_addr1)
+        self.assertEqual(value * 2, balance, balance)
+        balance = self.get_balance(score_addr2)
+        self.assertEqual(0, balance, balance)
+
+    def test_transfer_via_internal_call_error(self):
+        tx1: dict = self.create_deploy_score_tx(score_root="sample_internal_call_scores",
+                                                score_name="sample_score",
+                                                from_=self._accounts[0],
+                                                to_=ZERO_SCORE_ADDRESS)
+
+        tx2: dict = self.create_deploy_score_tx(score_root="sample_internal_call_scores",
+                                                score_name="sample_link_score",
+                                                from_=self._accounts[0],
+                                                to_=ZERO_SCORE_ADDRESS)
+
+        tx_results: List['TransactionResult'] = self.process_confirm_block_tx([tx1, tx2])
+        score_addr1: 'Address' = tx_results[0].score_address
+        score_addr2: 'Address' = tx_results[1].score_address
+
+        # callee SCORE = score_addr1
+        self.score_call(from_=self._accounts[0],
+                        to_=score_addr2,
+                        func_name="add_score_func",
+                        params={"score_addr": str(score_addr1)})
+
+        value = 2 * ICX_IN_LOOP
+
+        # transfer without balance
+        tx_results = self.score_call(from_=self._accounts[0],
+                                     to_=score_addr2,
+                                     func_name="transfer_icx_to_other_score",
+                                     params={"value": hex(value)},
+                                     expected_status=False)
+        self.assertTrue(tx_results[0].failure.message.startswith("Out of balance"))
+
+        # increase balance of score_addr2
+        self.transfer_icx(self._admin, score_addr2, value)
+        balance: int = self.get_balance(score_addr2)
+        self.assertEqual(value, balance)
+
+        # transfer via not payable external function
+        tx_results = self.score_call(from_=self._accounts[0],
+                                     to_=score_addr2,
+                                     func_name="transfer_icx_to_other_score_fail",
+                                     params={"value": hex(value)},
+                                     expected_status=False)
+        self.assertTrue(tx_results[0].failure.message.startswith("Method not payable"))


### PR DESCRIPTION
- remove IconScoreBase.call() from deprecated API list
- there are 2 ways to transfer ICX
  * self.call() method
    set transfer amount with last parameter 'amount'

   * self.create_score_interface() and @interface decorator
      1. set transfer amount to 'value' member
          - there are 2 ways
              - assign int value with '=' operator
              - ~~call set_transfer_value()~~
      2. invoke @interface decorated method