### PR TITLE
IS-991: Add option which determine opening RC monitor channel

### DIFF
--- a/iconservice/icon_config.py
+++ b/iconservice/icon_config.py
@@ -49,6 +49,7 @@ default_icon_config = {
     # If you want to change as TERM_PERIOD, you also must change REVISION.
     # so we determined that only TERM_PERIOD changed without IISS_CALCULATE_PERIOD.
     ConfigKey.ICON_RC_DIR_PATH: "",
+    ConfigKey.ICON_RC_MONITOR: True,
     ConfigKey.IISS_CALCULATE_PERIOD: IISS_DAY_BLOCK,
     ConfigKey.TERM_PERIOD: TERM_PERIOD,
     ConfigKey.INITIAL_IREP: 50_000 * ICX_IN_LOOP,

--- a/iconservice/icon_constant.py
+++ b/iconservice/icon_constant.py
@@ -170,8 +170,11 @@ class ConfigKey:
     STEP_TRACE_FLAG = 'stepTraceFlag'
     PRECOMMIT_DATA_LOG_FLAG = 'precommitDataLogFlag'
 
-    # Reward calculator executable path
+    # Reward calculator
+    # executable path
     ICON_RC_DIR_PATH = 'iconRcPath'
+    # Boolean which determines Opening RC monitor channel (Default True)
+    ICON_RC_MONITOR = 'iconRcMonitor'
 
     # IISS meta data
     IISS_META_DATA = "iissMetaData"

--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -208,7 +208,8 @@ class IconServiceEngine(ContextContainer):
                                      conf[ConfigKey.LOW_PRODUCTIVITY_PENALTY_THRESHOLD],
                                      conf[ConfigKey.BLOCK_VALIDATION_PENALTY_THRESHOLD],
                                      conf[ConfigKey.IPC_TIMEOUT],
-                                     conf[ConfigKey.ICON_RC_DIR_PATH])
+                                     conf[ConfigKey.ICON_RC_DIR_PATH],
+                                     conf[ConfigKey.ICON_RC_MONITOR])
 
         self._load_builtin_scores(
             context, Address.from_string(conf[ConfigKey.BUILTIN_SCORE_OWNER]))
@@ -257,7 +258,8 @@ class IconServiceEngine(ContextContainer):
                                 low_productivity_penalty_threshold: int,
                                 block_validation_penalty_threshold: int,
                                 ipc_timeout: int,
-                                icon_rc_path: str):
+                                icon_rc_path: str,
+                                icon_rc_monitor: bool):
         # storages MUST be prepared prior to engines because engines use them on open()
         IconScoreContext.storage.deploy.open(context)
         IconScoreContext.storage.fee.open(context)
@@ -276,7 +278,8 @@ class IconServiceEngine(ContextContainer):
                                           rc_data_path,
                                           rc_socket_path,
                                           ipc_timeout,
-                                          icon_rc_path)
+                                          icon_rc_path,
+                                          icon_rc_monitor)
         IconScoreContext.engine.prep.open(context,
                                           term_period,
                                           irep,

--- a/iconservice/iiss/engine.py
+++ b/iconservice/iiss/engine.py
@@ -233,7 +233,10 @@ class Engine(EngineBase):
                                                   ready_callback=self.ready_callback,
                                                   ipc_timeout=ipc_timeout,
                                                   icon_rc_path=icon_rc_path)
-        self._reward_calc_proxy.open(log_dir=log_dir, sock_path=socket_path, iiss_db_path=data_path, icon_rc_monitor=icon_rc_monitor)
+        self._reward_calc_proxy.open(log_dir=log_dir,
+                                     sock_path=socket_path,
+                                     iiss_db_path=data_path,
+                                     icon_rc_monitor=icon_rc_monitor)
         self._reward_calc_proxy.start()
 
     def _close_reward_calc_proxy(self):

--- a/iconservice/iiss/engine.py
+++ b/iconservice/iiss/engine.py
@@ -111,18 +111,19 @@ class Engine(EngineBase):
         self._listeners: List['IISSEngineListener'] = []
 
     def open(self, context: 'IconScoreContext',
-             log_dir: str, data_path: str, socket_path: str, ipc_timeout: int, icon_rc_path: str):
+             log_dir: str, data_path: str, socket_path: str, ipc_timeout: int,
+             icon_rc_path: str, icon_rc_monitor: bool):
         """
-
         :param context:
         :param log_dir:
         :param data_path:
         :param socket_path:
         :param ipc_timeout:
         :param icon_rc_path: ex) "/usr/local/bin"
+        :param icon_rc_monitor: Boolean which determines Opening RC monitor channel
         :return:
         """
