### PR TITLE
IS-1012: msgpack backward compatibility

### DIFF
--- a/iconservice/utils/msgpack_for_db.py
+++ b/iconservice/utils/msgpack_for_db.py
@@ -94,4 +94,4 @@ class MsgPackForDB(object):
 
     @classmethod
     def loads(cls, data: bytes) -> list:
-        return msgpack_loads(data, ext_hook=cls._decode, raw=False)
+        return msgpack_loads(data, ext_hook=cls._decode, raw=False, strict_map_key=False)

--- a/iconservice/utils/msgpack_for_ipc.py
+++ b/iconservice/utils/msgpack_for_ipc.py
@@ -130,8 +130,8 @@ class MsgPackForIpc(object):
 
     @classmethod
     def dumps(cls, data: Any) -> bytes:
-        return msgpack.dumps(data)
+        return msgpack.dumps(data, use_bin_type=False)
 
     @classmethod
     def loads(cls, data: bytes) -> list:
-        return msgpack.loads(data)
+        return msgpack.loads(data, raw=True, strict_map_key=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ plyvel>=1.0.5
 coincurve>=12.0.0
 earlgrey>=0.0.4
 iconcommons>=1.0.5
-msgpack
+msgpack~=1.0.0
 iso3166


### PR DESCRIPTION
Modify arguments of msgpack.loads and msgpack.dumps due to default parameter changed in msgpack 1.0.0 release. And specify msgpack version to compatible with 1.0.x release.