### PR TITLE
IS-998: Refactor PRepAddressConverter2

### DIFF
--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -791,7 +791,7 @@ class IconServiceEngine(ContextContainer):
                                                                            flag,
                                                                            rc_db_revision)
         context.update_batch()
-        context.prep_address_converter.save(context)
+        context.storage.meta.put_prep_address_converter(context, context.prep_address_converter)
 
         if main_prep_as_dict is not None:
             Logger.info(tag="TERM", msg=f"{main_prep_as_dict}")

--- a/iconservice/meta/storage.py
+++ b/iconservice/meta/storage.py
@@ -16,13 +16,14 @@
 
 from typing import TYPE_CHECKING, Tuple, List
 
-from iconservice.database.db import MetaContextDatabase, ContextDatabase
 from ..base.ComponentBase import StorageBase
-from ..base.address import Address
+from ..database.db import MetaContextDatabase, ContextDatabase
+from ..prep.prep_address_converter import PRepAddressConverter
 from ..utils.msgpack_for_db import MsgPackForDB
 
 if TYPE_CHECKING:
     from ..iconscore.icon_score_context import IconScoreContext
+    from ..base.address import Address
 
 
 class Storage(StorageBase):
@@ -82,20 +83,12 @@ class Storage(StorageBase):
         _version = data[0]
         return data[1]
 
-    def put_prev_node_address_mapper(self,
-                                     context: 'IconScoreContext',
-                                     prev_node_address_mapper: dict):
-        version = 0
-
-        value: bytes = MsgPackForDB.dumps([version, prev_node_address_mapper])
+    def put_prep_address_converter(self,
+                                   context: 'IconScoreContext',
+                                   prep_address_converter: 'PRepAddressConverter'):
+        value: bytes = prep_address_converter.to_bytes()
         self._db.put(context, self._KEY_PREV_NODE_ADDRESS_MAPPER, value)
 
-    def get_prev_node_address_mapper(self, context: 'IconScoreContext') -> dict:
+    def get_prep_address_converter(self, context: 'IconScoreContext') -> 'PRepAddressConverter':
         value: bytes = self._db.get(context, self._KEY_PREV_NODE_ADDRESS_MAPPER)
-        if value is None:
-            return {}
-        data: list = MsgPackForDB.loads(value)
-        _version = data[0]
-
-        data: dict = data[1]
-        return data
+        return PRepAddressConverter.from_bytes(value)

--- a/iconservice/prep/engine.py
+++ b/iconservice/prep/engine.py
@@ -78,7 +78,7 @@ class Engine(EngineBase, IISSEngineListener):
         self._initial_irep: Optional[int] = None
         self._penalty_imposer: Optional['PenaltyImposer'] = None
 
-        self.prep_address_converter: 'PRepAddressConverter' = PRepAddressConverter()
+        self.prep_address_converter: 'PRepAddressConverter' = None
 
         Logger.debug(tag=_TAG, msg="PRepEngine.__init__() end")
 
@@ -95,11 +95,11 @@ class Engine(EngineBase, IISSEngineListener):
                                    low_productivity_penalty_threshold,
                                    block_validation_penalty_threshold)
 
+        self.prep_address_converter: 'PRepAddressConverter' = context.storage.meta.get_prep_address_converter(context)
+
         self.preps = self._load_preps(context)
         self.term = self._load_term(context)
         self._initial_irep = irep
-
-        self.prep_address_converter.load(context)
 
         context.engine.iiss.add_listener(self)
 