-        self._init_reward_calc_proxy(log_dir, data_path, socket_path, ipc_timeout, icon_rc_path)
+        self._init_reward_calc_proxy(log_dir, data_path, socket_path, ipc_timeout, icon_rc_path, icon_rc_monitor)
 
     def add_listener(self, listener: 'IISSEngineListener'):
         assert isinstance(listener, IISSEngineListener)
@@ -226,12 +227,13 @@ class Engine(EngineBase):
         IconScoreContext.storage.rc.put_calc_response_from_rc(cb_data.iscore, cb_data.block_height, cb_data.state_hash)
         Logger.info(tag=_TAG, msg=f"calculate done callback called with {cb_data}")
 
-    def _init_reward_calc_proxy(self, log_dir: str, data_path: str, socket_path: str, ipc_timeout: int, icon_rc_path: str):
+    def _init_reward_calc_proxy(self, log_dir: str, data_path: str, socket_path: str, ipc_timeout: int,
+                                icon_rc_path: str, icon_rc_monitor: bool):
         self._reward_calc_proxy = RewardCalcProxy(calc_done_callback=self.calculate_done_callback,
                                                   ready_callback=self.ready_callback,
                                                   ipc_timeout=ipc_timeout,
                                                   icon_rc_path=icon_rc_path)
-        self._reward_calc_proxy.open(log_dir=log_dir, sock_path=socket_path, iiss_db_path=data_path)
+        self._reward_calc_proxy.open(log_dir=log_dir, sock_path=socket_path, iiss_db_path=data_path,)
         self._reward_calc_proxy.start()
 
     def _close_reward_calc_proxy(self):

--- a/iconservice/iiss/engine.py
+++ b/iconservice/iiss/engine.py
@@ -233,7 +233,7 @@ class Engine(EngineBase):
                                                   ready_callback=self.ready_callback,
                                                   ipc_timeout=ipc_timeout,
                                                   icon_rc_path=icon_rc_path)
-        self._reward_calc_proxy.open(log_dir=log_dir, sock_path=socket_path, iiss_db_path=data_path,)
+        self._reward_calc_proxy.open(log_dir=log_dir, sock_path=socket_path, iiss_db_path=data_path, icon_rc_monitor=icon_rc_monitor)
         self._reward_calc_proxy.start()
 
     def _close_reward_calc_proxy(self):

--- a/iconservice/iiss/reward_calc/ipc/reward_calc_proxy.py
+++ b/iconservice/iiss/reward_calc/ipc/reward_calc_proxy.py
@@ -83,7 +83,7 @@ class RewardCalcProxy(object):
 
         Logger.debug(tag=_TAG, msg="__init__() end")
 
-    def open(self, log_dir: str, sock_path: str, iiss_db_path: str):
+    def open(self, log_dir: str, sock_path: str, iiss_db_path: str, icon_rc_monitor: bool):
         Logger.debug(tag=_TAG, msg="open() start")
 
         self._loop = asyncio.get_event_loop()
@@ -92,7 +92,8 @@ class RewardCalcProxy(object):
                                            notify_handler=self.notify_handler)
         self._ipc_server.open(self._loop, self._message_queue, sock_path)
 
-        self.start_reward_calc(log_dir=log_dir, sock_path=sock_path, iiss_db_path=iiss_db_path)
+        self.start_reward_calc(log_dir=log_dir, sock_path=sock_path, iiss_db_path=iiss_db_path,
+                               icon_rc_monitor=icon_rc_monitor)
         self._ready_future = self._loop.create_future()
 
         Logger.debug(tag=_TAG, msg="open() end")
@@ -537,12 +538,13 @@ class RewardCalcProxy(object):
         elif isinstance(response, CalculateDoneNotification):
             self.calculate_done_handler(response=response)
 
-    def start_reward_calc(self, log_dir: str, sock_path: str, iiss_db_path: str):
+    def start_reward_calc(self, log_dir: str, sock_path: str, iiss_db_path: str, icon_rc_monitor: bool):
         """ Start reward calculator process
 
         :param log_dir: log directory
         :param sock_path: unix domain socket path for IPC
         :param iiss_db_path: IISS data DB path
+        :param icon_rc_monitor: Boolean which determines Opening RC monitor channel (default True)
         :return: void
         """
         Logger.debug(tag=_TAG, msg=f'run reward calc')
@@ -556,13 +558,14 @@ class RewardCalcProxy(object):
             args = [
                 reward_calculator_path,
                 "-client",
-                "-monitor",
                 "-db-count", "16",
                 "-db", f"{iscore_db_path}",
                 "-iissdata", f"{iiss_db_path}",
                 "-ipc-addr", f"{sock_path}",
                 "-log-file", f"{log_path}",
             ]
