### PR TITLE
IS-1053: Transaction should be failed when calling claimIScore with value 

### DIFF
--- a/iconservice/iconscore/system_score.py
+++ b/iconservice/iconscore/system_score.py
@@ -43,7 +43,6 @@ class SystemScore(IconScoreBase):
     def on_update(self, **kwargs) -> None:
         super().on_update()
 
-    @payable
     @external
     def setStake(self, value: int = 0) -> None:
         self._context.engine.iiss.invoke(*self._get_params(locals_params=locals()))
@@ -60,7 +59,6 @@ class SystemScore(IconScoreBase):
     def getDelegation(self, address: Address) -> dict:
         return self._context.engine.iiss.query(*self._get_params(locals_params=locals()))
 
-    @payable
     @external
     def claimIScore(self) -> None:
         self._context.engine.iiss.invoke(*self._get_params(locals_params=locals()))
@@ -167,7 +165,7 @@ class InterfaceSystemScore(InterfaceScore):
     def queryIScore(self, address: Address) -> dict: pass
 
     @interface
-    def getIISSInfo(address) -> dict: pass
+    def getIISSInfo(self) -> dict: pass
 
     @interface
     def getPRep(self, address: Address) -> dict: pass

--- a/tests/integrate_test/iiss/prevote/test_iiss_claim.py
+++ b/tests/integrate_test/iiss/prevote/test_iiss_claim.py
@@ -122,6 +122,16 @@ class TestIISSClaim(TestIISSBase):
         self.assertEqual([icx, iscore], tx_results[0].event_logs[0].data)
         RewardCalcProxy.commit_claim.assert_not_called()
 
+        # TEST: claim iscore with value should fail
+        expected_status = False
+        tx = self.create_score_call_tx(from_=self._accounts[0],
+                                       to_=SYSTEM_SCORE_ADDRESS,
+                                       func_name="claimIScore",
+                                       params={},
+                                       value=5)
+
+        self.process_confirm_block_tx([tx], expected_status=expected_status)
+
     def _query_iscore_with_invalid_params(self):
         params = {
             "version": self._version,

--- a/tests/integrate_test/iiss/prevote/test_iiss_delegation.py
+++ b/tests/integrate_test/iiss/prevote/test_iiss_delegation.py
@@ -187,3 +187,11 @@ class TestIISSDelegate(TestIISSBase):
                                              params={})
         self.process_confirm_block_tx([tx])
 
+        # TEST: set delegation with value should raise exception
+        tx: dict = self.create_score_call_tx(from_=self._accounts[0],
+                                             to_=SYSTEM_SCORE_ADDRESS,
+                                             func_name="setDelegation",
+                                             params={},
+                                             value=5)
+        self.process_confirm_block_tx([tx], expected_status=False)
+

--- a/tests/integrate_test/iiss/prevote/test_iiss_stake.py
+++ b/tests/integrate_test/iiss/prevote/test_iiss_stake.py
@@ -18,6 +18,7 @@
 """
 from typing import TYPE_CHECKING, List
 
+from iconservice import SYSTEM_SCORE_ADDRESS
 from iconservice.icon_constant import Revision, ICX_IN_LOOP
 from tests.integrate_test.iiss.test_iiss_base import TestIISSBase
 
@@ -371,3 +372,18 @@ class TestIISSStake(TestIISSBase):
         response: dict = self.get_delegation(self._accounts[0])
         voting_power: int = response['votingPower']
         self.assertFalse(voting_power < 0)
+
+    def test_stake_with_value_should_raise_exception(self):
+        self.update_governance()
+        self.set_revision(Revision.IISS.value)
+        balance: int = 10 * ICX_IN_LOOP
+        self.distribute_icx(accounts=self._accounts[:1],
+                            init_balance=balance)
+
+        tx: dict = self.create_score_call_tx(from_=self._accounts[0],
+                                             to_=SYSTEM_SCORE_ADDRESS,
+                                             func_name='setStake',
+                                             params={"value": hex(8 * ICX_IN_LOOP)},
+                                             value=5)
+
+        return self.process_confirm_block_tx([tx], expected_status=False)


### PR DESCRIPTION
To get the same TX result with the master branch, removed payable decorator instead of adding check value logic. Below is the removed method list.
- setStake
- claimIScore

I have synced with this branch and it correctly worked.

You may worry about failure message format (as not the same with the master branch).
As a 'failure' message is not applied to block hash, it can be changed without revisioning.
