### PR TITLE
IS-997: Refactor PRepAddressConverter

### DIFF
--- a/iconservice/iconscore/icon_score_context.py
+++ b/iconservice/iconscore/icon_score_context.py
@@ -158,7 +158,7 @@ class IconScoreContext(object):
         # to use for updating term info at the end of invoke
         self._term: Optional['Term'] = None
 
-        self.prep_address_converter: 'PRepAddressConverter' = None
+        self.prep_address_converter: Optional['PRepAddressConverter'] = None
         self.regulator: Optional['Regulator'] = None
 
     @classmethod

--- a/iconservice/iiss/engine.py
+++ b/iconservice/iiss/engine.py
@@ -19,6 +19,7 @@ from collections import OrderedDict
 from typing import TYPE_CHECKING, Any, Optional, List, Dict, Tuple, Union
 
 from iconcommons.logger import Logger
+
 from iconservice.iiss.listener import EngineListener as IISSEngineListener
 from .reward_calc.data_creator import DataCreator as RewardCalcDataCreator
 from .reward_calc.ipc.message import CalculateDoneNotification, ReadyNotification

--- a/iconservice/prep/prep_address_converter.py
+++ b/iconservice/prep/prep_address_converter.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import copy
-from typing import TYPE_CHECKING, Optional, List, Tuple
+from typing import TYPE_CHECKING
 
 from ..base.exception import InvalidParamsException
 
@@ -29,7 +29,7 @@ class PRepAddressConverter:
     Convert prep address being used for consensus in loopchain (i.e. node address) to
     P-Rep address being used for managing P-Rep (i.e. prep address).
 