+            if icon_rc_monitor is True:
+                args.append("-monitor")
 
             Logger.info(tag=_TAG, msg=f"cmd={' '.join(args)}")
             self._reward_calc = Popen(args)

--- a/tests/integrate_test/test_integrate_service_configuration_initial.py
+++ b/tests/integrate_test/test_integrate_service_configuration_initial.py
@@ -16,6 +16,7 @@
 
 """IconScoreEngine testcase
 """
+
 from iconcommons import IconConfig
 
 from iconservice.icon_config import default_icon_config
@@ -86,3 +87,32 @@ class TestIntegrateServiceConfigurationInitial(TestIntegrateBase):
         expected_flag = IconServiceFlag.FEE | IconServiceFlag.AUDIT | \
                         IconServiceFlag.SCORE_PACKAGE_VALIDATOR | IconServiceFlag.DEPLOYER_WHITE_LIST
         self.assertEqual(context.icon_service_flag, expected_flag)
+
+    def test_service_configuration_when_rc_monitor_setting_is_true(self):
+        self.config.update_conf({ConfigKey.ICON_RC_MONITOR: True})
+        self.icon_service_engine = IconServiceEngine()
+
+        self.icon_service_engine.open(self.config)
+
+        context = IconScoreContext(IconScoreContextType.INVOKE)
+        rc_open_command: list = context.engine.iiss._reward_calc_proxy._reward_calc.args
+        assert '-monitor' in rc_open_command
+
+    def test_service_configuration_when_rc_monitor_setting_is_false(self):
+        self.config.update_conf({ConfigKey.ICON_RC_MONITOR: False})
+        self.icon_service_engine = IconServiceEngine()
+
+        self.icon_service_engine.open(self.config)
+
+        context = IconScoreContext(IconScoreContextType.INVOKE)
+        rc_open_command: list = context.engine.iiss._reward_calc_proxy._reward_calc.args
+        assert '-monitor' not in rc_open_command
+
+    def test_service_configuration_default_rc_monitor_setting(self):
+        self.icon_service_engine = IconServiceEngine()
+
+        self.icon_service_engine.open(self.config)
+
+        context = IconScoreContext(IconScoreContextType.INVOKE)
+        rc_open_command: list = context.engine.iiss._reward_calc_proxy._reward_calc.args
+        assert '-monitor' in rc_open_command

--- a/tests/integrate_test/test_integrate_service_configuration_initial.py
+++ b/tests/integrate_test/test_integrate_service_configuration_initial.py
@@ -87,32 +87,3 @@ class TestIntegrateServiceConfigurationInitial(TestIntegrateBase):
         expected_flag = IconServiceFlag.FEE | IconServiceFlag.AUDIT | \
                         IconServiceFlag.SCORE_PACKAGE_VALIDATOR | IconServiceFlag.DEPLOYER_WHITE_LIST
         self.assertEqual(context.icon_service_flag, expected_flag)
-
-    def test_service_configuration_when_rc_monitor_setting_is_true(self):
-        self.config.update_conf({ConfigKey.ICON_RC_MONITOR: True})
-        self.icon_service_engine = IconServiceEngine()
-
-        self.icon_service_engine.open(self.config)
-
-        context = IconScoreContext(IconScoreContextType.INVOKE)
-        rc_open_command: list = context.engine.iiss._reward_calc_proxy._reward_calc.args
-        assert '-monitor' in rc_open_command
-
-    def test_service_configuration_when_rc_monitor_setting_is_false(self):
-        self.config.update_conf({ConfigKey.ICON_RC_MONITOR: False})
-        self.icon_service_engine = IconServiceEngine()
-
-        self.icon_service_engine.open(self.config)
-
-        context = IconScoreContext(IconScoreContextType.INVOKE)
-        rc_open_command: list = context.engine.iiss._reward_calc_proxy._reward_calc.args
-        assert '-monitor' not in rc_open_command
-
-    def test_service_configuration_default_rc_monitor_setting(self):
-        self.icon_service_engine = IconServiceEngine()
-
-        self.icon_service_engine.open(self.config)
-
-        context = IconScoreContext(IconScoreContextType.INVOKE)
-        rc_open_command: list = context.engine.iiss._reward_calc_proxy._reward_calc.args
-        assert '-monitor' in rc_open_command


### PR DESCRIPTION
### Changes
Add configuration field: 'iconRcMonitor'
- Default: monitor on

### Test
I have tested this new feature and leave the logs in Jira

### Suggestion
I have considered bundling up the RC configuration. below is example
`
"iconRc": {
	"path": "",
    	"monitor": true
},
`
If above is more prefer way, I will modify the code accordingly.