@@ -196,7 +196,7 @@ class Engine(EngineBase, IISSEngineListener):
         """
         Logger.info(tag=ROLLBACK_LOG_TAG, msg="rollback() start")
 
-        self.prep_address_converter.rollback(context)
+        self.prep_address_converter: 'PRepAddressConverter' = context.storage.meta.get_prep_address_converter(context)
 
         self.preps = self._load_preps(context)
         self.term = self._load_term(context)

--- a/tests/icon_score/test_icon_score_context.py
+++ b/tests/icon_score/test_icon_score_context.py
@@ -66,6 +66,7 @@ class TestIconScoreContext(unittest.TestCase):
         prep_engine = PRepEngine()
         prep_engine.preps = preps
         prep_engine.term = term
+        prep_engine.prep_address_converter = Mock()
 
         IconScoreContext.engine.prep = prep_engine
 

--- a/tests/prep/test_engine.py
+++ b/tests/prep/test_engine.py
@@ -525,6 +525,7 @@ class TestEngine(unittest.TestCase):
         engine = PRepEngine()
         engine.term = self.term
         engine.preps = self.preps
+        engine.prep_address_converter = Mock()
 
         self.term.freeze()
         self.preps.freeze()

--- a/tests/prep/test_prep_address_converter.py
+++ b/tests/prep/test_prep_address_converter.py
@@ -114,6 +114,22 @@ class TestPRepAddressConverter(unittest.TestCase):
         assert old_node_address == new_converter.get_prep_address_from_node_address(old_node_address)
         assert prep_address == converter.get_prep_address_from_node_address(old_node_address)
 
+    def test_serialize(self):
+        # empty
+        data: bytes = PRepAddressConverter().to_bytes()
+        converter: 'PRepAddressConverter' = PRepAddressConverter.from_bytes(data)
+        assert self.converter._prev_node_address_mapper == converter._prev_node_address_mapper
+
+        # add data
+        old_node_address = self.node_addresses[0]
+        new_node_address = self.node_addresses[1]
+        prep_address = self.prep_addresses[0]
+
+        self.converter.replace_node_address(old_node_address, prep_address, new_node_address)
+        data: bytes = self.converter.to_bytes()
+        converter: 'PRepAddressConverter' = PRepAddressConverter.from_bytes(data)
+        assert self.converter._prev_node_address_mapper == converter._prev_node_address_mapper
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_fee_sharing.py
+++ b/tests/test_fee_sharing.py
@@ -45,6 +45,7 @@ class TestFeeSharing(unittest.TestCase):
         IconScoreContext.engine.icx.transfer = Mock()
         IconScoreContext.engine.icx.get_balance = Mock(return_value=5000)
         IconScoreContext.engine.prep.preps = Mock()
+        IconScoreContext.engine.prep.prep_address_converter = Mock()
 
     def tearDown(self):
         ContextContainer._clear_context()

--- a/tests/test_icon_score_api.py
+++ b/tests/test_icon_score_api.py
@@ -33,6 +33,7 @@ from iconservice.iconscore.icon_score_context import IconScoreContext, IconScore
 from iconservice.iconscore.icon_score_step import IconScoreStepCounterFactory, StepType
 from iconservice.prep import PRepEngine
 from iconservice.prep.data import PRep, Term, PRepContainer
+from iconservice.prep.prep_address_converter import PRepAddressConverter
 from iconservice.utils import ContextEngine
 from tests import create_address
 
@@ -93,6 +94,7 @@ class TestIconScoreApi(unittest.TestCase):
         self.step_limit = 1_000_000_000
 
         self._prep_engine = PRepEngine()
+        self._prep_engine.prep_address_converter = PRepAddressConverter()
 
         self.context = self._create_context()
         ContextContainer._push_context(self.context)

--- a/tests/test_icon_score_result.py
+++ b/tests/test_icon_score_result.py
@@ -213,6 +213,7 @@ class TestTransactionResult(unittest.TestCase):
     def test_request(self, score_invoke):
         inner_task = generate_inner_task(3)
         IconScoreContext.engine.prep.preps = Mock()
+        IconScoreContext.engine.prep.prep_address_converter = Mock()
 
         # noinspection PyUnusedLocal
         def intercept_invoke(*args, **kwargs):

--- a/tests/test_icon_score_step.py
+++ b/tests/test_icon_score_step.py
@@ -56,6 +56,7 @@ class TestIconScoreStepCounter(unittest.TestCase):
         self.step_cost_dict = self._init_step_cost()
         prep_engine = PRepEngine()
         prep_engine.preps = Mock()
+        prep_engine.prep_address_converter = Mock()
         fee_engine = FeeEngine()
         icx_engine = IcxEngine()
         IconScoreContext.engine = ContextEngine(


### PR DESCRIPTION
* Remove save(), load() and rollback()
* Fix errors in unittests
* Refactor get_prep_address_converter() and put_prep_address_converter() on meta storage