-    Loopchain distinguish P-Reps using node address, but iconservice uses an prep address as a identification.
+    Loopchain distinguishes P-Reps using node address, but iconservice uses an prep address as a identification.
     """
 
     def __init__(self,
@@ -55,7 +55,7 @@ class PRepAddressConverter:
 
     def add_node_address(self, node: 'Address', prep: 'Address'):
         if node in self._node_address_mapper:
-            raise InvalidParamsException(f"assert deprecated node address assigned: {node}")
+            raise InvalidParamsException(f"nodeAddress already in use: {node}")
         self._node_address_mapper[node] = prep
 
     def delete_node_address(self, node: 'Address'):
@@ -80,21 +80,6 @@ class PRepAddressConverter:
         self._node_address_mapper.clear()
         self.load(context=context)
 
-    def node_address_to_prep_address(self,
-                                     prev_block_generator: Optional['Address'] = None,
-                                     prev_block_votes: Optional[List[Tuple['Address', int]]] = None) -> tuple:
-
-        prev_block_generator: 'Address' = self._get_prep_address_from_node_address(prev_block_generator)
-        tmp_votes: List[Tuple['Address', int]] = []
-
-        for address, vote in prev_block_votes:
-            if self._is_contains_node_address(address):
-                tmp_votes.append([self._get_prep_address_from_node_address(address), vote])
-            else:
-                tmp_votes.append([address, vote])
-        prev_block_votes: List[Tuple['Address', int]] = tmp_votes
-        return prev_block_votes, prev_block_generator
-
     def reset_prev_node_address(self):
         self._prev_node_address_mapper.clear()
 
@@ -104,11 +89,8 @@ class PRepAddressConverter:
         if address in self._node_address_mapper:
             raise InvalidParamsException(f"nodeAddress already in use: {address}")
 
-    def _is_contains_node_address(self,
-                                  node_address: 'Address') -> bool:
-        return node_address in self._prev_node_address_mapper or node_address in self._node_address_mapper
+    def get_prep_address_from_node_address(self,
+                                           node_address: 'Address') -> 'Address':
 
-    def _get_prep_address_from_node_address(self,
-                                            node_address: 'Address') -> 'Address':
         return self._prev_node_address_mapper.get(node_address,
                                                   self._node_address_mapper.get(node_address, node_address))

--- a/tests/prep/test_prep_address_converter.py
+++ b/tests/prep/test_prep_address_converter.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 ICON Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from iconservice.base.address import Address, AddressPrefix
+from iconservice.prep.prep_address_converter import PRepAddressConverter
+
+
+class TestPRepAddressConverter(unittest.TestCase):
+    def setUp(self) -> None:
+        self.converter = PRepAddressConverter()
+        self.node_addresses = []
+        self.prep_addresses = []
+
+        # Generate sample addresses for test
+        for i in range(10):
+            node_address = Address.from_data(AddressPrefix.EOA, f'node_address{i}'.encode("utf-8"))
+            prep_address = Address.from_data(AddressPrefix.EOA, f'prep_address{i}'.encode("utf-8"))
+
+            self.node_addresses.append(node_address)
+            self.prep_addresses.append(prep_address)
+
+    def test_add_node_address(self):
+        node_address = self.node_addresses[0]
+        prep_address = self.prep_addresses[0]
+
+        # In case when a given node address is not added
+        address = self.converter.get_prep_address_from_node_address(node_address)
+        assert address == node_address
+
+        # In case when a given node address is added
+        self.converter.add_node_address(node_address, prep_address)
+        address = self.converter.get_prep_address_from_node_address(node_address)
+        assert address == prep_address
+
+        self.converter.delete_node_address(node_address)
+        address = self.converter.get_prep_address_from_node_address(node_address)
+        assert address == node_address
+        assert address != prep_address
+
+    def test_replace_node_address(self):
+        converter = self.converter
+
+        old_node_address = self.node_addresses[0]
+        new_node_address = self.node_addresses[1]
+        prep_address = self.prep_addresses[0]
+
+        # Confirm that 3 addresses are different
+        assert old_node_address != new_node_address
+        assert old_node_address != prep_address
+        assert new_node_address != prep_address
+
+        # Check whether old_node_address is not added to converter
+        address = self.converter.get_prep_address_from_node_address(old_node_address)
+        assert address == old_node_address
+
+        # Add old_node_address
+        converter.add_node_address(old_node_address, prep_address)
+        address = self.converter.get_prep_address_from_node_address(old_node_address)
+        assert address == prep_address
+
+        # Replace old_node_address with a new node_address
+        converter.replace_node_address(old_node_address, prep_address, new_node_address)
+        assert prep_address == converter.get_prep_address_from_node_address(old_node_address)
+        assert prep_address == converter.get_prep_address_from_node_address(new_node_address)
+        assert old_node_address in converter._prev_node_address_mapper
+        assert new_node_address in converter._node_address_mapper
+        assert len(converter._prev_node_address_mapper) == 1
+        assert len(converter._node_address_mapper) == 1
+
+    def test_copy(self):
+        converter = self.converter
+        old_node_address = self.node_addresses[0]
+        new_node_address = self.node_addresses[1]
+        prep_address = self.prep_addresses[0]
+
+        # Add old_node_address
+        converter.add_node_address(old_node_address, prep_address)
+        address = self.converter.get_prep_address_from_node_address(old_node_address)
+        assert address == prep_address
+
+        # Replace old_node_address with a new node_address
+        converter.replace_node_address(old_node_address, prep_address, new_node_address)
+
+        new_converter = converter.copy()
+        assert isinstance(new_converter, PRepAddressConverter)
+        assert prep_address == new_converter.get_prep_address_from_node_address(old_node_address)
+        assert prep_address == new_converter.get_prep_address_from_node_address(new_node_address)
+        assert old_node_address in new_converter._prev_node_address_mapper
+        assert new_node_address in new_converter._node_address_mapper
+        assert len(new_converter._prev_node_address_mapper) == 1
+        assert len(new_converter._node_address_mapper) == 1
+        assert id(new_converter._prev_node_address_mapper) != id(converter._prev_node_address_mapper)
+        assert id(new_converter._node_address_mapper) != id(converter._node_address_mapper)
+
+        new_converter.delete_node_address(new_node_address)
+        assert new_node_address == new_converter.get_prep_address_from_node_address(new_node_address)
+        assert prep_address == converter.get_prep_address_from_node_address(new_node_address)
+
+        new_converter.reset_prev_node_address()
+        assert old_node_address == new_converter.get_prep_address_from_node_address(old_node_address)
+        assert prep_address == converter.get_prep_address_from_node_address(old_node_address)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
* Remove node_address_to_prep_address()
* Remove is_contains_node_address()
* Remove '_' from  _get_prep_address_from_node_address()
* Refactor IconServiceEngine._get_prev_block_votes()
* Add an unittest for PRepAddressConverter
