### PR TITLE
IS-274: Refactoring Precommitdata Manager

### DIFF
--- a/iconservice/base/block.py
+++ b/iconservice/base/block.py
@@ -47,7 +47,7 @@ class Block(object):
 
     def __init__(self,
                  block_height: int,
-                 block_hash: bytes,
+                 block_hash: Optional[bytes],
                  timestamp: int,
                  prev_hash: Optional[bytes],
                  cumulative_fee: int = 0) -> None:
@@ -211,4 +211,4 @@ class Block(object):
 
 
 # This predefined block is used to fix context.block.height access error before genesis block is synchronized.
-EMPTY_BLOCK = Block(block_height=-1, block_hash=bytes(64), timestamp=0, prev_hash=None)
+NULL_BLOCK = Block(block_height=-1, block_hash=None, timestamp=0, prev_hash=None)

--- a/iconservice/base/type_converter_templates.py
+++ b/iconservice/base/type_converter_templates.py
@@ -40,7 +40,7 @@ class ParamType(IntEnum):
     ISE_GET_STATUS = 305
 
     WRITE_PRECOMMIT = 400
-    REMOVE_PRECOMMIT = 500
+    # REMOVE_PRECOMMIT = 500
     ROLLBACK = 501
 
     VALIDATE_TRANSACTION = 600
@@ -324,8 +324,6 @@ type_convert_templates[ParamType.WRITE_PRECOMMIT] = {
     ConstantKeys.OLD_BLOCK_HASH: ValueType.BYTES,
     ConstantKeys.NEW_BLOCK_HASH: ValueType.BYTES
 }
-
-type_convert_templates[ParamType.REMOVE_PRECOMMIT] = type_convert_templates[ParamType.WRITE_PRECOMMIT]
 
 type_convert_templates[ParamType.ROLLBACK] = {
     ConstantKeys.BLOCK_HEIGHT: ValueType.INT,

--- a/iconservice/database/db.py
+++ b/iconservice/database/db.py
@@ -216,24 +216,19 @@ class ContextDatabase(object):
 
         Search order
         1. TransactionBatch
-        2. BlockBatch
-        3. StateDB
+        2. Current BlockBatch
+        3. Prev BlockBatch
+        4. StateDB
 
         :param context:
         :param key:
 
         :return: a value for a given key
         """
-        block_batch = context.block_batch
-        tx_batch = context.tx_batch
-
-        # get value from tx_batch
-        if key in tx_batch:
-            return tx_batch[key].value
-
-        # get value from block_batch
-        if key in block_batch:
-            return block_batch[key].value
+        # Find the value from tx_batch, block_batch and prev_block_batches with a given key
+        for batch in context.get_batches():
+            if key in batch:
+                return batch[key].value
 
         # get value from state_db
         return self.key_value_db.get(key)

--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -403,7 +403,10 @@ class IconServiceEngine(ContextContainer):
         # Check for block validation before invoke
         self._precommit_data_manager.validate_block_to_invoke(block)
 
-        context: 'IconScoreContext' = self._context_factory.create(IconScoreContextType.INVOKE, block=block)
+        context: 'IconScoreContext' = self._context_factory.create(
+            IconScoreContextType.INVOKE,
+            block=block,
+            prev_block_batches=self._precommit_data_manager.get_block_batches(block.prev_hash))
 
         # TODO: prev_block_votes must be support to low version about prev_block_validators by using meta storage.
         prev_block_votes: Optional[List[Tuple['Address', int]]] = \
@@ -1242,11 +1245,9 @@ class IconServiceEngine(ContextContainer):
         """
         # Checks the balance only on the invoke context(skip estimate context)
         if context.type == IconScoreContextType.INVOKE:
-            tmp_context: 'IconScoreContext' = IconScoreContext(IconScoreContextType.QUERY)
-            tmp_context.block = self._get_last_block()
             # Check if from account can charge a tx fee
             self._icon_pre_validator.execute_to_check_out_of_balance(
-                context if context.revision >= Revision.THREE.value else tmp_context,
+                context,
                 params,
                 step_price=context.step_counter.step_price)
 

--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -393,7 +393,7 @@ class IconServiceEngine(ContextContainer):
             else:
                 Logger.info(tag=_TAG,
                             msg=f"Block result already exists: \n"
-                            f"state_root_hash={bytes_to_hex(precommit_data.state_root_hash)}")
+                                f"state_root_hash={bytes_to_hex(precommit_data.state_root_hash)}")
 
             return \
                 precommit_data.block_result, \
@@ -483,9 +483,9 @@ class IconServiceEngine(ContextContainer):
                 context.storage.iiss.put_calc_period(context, context.term_period)
 
         next_preps, term, rc_state_hash = self._after_transaction_process(context,
-                                                                                 rc_db_revision,
-                                                                                 prev_block_generator,
-                                                                                 prev_block_votes)
+                                                                          rc_db_revision,
+                                                                          prev_block_generator,
+                                                                          prev_block_votes)
 
         # Save precommit data
         # It will be written to levelDB on commit

--- a/iconservice/icx/storage.py
+++ b/iconservice/icx/storage.py
@@ -25,7 +25,7 @@ from .icx_account import Account
 from .stake_part import StakePart
 from ..base.ComponentBase import StorageBase
 from ..base.address import Address
-from ..base.block import Block, EMPTY_BLOCK
+from ..base.block import Block, NULL_BLOCK
 from ..icon_constant import DEFAULT_BYTE_SIZE, DATA_BYTE_ORDER, ICX_LOG_TAG, ROLLBACK_LOG_TAG
 from ..utils import bytes_to_hex
 
@@ -68,7 +68,7 @@ class Storage(StorageBase):
         """
         super().__init__(db)
         self._db = db
-        self._last_block = EMPTY_BLOCK
+        self._last_block = NULL_BLOCK
         self._genesis: Optional['Address'] = None
         self._fee_treasury: Optional['Address'] = None
 

--- a/iconservice/precommit_data_manager.py
+++ b/iconservice/precommit_data_manager.py
@@ -226,6 +226,7 @@ class PrecommitDataManager(object):
 
     def __init__(self):
         self._root: Optional['PrecommitDataManager.Node'] = None
+        # block_hash : PrecommitDataManager.Node instance
         self._precommit_data_mapper: Dict[bytes, 'PrecommitDataManager.Node'] = {}
 
     def __len__(self):
@@ -366,3 +367,13 @@ class PrecommitDataManager(object):
     def _set_root(self, node: 'PrecommitDataManager.Node'):
         node.parent = None
         self._root = node
+
+    def get_block_batches(self, block_hash: bytes) -> Iterable['BlockBatch']:
+        node = self._precommit_data_mapper.get(block_hash)
+        if not node:
+            return
+
+        while not node.is_root():
+            yield node.precommit_data.block_batch
+            # parent means previous block node
+            node = node.parent

--- a/iconservice/precommit_data_manager.py
+++ b/iconservice/precommit_data_manager.py
@@ -224,10 +224,9 @@ class PrecommitDataManager(object):
         def is_leaf(self) -> bool:
             return len(self._children) == 0
 
-        def update_block_hash(self, src: bytes, dest: bytes):
-            self.precommit_data.block_batch.update_block_hash(dest)
+        def update_block_hash(self, block_hash: bytes):
+            self.precommit_data.block_batch.update_block_hash(block_hash)
             self._block = self.precommit_data.block_batch.block
-            self.precommit_data.block_batch.set_block_to_batch(self.precommit_data.revision)
 
     def __init__(self):
         self._root: Optional['PrecommitDataManager.Node'] = None
@@ -393,6 +392,6 @@ class PrecommitDataManager(object):
             raise InvalidParamsException(
                 f"Invalid node data (not leaf): src={src}, dest={dst}")
 
-        node.update_block_hash(src=src, dest=dst)
+        node.update_block_hash(block_hash=dst)
         del self._precommit_data_mapper[src]
         self._precommit_data_mapper[dst] = node

--- a/iconservice/precommit_data_manager.py
+++ b/iconservice/precommit_data_manager.py
@@ -14,23 +14,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from threading import Lock
-from typing import TYPE_CHECKING, Optional, List
+from typing import TYPE_CHECKING, Optional, List, Dict, Iterable
 
-from .base.block import Block, EMPTY_BLOCK
-from .base.exception import InvalidParamsException
+from iconcommons import Logger
+from .base.block import Block, NULL_BLOCK
+from .base.exception import InvalidParamsException, InternalServiceErrorException
 from .database.batch import BlockBatch
 from .database.batch import TransactionBatchValue
 from .icon_constant import Revision
-from .inv.container import Container as INVContainer
 from .iconscore.icon_score_mapper import IconScoreMapper
 from .iiss.reward_calc.msg_data import TxData
+from .inv.container import Container as INVContainer
 from .prep.prep_address_converter import PRepAddressConverter
 from .utils import bytes_to_hex, sha3_256
 
 if TYPE_CHECKING:
     from .base.address import Address
     from .prep.data import PRepContainer, Term
+
+
+_TAG = "PRECOMMIT"
 
 
 def _print_block_batch(block_batch: 'BlockBatch') -> List[str]:
@@ -169,96 +172,197 @@ class PrecommitData(object):
 class PrecommitDataManager(object):
     """Manages multiple precommit block data
 
+    Assume that it manages only 2-depth block precommit
+    - root: confirmed block: 0-depth
+    - root.children (parent): 1-depth
+    - parent.children: 2-depth
     """
 
+    class Node(object):
+        """Inner class used to manage PrecommitData in LinkedList
+
+        """
+
+        def __init__(
+                self, block: 'Block',
+                data: 'PrecommitData' = None,
+                parent: Optional['PrecommitDataManager.Node'] = None):
+            self._block = block
+            self._data = data
+            self._parent = parent
+            self._children: Dict[bytes, 'PrecommitDataManager.Node'] = {}
+
+        @property
+        def precommit_data(self) -> 'PrecommitData':
+            return self._data
+
+        @property
+        def parent(self) -> Optional['PrecommitDataManager.Node']:
+            return self._parent
+
+        @parent.setter
+        def parent(self, node: Optional['PrecommitDataManager.Node']):
+            self._parent = node
+
+        @property
+        def block(self) -> 'Block':
+            return self._block
+
+        def add_child(self, node: 'PrecommitDataManager.Node'):
+            self._children[node.block.hash] = node
+
+        def get_child(self, block_hash: bytes) -> Optional['PrecommitDataManager.Node']:
+            return self._children.get(block_hash)
+
+        def children(self) -> Iterable['PrecommitDataManager.Node']:
+            for child in self._children.values():
+                yield child
+
+        def is_root(self) -> bool:
+            return self._parent is None
+
+        def is_leaf(self) -> bool:
+            return len(self._children) == 0
+
     def __init__(self):
-        self._lock = Lock()
-        self._precommit_data_mapper = {}
-        self._last_block: Optional['Block'] = None
+        self._root: Optional['PrecommitDataManager.Node'] = None
+        self._precommit_data_mapper: Dict[bytes, 'PrecommitDataManager.Node'] = {}
+
+    def __len__(self):
+        return len(self._precommit_data_mapper)
+
+    def init(self, block: Optional['Block']):
+        """This is called in IconServiceEngine.open(), IconServiceEngine.rollback() or self._clear()
+
+        :param block: the last confirmed(=committed) block
+        :return:
+        """
+        if not block:
+            block = NULL_BLOCK
+
+        self._precommit_data_mapper.clear()
+
+        root = PrecommitDataManager.Node(block)
+        self._precommit_data_mapper[root.block.hash] = root
+        self._set_root(root)
 
     @property
     def last_block(self) -> 'Block':
-        with self._lock:
-            return self._last_block
-
-    @last_block.setter
-    def last_block(self, block: 'Block'):
-        """Set the last confirmed block
-
-        :param block:
-        :return:
-        """
-        with self._lock:
-            self._last_block = block if block else EMPTY_BLOCK
+        return self._root.block
 
     def push(self, precommit_data: 'PrecommitData'):
         block: 'Block' = precommit_data.block_batch.block
-        self._precommit_data_mapper[block.hash] = precommit_data
+        parent: Optional['PrecommitDataManager.Node'] = self._precommit_data_mapper.get(block.prev_hash)
 
-    def get(self, block_hash: 'bytes') -> Optional['PrecommitData']:
-        precommit_data = self._precommit_data_mapper.get(block_hash)
-        return precommit_data
+        if parent is None:
+            # Genesis block has no prev(=parent) block
+            parent = self._root
+        elif not (parent and parent.block.height == block.height - 1):
+            raise InternalServiceErrorException(
+                f"Parent precommitData not found: {bytes_to_hex(block.prev_hash)}")
+
+        node = PrecommitDataManager.Node(block, precommit_data, parent)
+
+        parent.add_child(node)
+        self._precommit_data_mapper[block.hash] = node
+
+    def get(self, block_hash: bytes) -> Optional['PrecommitData']:
+        if not isinstance(block_hash, bytes):
+            return None
+
+        node = self._precommit_data_mapper.get(block_hash)
+        return node.precommit_data if node else None
 
     def commit(self, block: 'Block'):
-        with self._lock:
-            self._last_block = block
+        node = self._precommit_data_mapper.get(block.hash)
+        if node is None:
+            Logger.warning(
+                tag=_TAG,
+                msg=f"No precommit data: height={block.height} hash={bytes_to_hex(block.hash)}")
+            return
 
-        # Clear remaining precommit data which have the same block height
-        self._precommit_data_mapper.clear()
+        if not node.parent.is_root() and self._root == node.parent:
+            raise InternalServiceErrorException(f"Parent should be a root")
 
-    def remove_precommit_state(self, instant_block_hash: bytes):
-        if instant_block_hash in self._precommit_data_mapper:
-            del self._precommit_data_mapper[instant_block_hash]
+        self._remove_sibling_precommit_data(block)
+        del self._precommit_data_mapper[self._root.block.hash]
+        self._set_root(node)
 
-    def empty(self) -> bool:
-        return len(self._precommit_data_mapper) == 0
+    def _remove_sibling_precommit_data(self, block_to_commit: 'Block'):
+        """Remove the sibling blocks whose height is the same as that of the block to commit
+
+        :param block_to_commit:
+        :return:
+        """
+        def pick_up_blocks_to_remove() -> Iterable['PrecommitDataManager.Node']:
+            for parent in self._root.children():
+                if block_to_commit.hash == parent.block.hash:
+                    # DO NOT remove the confirmed block and its children
+                    continue
+
+                yield parent
+                for child in parent.children():
+                    assert parent == child.parent
+                    assert child.is_leaf()
+                    yield child
+
+        for node_to_remove in pick_up_blocks_to_remove():
+            del self._precommit_data_mapper[node_to_remove.block.hash]
+
+    # def remove_precommit_state(self, instant_block_hash: bytes):
+    #     if instant_block_hash in self._precommit_data_mapper:
+    #         del self._precommit_data_mapper[instant_block_hash]
 
     def clear(self):
-        """Clear precommit data
+        """Clear all data except for root
 
         :return:
         """
-        self._precommit_data_mapper.clear()
+        self.init(self.last_block)
 
     def validate_block_to_invoke(self, block: 'Block'):
         """Check if the block to invoke is valid before invoking it
 
         :param block: block to invoke
         """
-        if not self._is_last_block_valid():
+        if self._root.block.height < 0:
+            # Exception handling for genesis block
             return
 
-        if block.prev_hash == self._last_block.hash and \
-                block.height == self._last_block.height + 1:
-            return
+        parent: 'PrecommitDataManager.Node' = self._precommit_data_mapper.get(block.prev_hash)
+        if parent:
+            if block.prev_hash == parent.block.hash and block.height == parent.block.height + 1:
+                return
 
         raise InvalidParamsException(
             f'Failed to invoke a block: '
-            f'last_block({self._last_block}) '
+            f'prev_block({parent.block if parent else None}) '
             f'block_to_invoke({block})')
 
-    def validate_precommit_block(self, instant_block_hash: bytes):
+    def validate_block_to_commit(self, block_hash: bytes):
         """Check block validation
         before write_precommit_state() or remove_precommit_state()
+        No need to consider an instant_block_hash on 2-depth block invocation
 
-        :param instant_block_hash: hash data which is used for retrieving block instance from the pre-commit data mapper
+        :param block_hash: hash data which is used for retrieving block instance from the pre-commit data mapper
         """
-        assert isinstance(instant_block_hash, bytes)
+        assert isinstance(block_hash, bytes)
 
-        precommit_data = self._precommit_data_mapper.get(instant_block_hash)
-        if precommit_data is None:
+        node: 'PrecommitDataManager.Node' = self._precommit_data_mapper.get(block_hash)
+        if node is None:
             raise InvalidParamsException(
-                f'No precommit data: block_hash({bytes_to_hex(instant_block_hash)})')
+                f'No precommit data: block_hash={bytes_to_hex(block_hash)}')
 
-        if not self._is_last_block_valid():
+        block = node.block
+        prev_block = self._root.block
+
+        if block.height == prev_block.height + 1 \
+                and (block.height == 0 or node.block.prev_hash == prev_block.hash):
             return
 
-        precommit_block = precommit_data.block
+        raise InvalidParamsException(
+            f'Invalid precommit block: prev_block({prev_block}) block({block})')
 
-        if self._last_block.hash != precommit_block.prev_hash or \
-                self._last_block.height + 1 != precommit_block.height:
-            raise InvalidParamsException(
-                f'Invalid precommit block: last_block({self._last_block}) precommit_block({precommit_block})')
-
-    def _is_last_block_valid(self) -> bool:
-        return self._last_block.height >= 0
+    def _set_root(self, node: 'PrecommitDataManager.Node'):
+        node.parent = None
+        self._root = node

--- a/iconservice/prep/engine.py
+++ b/iconservice/prep/engine.py
@@ -268,18 +268,18 @@ class Engine(EngineBase, IISSEngineListener):
 
         if is_decentralization_started or self._is_term_ended(context):
             # The current P-Rep term is over. Prepare the next P-Rep term
-            main_prep_as_dict, new_term = self._on_term_ended(context)
+            next_preps, new_term = self._on_term_ended(context)
         elif context.is_decentralized():
             # In-term P-Rep replacement
-            main_prep_as_dict, new_term = self._on_term_updated(context)
+            next_preps, new_term = self._on_term_updated(context)
         else:
-            main_prep_as_dict, new_term = None, None
+            next_preps, new_term = None, None
 
         if new_term:
             self._update_prep_grades(context, context.preps, self.term, new_term)
             context.storage.prep.put_term(context, new_term)
 
-        return main_prep_as_dict, new_term
+        return next_preps, new_term
 
     def _is_term_ended(self, context: 'IconScoreContext') -> bool:
         if self.term is None:
@@ -309,12 +309,15 @@ class Engine(EngineBase, IISSEngineListener):
 
         # Create a term with context.preps whose grades are up-to-date
         new_term: 'Term' = self._create_next_term(context, self.term)
-        main_preps_as_dict: dict = \
-            self._get_updated_main_preps(context, new_term, PRepResultState.NORMAL)
+        next_preps: dict = self._get_updated_main_preps(
+            context=context,
+            term=new_term,
+            state=PRepResultState.NORMAL
+        )
 
         Logger.debug(tag=_TAG, msg=f"{new_term}")
 
-        return main_preps_as_dict, new_term
+        return next_preps, new_term
 
     @classmethod
     def _put_last_term_info(cls, context: 'IconScoreContext', term: 'Term'):
@@ -363,12 +366,15 @@ class Engine(EngineBase, IISSEngineListener):
         if bool(new_term.flags & (TermFlag.MAIN_PREPS |
                                   TermFlag.MAIN_PREP_P2P_ENDPOINT |
                                   TermFlag.MAIN_PREP_NODE_ADDRESS)):
-            main_preps_as_dict = \
-                self._get_updated_main_preps(context, new_term, PRepResultState.IN_TERM_UPDATED)
+            next_preps = self._get_updated_main_preps(
+                context=context,
+                term=new_term,
+                state=PRepResultState.IN_TERM_UPDATED
+            )
         else:
-            main_preps_as_dict = None
+            next_preps = None
 
-        return main_preps_as_dict, new_term
+        return next_preps, new_term
 
     @classmethod
     def _update_prep_grades(cls,
@@ -530,14 +536,14 @@ class Engine(EngineBase, IISSEngineListener):
 
         :return:
         """
-        prep_as_dict: Optional[dict] = \
+        updated_main_preps: Optional[dict] = \
             cls.get_main_preps_in_dict(context, term)
 
-        if prep_as_dict:
-            prep_as_dict['irep'] = term.irep
-            prep_as_dict['state'] = state.value
+        if updated_main_preps:
+            updated_main_preps['irep'] = term.irep
+            updated_main_preps['state'] = state.value
 
-        return prep_as_dict
+        return updated_main_preps
 
     @classmethod
     def get_main_preps_in_dict(cls,

--- a/tests/integrate_test/iiss/2-depth/test_integrate_sending_icx_using_fee.py
+++ b/tests/integrate_test/iiss/2-depth/test_integrate_sending_icx_using_fee.py
@@ -1,0 +1,306 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 ICON Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""IconScoreEngine testcase
+"""
+
+import json
+from typing import TYPE_CHECKING, Optional
+
+import pytest
+
+from iconservice.base.address import Address
+from iconservice.icon_constant import ConfigKey
+from iconservice.icon_constant import Revision
+from iconservice.utils import icx_to_loop
+from tests import create_address
+from tests.integrate_test.test_integrate_base import TestIntegrateBase
+
+if TYPE_CHECKING:
+    from iconservice.icon_service_engine import IconServiceEngine
+
+
+class TestIntegrateSendingIcx(TestIntegrateBase):
+
+    def _make_init_config(self) -> dict:
+        return {ConfigKey.SERVICE: {ConfigKey.SERVICE_FEE: True}}
+
+    # def test_fail_icx_validator(self):
+    #     icx = 3 * FIXED_FEE
+    #     self.transfer_icx(from_=self._admin,
+    #                       to_=self._accounts[0],
+    #                       value=icx)
+    #
+    #     self.assertEqual(icx, self.get_balance(self._accounts[0]))
+    #
+    #     tx1 = self.create_transfer_icx_tx(from_=self._accounts[0],
+    #                                       to_=self._accounts[1],
+    #                                       value=1 * FIXED_FEE,
+    #                                       support_v2=True)
+    #     tx2 = self.create_transfer_icx_tx(from_=self._accounts[0],
+    #                                       to_=self._accounts[1],
+    #                                       value=1 * FIXED_FEE,
+    #                                       support_v2=True)
+    #     tx_results: List['TransactionResult'] = self.process_confirm_block_tx([tx1, tx2])
+    #
+    #     self.assertEqual(tx_results[0].step_used, 1_000_000)
+    #     # wrong!
+    #     self.assertEqual(tx_results[1].step_used, 0)
+
+    # def test_fix_icx_validator(self):
+    #     self.update_governance()
+    #     self.set_revision(Revision.THREE.value)
+    #
+    #     icx = 3 * FIXED_FEE
+    #     self.transfer_icx(from_=self._admin,
+    #                       to_=self._accounts[0],
+    #                       value=icx)
+    #
+    #     self.assertEqual(icx, self.get_balance(self._accounts[0]))
+    #
+    #     tx1 = self.create_transfer_icx_tx(from_=self._accounts[0],
+    #                                       to_=self._accounts[1],
+    #                                       value=1 * FIXED_FEE,
+    #                                       support_v2=True)
+    #     tx2 = self.create_transfer_icx_tx(from_=self._accounts[0],
+    #                                       to_=self._accounts[1],
+    #                                       value=1 * FIXED_FEE,
+    #                                       support_v2=True)
+    #
+    #     prev_block, hash_list = self.make_and_req_block([tx1, tx2])
+    #     self._write_precommit_state(prev_block)
+    #
+    #     tx_results: List['TransactionResult'] = self.get_tx_results(hash_list)
+    #     self.assertEqual(tx_results[0].step_used, 1_000_000)
+    #     self.assertEqual(tx_results[1].status, 0)
+
+    @staticmethod
+    def _calculate_step_limit(
+            revision: int,
+            data: Optional[str] = None,
+            default_step_cost: int = 100_000,
+            input_step_cost: int = 200
+    ) -> int:
+        if revision == Revision.THREE.value:
+            # Check backward compatibility on TestNet Database
+            # step_used increases by input_step_cost * len(json.dumps(None))
+            # because of None parameter handling error on get_input_data_size()
+            step_limit = default_step_cost + input_step_cost * len(json.dumps(data))
+        else:
+            step_limit = default_step_cost
+
+        return step_limit
+
+    def test_send_icx(self):
+        from_: 'Address' = self._admin.address
+        step_price = 10 ** 10
+        default_step_cost = 100_000
+        input_step_cost = 200
+        value = icx_to_loop(7)
+
+        icon_service_engine: IconServiceEngine = self.icon_service_engine
+
+        self.update_governance()
+
+        for revision in range(Revision.THREE.value, Revision.LATEST.value + 1):
+            self.set_revision(revision)
+
+            # The latest confirmed block
+            root_block = icon_service_engine._precommit_data_manager.last_block
+
+            # Check that "from_" address has enough icx to transfer
+            balance0: int = self.get_balance(from_)
+            self.assertTrue(balance0 > value)
+
+            # Check "to" address balance. It should be 0
+            addresses = []
+            for _ in range(2):
+                address: 'Address' = create_address()
+                balance: int = self.get_balance(address)
+                assert balance == 0
+
+                addresses.append(address)
+
+            # Estimate the step limit of icx transfer tx
+            step_limit = self._calculate_step_limit(
+                revision,
+                data=None,
+                default_step_cost=default_step_cost,
+                input_step_cost=input_step_cost
+            )
+
+            # Root -> Parent ========================================
+            # from_ sends 10 ICX to addresses[0]
+            tx = self.create_transfer_icx_tx(
+                from_=from_,
+                to_=addresses[0],
+                value=value,
+                disable_pre_validate=False,
+                support_v2=False,
+                step_limit=step_limit
+            )
+
+            prev_block = root_block
+            block, hash_list = self.make_and_req_block_for_2_depth_invocation([tx], prev_block=prev_block)
+            assert block.prev_hash == prev_block.hash
+            assert block.height == prev_block.height + 1
+            parent_block = block
+
+            # Before confirming a parent block
+            for address in addresses:
+                balance = self.get_balance(address)
+                assert balance == 0
+
+            # Root -> Parent -> Child =====================================
+            prev_block = block
+
+            # addresses[0] sends 5 ICX to addresses[1]
+            tx = self.create_transfer_icx_tx(
+                from_=addresses[0],
+                to_=addresses[1],
+                value=icx_to_loop(5),
+                disable_pre_validate=True,
+                support_v2=False,
+                step_limit=step_limit
+            )
+
+            block, hash_list = self.make_and_req_block_for_2_depth_invocation([tx], prev_block=prev_block)
+            assert block.prev_hash == prev_block.hash
+            assert block.height == prev_block.height + 1
+            child_block = block
+
+            # Before confirming a parent block
+            for address in addresses:
+                balance = self.get_balance(address)
+                assert balance == 0
+
+            self._write_precommit_state(parent_block)
+
+            balance = self.get_balance(addresses[0])
+            assert balance == icx_to_loop(7)
+
+            balance = self.get_balance(addresses[1])
+            assert balance == 0
+
+            self._write_precommit_state(child_block)
+
+            balance = self.get_balance(addresses[0])
+            assert balance < icx_to_loop(5)
+
+            balance = self.get_balance(addresses[1])
+            assert balance == icx_to_loop(5)
+
+    def test_send_icx2(self):
+        from_: 'Address' = self._admin.address
+        default_step_cost = 100_000
+        input_step_cost = 200
+        step_price = 10 ** 10
+        revision = Revision.LATEST.value
+
+        icon_service_engine: IconServiceEngine = self.icon_service_engine
+        precommit_data_manager = icon_service_engine._precommit_data_manager
+
+        self.update_governance()
+        self.set_revision(Revision.LATEST.value)
+
+        # Estimate the step limit of icx transfer tx
+        step_limit = self._calculate_step_limit(
+            revision,
+            data=None,
+            default_step_cost=default_step_cost,
+            input_step_cost=input_step_cost
+        )
+
+        # The latest confirmed block
+        root_block = icon_service_engine._precommit_data_manager.last_block
+
+        # Check that "from_" address has enough icx to transfer
+        from_balance: int = self.get_balance(from_)
+        self.assertTrue(from_balance > 0)
+
+        # Prepare empty addresses
+        count = 3
+
+        parent_addresses = []
+        child_addresses = []
+        for _ in range(count):
+            address: 'Address' = create_address()
+            balance: int = self.get_balance(address)
+            assert balance == 0
+            parent_addresses.append(address)
+
+            address: 'Address' = create_address()
+            balance: int = self.get_balance(address)
+            assert balance == 0
+            child_addresses.append(address)
+
+        parent_blocks = []
+        child_blocks = []
+
+        # from_ sends 10 ICX to addresses[0]
+        for i in range(count):
+            balance = self.get_balance(from_)
+            assert balance == from_balance
+
+            value = icx_to_loop(1)
+
+            # Root -> Parent ========================================
+            tx = self.create_transfer_icx_tx(
+                from_=from_,
+                to_=parent_addresses[i],
+                value=value,
+                disable_pre_validate=False,
+                support_v2=False,
+                step_limit=step_limit
+            )
+
+            block, hash_list = self.make_and_req_block_for_2_depth_invocation([tx], prev_block=root_block)
+            parent_blocks.append(block)
+
+            # Root -> Parent -> Child =====================================
+            value //= 2
+            tx = self.create_transfer_icx_tx(
+                from_=parent_addresses[i],
+                to_=child_addresses[i],
+                value=value,
+                disable_pre_validate=True,
+                support_v2=False,
+                step_limit=step_limit
+            )
+
+            block, hash_list = self.make_and_req_block_for_2_depth_invocation([tx], prev_block=block)
+            child_blocks.append(block)
+
+        index = 0
+        block = parent_blocks[index]
+        self._write_precommit_state(block)
+
+        for i in range(count):
+            balance = self.get_balance(parent_addresses[i])
+            assert balance == (icx_to_loop(1) if i == index else 0)
+            assert self.get_balance(child_addresses[i]) == 0
+
+            if i == index:
+                assert precommit_data_manager.get(parent_blocks[i].hash)
+                assert precommit_data_manager.get(child_blocks[i].hash)
+            else:
+                assert precommit_data_manager.get(parent_blocks[i].hash) is None
+                assert precommit_data_manager.get(child_blocks[i].hash) is None
+
+        last_block: 'Block' = precommit_data_manager.last_block
+        parent_blocks[index].cumulative_fee = step_limit * step_price
+        assert len(precommit_data_manager) == 2
+        assert last_block == parent_blocks[index]

--- a/tests/integrate_test/iiss/2-depth/test_integrate_sending_icx_using_fee.py
+++ b/tests/integrate_test/iiss/2-depth/test_integrate_sending_icx_using_fee.py
@@ -20,8 +20,6 @@
 import json
 from typing import TYPE_CHECKING, Optional
 
-import pytest
-
 from iconservice.base.address import Address
 from iconservice.icon_constant import ConfigKey
 from iconservice.icon_constant import Revision
@@ -30,7 +28,7 @@ from tests import create_address
 from tests.integrate_test.test_integrate_base import TestIntegrateBase
 
 if TYPE_CHECKING:
-    from iconservice.icon_service_engine import IconServiceEngine
+    from iconservice.base.block import Block
 
 
 class TestIntegrateSendingIcx(TestIntegrateBase):
@@ -111,15 +109,13 @@ class TestIntegrateSendingIcx(TestIntegrateBase):
         input_step_cost = 200
         value = icx_to_loop(7)
 
-        icon_service_engine: IconServiceEngine = self.icon_service_engine
-
         self.update_governance()
 
         for revision in range(Revision.THREE.value, Revision.LATEST.value + 1):
             self.set_revision(revision)
 
             # The latest confirmed block
-            root_block = icon_service_engine._precommit_data_manager.last_block
+            root_block = self.get_last_block()
 
             # Check that "from_" address has enough icx to transfer
             balance0: int = self.get_balance(from_)
@@ -210,9 +206,6 @@ class TestIntegrateSendingIcx(TestIntegrateBase):
         step_price = 10 ** 10
         revision = Revision.LATEST.value
 
-        icon_service_engine: IconServiceEngine = self.icon_service_engine
-        precommit_data_manager = icon_service_engine._precommit_data_manager
-
         self.update_governance()
         self.set_revision(Revision.LATEST.value)
 
@@ -225,7 +218,7 @@ class TestIntegrateSendingIcx(TestIntegrateBase):
         )
 
         # The latest confirmed block
-        root_block = icon_service_engine._precommit_data_manager.last_block
+        root_block = self.get_last_block()
 
         # Check that "from_" address has enough icx to transfer
         from_balance: int = self.get_balance(from_)
@@ -288,6 +281,7 @@ class TestIntegrateSendingIcx(TestIntegrateBase):
         block = parent_blocks[index]
         self._write_precommit_state(block)
 
+        precommit_data_manager = self.icon_service_engine._precommit_data_manager
         for i in range(count):
             balance = self.get_balance(parent_addresses[i])
             assert balance == (icx_to_loop(1) if i == index else 0)

--- a/tests/integrate_test/iiss/change_block_hash.py
+++ b/tests/integrate_test/iiss/change_block_hash.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2018 ICON Foundation
+# Copyright 2020 ICON Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integrate_test/iiss/change_block_hash.py
+++ b/tests/integrate_test/iiss/change_block_hash.py
@@ -1,0 +1,160 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 ICON Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""IconScoreEngine testcase
+"""
+
+from typing import TYPE_CHECKING
+from unittest.mock import Mock
+
+from iconservice import AddressPrefix
+from iconservice.base.block import Block
+from iconservice.icon_constant import ConfigKey, IconScoreContextType
+from iconservice.iconscore.icon_score_context import IconScoreContext
+from iconservice.icx.issue.base_transaction_creator import BaseTransactionCreator
+from iconservice.iiss.reward_calc.ipc.reward_calc_proxy import RewardCalcProxy
+from iconservice.utils import icx_to_loop
+from tests import create_block_hash, create_timestamp, create_address, create_tx_hash
+from tests.integrate_test.iiss.test_iiss_base import TestIISSBase
+
+if TYPE_CHECKING:
+    pass
+
+
+class TestChangeBlockHash(TestIISSBase):
+
+    def _create_base_transaction(self):
+        context = IconScoreContext(IconScoreContextType.DIRECT)
+        context._preps = context.engine.prep.preps.copy(mutable=True)
+        context._term = context.engine.prep.term.copy()
+        block_height: int = self._block_height
+        block_hash = create_block_hash()
+        timestamp_us = create_timestamp()
+        block = Block(block_height, block_hash, timestamp_us, self._prev_block_hash, 0)
+        context.block = block
+        transaction = BaseTransactionCreator.create_base_transaction(context)
+        return transaction
+
+    def test_change_block_hash_before_iiss1(self):
+        tx_list = []
+        tx = self.create_transfer_icx_tx(
+            from_=self._admin,
+            to_=self._accounts[0],
+            value=icx_to_loop(1)
+        )
+        tx_list.append(tx)
+
+        block, _ = self.make_and_req_block(tx_list=tx_list)
+        new_block_hash = create_block_hash()
+        self._write_precommit_state_leader(
+            block_height=block.height,
+            old_block_hash=block.hash,
+            new_block_hash=new_block_hash
+        )
+
+        self.assertEqual(self.get_last_block().hash, new_block_hash)
+        self.assertEqual(IconScoreContext.storage.icx.last_block.hash, new_block_hash)
+
+    def test_change_block_hash_after_iiss1(self):
+        self.init_decentralized()
+
+        tx_list = []
+        tx = self.create_transfer_icx_tx(
+            from_=self._admin,
+            to_=self._accounts[0],
+            value=icx_to_loop(1)
+        )
+        tx_list.append(tx)
+
+        block, _ = self.make_and_req_block(tx_list=tx_list)
+        new_block_hash = create_block_hash()
+        self._write_precommit_state_leader(
+            block_height=block.height,
+            old_block_hash=block.hash,
+            new_block_hash=new_block_hash
+        )
+
+        self.assertEqual(self.get_last_block().hash, new_block_hash)
+        self.assertEqual(IconScoreContext.storage.icx.last_block.hash, new_block_hash)
+
+    def test_change_block_hash3(self):
+        """
+        about commit, rollback
+        :return:
+        """
+        self.init_decentralized()
+
+        self.transfer_icx(from_=self._admin.address,
+                          to_=self._accounts[0],
+                          value=icx_to_loop(1))
+
+        tx_list = []
+        tx = self.create_transfer_icx_tx(
+            from_=self._admin,
+            to_=self._accounts[0],
+            value=icx_to_loop(5)
+        )
+        tx_list.append(tx)
+
+        block_height = 10 ** 2
+        icx = 10 ** 3
+        iscore = icx * 10 ** 3
+        RewardCalcProxy.claim_iscore = Mock(
+            return_value=(iscore, block_height))
+        RewardCalcProxy.commit_claim = Mock()
+
+        tx = self.create_claim_tx(from_=self._accounts[0])
+        tx_list.append(tx)
+
+        last_block = self.get_last_block()
+        block, tx_rets = self.make_and_req_block(
+            tx_list=tx_list
+        )
+
+        new_hash: bytes = create_block_hash()
+
+        self._write_precommit_state_leader(
+            block_height=block.height,
+            old_block_hash=block.hash,
+            new_block_hash=new_hash
+        )
+
+        m = RewardCalcProxy.commit_block
+        actual_height = m.call_args[0][1]
+        actual_hash = m.call_args[0][2]
+
+        assert block.height == actual_height
+        assert block.hash == actual_hash
+
+        m = RewardCalcProxy.commit_claim
+        actual_height = m.call_args[0][2]
+        actual_hash = m.call_args[0][3]
+
+        assert block.height == actual_height
+        assert block.hash == actual_hash
+
+        RewardCalcProxy.rollback = Mock(
+            return_value=(True, last_block.height, last_block.hash))
+
+        self.rollback(block_height=last_block.height,
+                      block_hash=last_block.hash)
+
+        m = RewardCalcProxy.rollback
+        actual_height = m.call_args[0][0]
+        actual_hash = m.call_args[0][1]
+
+        assert last_block.height == actual_height
+        assert last_block.hash == actual_hash

--- a/tests/integrate_test/iiss/change_block_hash.py
+++ b/tests/integrate_test/iiss/change_block_hash.py
@@ -81,7 +81,7 @@ class TestChangeBlockHash(TestIISSBase):
 
         block, _ = self.make_and_req_block(tx_list=tx_list)
         new_block_hash = create_block_hash()
-        self._write_precommit_state_leader(
+        self._write_precommit_state_in_leader(
             block_height=block.height,
             old_block_hash=block.hash,
             new_block_hash=new_block_hash

--- a/tests/integrate_test/iiss/change_block_hash.py
+++ b/tests/integrate_test/iiss/change_block_hash.py
@@ -126,7 +126,7 @@ class TestChangeBlockHash(TestIISSBase):
 
         new_hash: bytes = create_block_hash()
 
-        self._write_precommit_state_leader(
+        self._write_precommit_state_in_leader(
             block_height=block.height,
             old_block_hash=block.hash,
             new_block_hash=new_hash

--- a/tests/integrate_test/iiss/decentralized/test_decentralized2.py
+++ b/tests/integrate_test/iiss/decentralized/test_decentralized2.py
@@ -192,8 +192,8 @@ class TestIISSDecentralized2(TestIISSBase):
         tx: dict = self.create_set_prep_tx(from_=address,
                                            set_data={"p2pEndpoint": new_p2p_endpoint})
 
-        _, _, _, _, main_prep_as_dict = self.debug_make_and_req_block(tx_list=[tx])
-        self.assertIsNone(main_prep_as_dict)
+        _, _, _, _, next_preps = self.debug_make_and_req_block(tx_list=[tx])
+        self.assertIsNone(next_preps)
 
         self.set_revision(Revision.FIX_TOTAL_ELECTED_PREP_DELEGATED.value)
         self.set_revision(Revision.REALTIME_P2P_ENDPOINT_UPDATE.value)
@@ -203,16 +203,16 @@ class TestIISSDecentralized2(TestIISSBase):
         tx: dict = self.create_set_prep_tx(from_=address,
                                            set_data={"p2pEndpoint": new_p2p_endpoint})
 
-        _, _, _, _, main_prep_as_dict = self.debug_make_and_req_block(tx_list=[tx])
-        self.assertEqual(new_p2p_endpoint, main_prep_as_dict["preps"][0]["p2pEndpoint"])
+        _, _, _, _, next_preps = self.debug_make_and_req_block(tx_list=[tx])
+        self.assertEqual(new_p2p_endpoint, next_preps["preps"][0]["p2pEndpoint"])
 
         # set prep with the same p2pEndpoint as the old one
         tx: dict = self.create_set_prep_tx(from_=address,
                                            set_data={"p2pEndpoint": old_p2p_endpoint})
 
-        # main_prep_as_dict should not be modified
-        _, _, _, _, main_prep_as_dict = self.debug_make_and_req_block(tx_list=[tx])
-        assert main_prep_as_dict is None
+        # next_preps should not be modified
+        _, _, _, _, next_preps = self.debug_make_and_req_block(tx_list=[tx])
+        assert next_preps is None
 
     def test_check_update_endpoint2(self):
         self.update_governance()
@@ -249,9 +249,9 @@ class TestIISSDecentralized2(TestIISSBase):
                                                set_data={"p2pEndpoint": new_p2p_endpoint})
             tx_list.append(tx)
 
-        # To change the p2pEndpoints of sub P-Reps cannot affect main_prep_as_dict
-        _, _, _, _, main_prep_as_dict = self.debug_make_and_req_block(tx_list)
-        assert main_prep_as_dict is None
+        # To change the p2pEndpoints of sub P-Reps cannot affect next_preps
+        _, _, _, _, next_preps = self.debug_make_and_req_block(tx_list)
+        assert next_preps is None
 
         self.process_confirm_block_tx(tx_list)
 
@@ -265,6 +265,6 @@ class TestIISSDecentralized2(TestIISSBase):
 
         # Unregistered main P-Rep is replaced by the first sub P-Rep in descending order by delegated
         tx: dict = self.create_unregister_prep_tx(self._accounts[0])
-        _, _, _, _, main_prep_as_dict = self.debug_make_and_req_block(tx_list=[tx])
+        _, _, _, _, next_preps = self.debug_make_and_req_block(tx_list=[tx])
 
-        assert f"192.168.0.{start}:7100" == main_prep_as_dict["preps"][0]["p2pEndpoint"]
+        assert f"192.168.0.{start}:7100" == next_preps["preps"][0]["p2pEndpoint"]

--- a/tests/integrate_test/iiss/decentralized/test_preps_divide_node_address.py
+++ b/tests/integrate_test/iiss/decentralized/test_preps_divide_node_address.py
@@ -54,7 +54,7 @@ class TestPRepNodeAddressDivision(TestIISSBase):
         tx: dict = self.create_register_prep_tx(from_=account,
                                                 reg_data=reg_data)
 
-        _, tx_results, _, _, main_prep_as_dict = self.debug_make_and_req_block(tx_list=[tx])
+        _, tx_results, _, _, next_preps = self.debug_make_and_req_block(tx_list=[tx])
         self.assertEqual(tx_results[1].failure.code, ExceptionCode.INVALID_PARAMETER)
         self.assertEqual(tx_results[1].failure.message,
                          f"nodeAddress not supported: revision={Revision.DECENTRALIZATION.value}")
@@ -70,7 +70,7 @@ class TestPRepNodeAddressDivision(TestIISSBase):
         tx: dict = self.create_set_prep_tx(from_=account,
                                            set_data={"nodeAddress": str(dummy_node)})
 
-        _, tx_results, _, _, main_prep_as_dict = self.debug_make_and_req_block(tx_list=[tx])
+        _, tx_results, _, _, next_preps = self.debug_make_and_req_block(tx_list=[tx])
         self.assertEqual(tx_results[1].failure.code, ExceptionCode.INVALID_PARAMETER)
         self.assertEqual(tx_results[1].failure.message,
                          f"nodeAddress not supported: revision={Revision.DECENTRALIZATION.value}")
@@ -90,7 +90,7 @@ class TestPRepNodeAddressDivision(TestIISSBase):
         tx: dict = self.create_register_prep_tx(from_=account,
                                                 reg_data=reg_data)
 
-        block, tx_results, _, _, main_prep_as_dict = self.debug_make_and_req_block(tx_list=[tx])
+        block, tx_results, _, _, next_preps = self.debug_make_and_req_block(tx_list=[tx])
         self.assertEqual(tx_results[1].status, True)
 
         self._write_precommit_state(block)
@@ -111,9 +111,9 @@ class TestPRepNodeAddressDivision(TestIISSBase):
         tx: dict = self.create_set_prep_tx(from_=account,
                                            set_data={"nodeAddress": str(dummy_node)})
 
-        _, tx_results, _, _, main_prep_as_dict = self.debug_make_and_req_block(tx_list=[tx])
+        _, tx_results, _, _, next_preps = self.debug_make_and_req_block(tx_list=[tx])
         self.assertEqual(tx_results[1].status, True)
-        self.assertEqual(main_prep_as_dict["preps"][0]["id"], dummy_node)
+        self.assertEqual(next_preps["preps"][0]["id"], dummy_node)
 
     def test_prep_set_node_address_check_generator(self):
         self.set_revision(Revision.DIVIDE_NODE_ADDRESS.value)
@@ -135,23 +135,23 @@ class TestPRepNodeAddressDivision(TestIISSBase):
             tx_list.append(self.create_set_prep_tx(from_=account,
                                                    set_data={"nodeAddress": str(dummy_addrs[i])}))
 
-        block, tx_results, _, _, main_prep_as_dict = self.debug_make_and_req_block(tx_list=tx_list)
+        block, tx_results, _, _, next_preps = self.debug_make_and_req_block(tx_list=tx_list)
         for i in range(dummy_cnt):
             self.assertEqual(tx_results[i + 1].status, True)
 
-        self.assertEqual(main_prep_as_dict["preps"][0]["id"], last_dummy_addr)
+        self.assertEqual(next_preps["preps"][0]["id"], last_dummy_addr)
         self._write_precommit_state(block)
 
         # 1 before change node_address
         prev_block_generator = self._accounts[0].address
         prev_block_votes = [(x.address, True) for x in self._accounts[1:PREP_MAIN_PREPS]]
-        block, tx_results, _, _, main_prep_as_dict = self.debug_make_and_req_block(tx_list=[],
+        block, tx_results, _, _, next_preps = self.debug_make_and_req_block(tx_list=[],
                                                                                    prev_block_generator=prev_block_generator,
                                                                                    prev_block_validators=None,
                                                                                    prev_block_votes=prev_block_votes,
                                                                                    block=None)
         self.assertEqual(tx_results[0].status, True)
-        self.assertEqual(main_prep_as_dict, None)
+        self.assertEqual(next_preps, None)
 
         self._write_precommit_state(block)
 
@@ -164,13 +164,13 @@ class TestPRepNodeAddressDivision(TestIISSBase):
                                            set_data={"nodeAddress": str(dummy_node2)})
 
         prev_block_votes = [(x.address, True) for x in self._accounts[1:PREP_MAIN_PREPS]]
-        block, tx_results, _, _, main_prep_as_dict = self.debug_make_and_req_block(tx_list=[tx],
+        block, tx_results, _, _, next_preps = self.debug_make_and_req_block(tx_list=[tx],
                                                                                    prev_block_generator=prev_block_generator,
                                                                                    prev_block_validators=None,
                                                                                    prev_block_votes=prev_block_votes,
                                                                                    block=None)
         self.assertEqual(tx_results[0].status, True)
-        self.assertEqual(main_prep_as_dict["preps"][0]["id"], dummy_node2)
+        self.assertEqual(next_preps["preps"][0]["id"], dummy_node2)
         self._write_precommit_state(block)
 
     def test_prep_set_node_address_check_votes(self):
@@ -193,22 +193,22 @@ class TestPRepNodeAddressDivision(TestIISSBase):
             tx_list.append(self.create_set_prep_tx(from_=account,
                                                    set_data={"nodeAddress": str(dummy_addrs[i])}))
 
-        block, tx_results, _, _, main_prep_as_dict = self.debug_make_and_req_block(tx_list=tx_list)
+        block, tx_results, _, _, next_preps = self.debug_make_and_req_block(tx_list=tx_list)
         for i in range(dummy_cnt):
             self.assertEqual(tx_results[i + 1].status, True)
-        self.assertEqual(main_prep_as_dict["preps"][1]["id"], last_dummy_addr)
+        self.assertEqual(next_preps["preps"][1]["id"], last_dummy_addr)
         self._write_precommit_state(block)
 
         # 1 before change node_address
         prev_block_generator = self._accounts[0].address
         prev_block_votes = [(x.address, True) for x in self._accounts[1:PREP_MAIN_PREPS]]
-        block, tx_results, _, _, main_prep_as_dict = self.debug_make_and_req_block(tx_list=[],
+        block, tx_results, _, _, next_preps = self.debug_make_and_req_block(tx_list=[],
                                                                                    prev_block_generator=prev_block_generator,
                                                                                    prev_block_validators=None,
                                                                                    prev_block_votes=prev_block_votes,
                                                                                    block=None)
         self.assertEqual(tx_results[0].status, True)
-        self.assertEqual(main_prep_as_dict, None)
+        self.assertEqual(next_preps, None)
 
         self._write_precommit_state(block)
 
@@ -221,13 +221,13 @@ class TestPRepNodeAddressDivision(TestIISSBase):
                                            set_data={"nodeAddress": str(dummy_node2)})
 
         prev_block_votes = [(x.address, True) for x in self._accounts[1:PREP_MAIN_PREPS]]
-        block, tx_results, _, _, main_prep_as_dict = self.debug_make_and_req_block(tx_list=[tx],
+        block, tx_results, _, _, next_preps = self.debug_make_and_req_block(tx_list=[tx],
                                                                                    prev_block_generator=prev_block_generator,
                                                                                    prev_block_validators=None,
                                                                                    prev_block_votes=prev_block_votes,
                                                                                    block=None)
         self.assertEqual(tx_results[0].status, True)
-        self.assertEqual(main_prep_as_dict["preps"][1]["id"], dummy_node2)
+        self.assertEqual(next_preps["preps"][1]["id"], dummy_node2)
         self._write_precommit_state(block)
 
     def test_scenario1(self):
@@ -250,7 +250,7 @@ class TestPRepNodeAddressDivision(TestIISSBase):
         tx_list: list = [self.create_set_prep_tx(from_=prep_b,
                                                  set_data={"nodeAddress": str(prep_a)})]
 
-        block, tx_results, _, _, main_prep_as_dict = self.debug_make_and_req_block(tx_list=tx_list)
+        block, tx_results, _, _, next_preps = self.debug_make_and_req_block(tx_list=tx_list)
         self.assertEqual(tx_results[1].status, False)
         self.assertEqual(tx_results[1].failure.message, f"nodeAddress already in use: {str(prep_a)}")
 
@@ -275,13 +275,13 @@ class TestPRepNodeAddressDivision(TestIISSBase):
 
         tx_list: list = [self.create_set_prep_tx(from_=prep_a,
                                                  set_data={"nodeAddress": str(new_addr)})]
-        block, tx_results, _, _, main_prep_as_dict = self.debug_make_and_req_block(tx_list=tx_list)
+        block, tx_results, _, _, next_preps = self.debug_make_and_req_block(tx_list=tx_list)
         self.assertEqual(tx_results[1].status, True)
         self._write_precommit_state(block)
 
         tx_list: list = [self.create_set_prep_tx(from_=prep_a,
                                                  set_data={"nodeAddress": str(old_addr)})]
-        block, tx_results, _, _, main_prep_as_dict = self.debug_make_and_req_block(tx_list=tx_list)
+        block, tx_results, _, _, next_preps = self.debug_make_and_req_block(tx_list=tx_list)
         self.assertEqual(tx_results[1].status, True)
 
     def test_scenario3(self):
@@ -309,7 +309,7 @@ class TestPRepNodeAddressDivision(TestIISSBase):
 
         tx_list: list = [self.create_set_prep_tx(from_=prep_a,
                                                  set_data={"nodeAddress": str(prep_a_new_addr1)})]
-        block, tx_results, _, _, main_prep_as_dict = self.debug_make_and_req_block(tx_list=tx_list)
+        block, tx_results, _, _, next_preps = self.debug_make_and_req_block(tx_list=tx_list)
         self.assertEqual(tx_results[1].status, True)
         self._write_precommit_state(block)
 
@@ -318,7 +318,7 @@ class TestPRepNodeAddressDivision(TestIISSBase):
                          self.create_set_prep_tx(from_=prep_b,
                                                  set_data={"nodeAddress": str(prep_a_new_addr1)})]
 
-        block, tx_results, _, _, main_prep_as_dict = self.debug_make_and_req_block(tx_list=tx_list)
+        block, tx_results, _, _, next_preps = self.debug_make_and_req_block(tx_list=tx_list)
         self.assertEqual(tx_results[1].status, True)
         self.assertEqual(tx_results[2].status, True)
 
@@ -345,7 +345,7 @@ class TestPRepNodeAddressDivision(TestIISSBase):
                          self.create_set_prep_tx(from_=prep_a,
                                                  set_data={"nodeAddress": str(prep_b.address)})]
 
-        block, tx_results, _, _, main_prep_as_dict = self.debug_make_and_req_block(tx_list=tx_list)
+        block, tx_results, _, _, next_preps = self.debug_make_and_req_block(tx_list=tx_list)
         self.assertEqual(tx_results[1].status, True)
         self.assertEqual(tx_results[2].status, True)
 
@@ -393,7 +393,7 @@ class TestPRepNodeAddressDivision(TestIISSBase):
         tx_list: list = [self.create_set_prep_tx(from_=prep_a,
                                                  set_data={"nodeAddress": str(prep_b.address)})]
 
-        block, tx_results, _, _, main_prep_as_dict = self.debug_make_and_req_block(tx_list=tx_list)
+        block, tx_results, _, _, next_preps = self.debug_make_and_req_block(tx_list=tx_list)
         self.assertEqual(tx_results[1].status, True)
 
         # Before calling write_precommit_state()
@@ -458,7 +458,7 @@ class TestPRepNodeAddressDivision(TestIISSBase):
         tx_list: list = [self.create_set_prep_tx(from_=prep_a,
                                                  set_data={"nodeAddress": str(prep_b.address)})]
 
-        block, tx_results, _, _, main_prep_as_dict = self.debug_make_and_req_block(tx_list=tx_list)
+        block, tx_results, _, _, next_preps = self.debug_make_and_req_block(tx_list=tx_list)
         self.assertEqual(tx_results[1].status, False)
 
         # Before calling write_precommit_state()

--- a/tests/integrate_test/iiss/test_recover_using_wal.py
+++ b/tests/integrate_test/iiss/test_recover_using_wal.py
@@ -85,7 +85,10 @@ class TestRecoverUsingWAL(TestIISSBase):
         unregister_tx = self.create_unregister_prep_tx(self.prep_to_be_unregistered)
         delegation_tx = self.create_set_delegation_tx(self.delegator, [(self.delegated_prep, self.delegate_amount)])
         block, hash_list = self.make_and_req_block([stake_tx, unregister_tx, delegation_tx])
-        precommit_data = self.icon_service_engine._get_updated_precommit_data(block.hash, block.hash)
+
+        precommit_data = self.icon_service_engine._precommit_data_manager.get(block.hash)
+        precommit_data.block_batch.set_block_to_batch(precommit_data.revision)
+
         return precommit_data
 
     def _get_wal_writer(self, precommit_data: 'PrecommitData', is_calc_period_start_block: bool):

--- a/tests/integrate_test/test_integrate_base.py
+++ b/tests/integrate_test/test_integrate_base.py
@@ -319,11 +319,17 @@ class TestIntegrateBase(TestCase):
 
         return block, self.get_hash_list_from_tx_list(tx_list)
 
-    def _write_precommit_state(self, block: 'Block') -> None:
+    def _write_precommit_state(self, block: 'Block'):
         self.icon_service_engine.commit(block.height, block.hash, block.hash)
         self._block_height += 1
         assert block.height == self._block_height
         self._prev_block_hash = block.hash
+
+    def _write_precommit_state_leader(self, block_height: int, old_block_hash: bytes, new_block_hash: bytes):
+        self.icon_service_engine.commit(block_height, old_block_hash, new_block_hash)
+        self._block_height += 1
+        assert block_height == self._block_height
+        self._prev_block_hash = new_block_hash
 
     def rollback(self, block_height: int = -1, block_hash: Optional[bytes] = None):
         """Rollback the current state to the old one indicated by a given block

--- a/tests/integrate_test/test_integrate_base.py
+++ b/tests/integrate_test/test_integrate_base.py
@@ -170,11 +170,14 @@ class TestIntegrateBase(TestCase):
             block,
             [tx]
         )
-        self.icon_service_engine.commit(block.height, block.hash, None)
+        self.icon_service_engine.commit(block.height, block.hash, block.hash)
         self._block_height += 1
         self._prev_block_hash = block_hash
 
         return invoke_response
+
+    def get_last_block(self) -> 'Block':
+        return self.icon_service_engine._precommit_data_manager.last_block
 
     def get_tx_results(self, hash_list: List[bytes]):
         tx_results: List['TransactionResult'] = []
@@ -215,7 +218,7 @@ class TestIntegrateBase(TestCase):
         if context.is_decentralized():
             is_block_editable = True
 
-        tx_results, state_root_hash, added_transactions, main_prep_as_dict = \
+        tx_results, state_root_hash, added_transactions, next_preps = \
             self.icon_service_engine.invoke(block=block,
                                             tx_requests=tx_list,
                                             prev_block_generator=prev_block_generator,
@@ -226,12 +229,13 @@ class TestIntegrateBase(TestCase):
         self.add_tx_result(tx_results)
         return block, self.get_hash_list_from_tx_list(tx_list)
 
-    def make_and_req_block_for_2_depth_invocation(self,
-                           tx_list: list,
-                           prev_block: 'Block',
-                           prev_block_generator: Optional['Address'] = None,
-                           prev_block_validators: Optional[List['Address']] = None,
-                           prev_block_votes: Optional[List[Tuple['Address', int]]] = None,
+    def make_and_req_block_for_2_depth_invocation(
+            self,
+            tx_list: list,
+            prev_block: 'Block',
+            prev_block_generator: Optional['Address'] = None,
+            prev_block_validators: Optional[List['Address']] = None,
+            prev_block_votes: Optional[List[Tuple['Address', int]]] = None,
     ) -> Tuple['Block', List[bytes]]:
         block_height: int = prev_block.height + 1
         block_hash = create_block_hash()
@@ -241,11 +245,10 @@ class TestIntegrateBase(TestCase):
         context = IconScoreContext(IconScoreContextType.DIRECT)
 
         is_block_editable = False
-        self.icon_service_engine._set_revision_to_context(context)
         if context.is_decentralized():
             is_block_editable = True
 
-        tx_results, state_root_hash, added_transactions, main_prep_as_dict = \
+        tx_results, state_root_hash, added_transactions, next_preps = \
             self.icon_service_engine.invoke(block=block,
                                             tx_requests=tx_list,
                                             prev_block_generator=prev_block_generator,
@@ -279,7 +282,7 @@ class TestIntegrateBase(TestCase):
         if context.is_decentralized():
             is_block_editable = True
 
-        tx_results, state_root_hash, added_transactions, main_prep_as_dict = \
+        tx_results, state_root_hash, added_transactions, next_preps = \
             self.icon_service_engine.invoke(block=block,
                                             tx_requests=tx_list,
                                             prev_block_generator=prev_block_generator,
@@ -287,7 +290,7 @@ class TestIntegrateBase(TestCase):
                                             prev_block_votes=prev_block_votes,
                                             is_block_editable=is_block_editable)
 
-        return block, tx_results, state_root_hash, added_transactions, main_prep_as_dict
+        return block, tx_results, state_root_hash, added_transactions, next_preps
 
     def _make_and_req_block_for_issue_test(self,
                                            tx_list: list,
@@ -304,7 +307,7 @@ class TestIntegrateBase(TestCase):
 
         block = Block(block_height, block_hash, timestamp_us, self._prev_block_hash, cumulative_fee)
 
-        tx_results, _, added_transactions, main_prep_as_dict = \
+        tx_results, _, added_transactions, next_preps = \
             self.icon_service_engine.invoke(block=block,
                                             tx_requests=tx_list,
                                             prev_block_generator=prev_block_generator,
@@ -317,16 +320,10 @@ class TestIntegrateBase(TestCase):
         return block, self.get_hash_list_from_tx_list(tx_list)
 
     def _write_precommit_state(self, block: 'Block') -> None:
-        self.icon_service_engine.commit(block.height, block.hash, None)
+        self.icon_service_engine.commit(block.height, block.hash, block.hash)
         self._block_height += 1
         assert block.height == self._block_height
         self._prev_block_hash = block.hash
-
-    def _remove_precommit_state(self, block: 'Block') -> None:
-        """Revoke to commit the precommit data to db
-
-        """
-        self.icon_service_engine.remove_precommit_state(block.height, block.hash)
 
     def rollback(self, block_height: int = -1, block_hash: Optional[bytes] = None):
         """Rollback the current state to the old one indicated by a given block
@@ -956,7 +953,7 @@ class EOAAccount:
 
     @property
     def public_key(self) -> bytes:
-        return self._wallet.bytes_public_key
+        return self._wallet.public_key
 
     @property
     def address(self) -> 'Address':

--- a/tests/integrate_test/test_integrate_base.py
+++ b/tests/integrate_test/test_integrate_base.py
@@ -325,7 +325,7 @@ class TestIntegrateBase(TestCase):
         assert block.height == self._block_height
         self._prev_block_hash = block.hash
 
-    def _write_precommit_state_leader(self, block_height: int, old_block_hash: bytes, new_block_hash: bytes):
+    def _write_precommit_state_in_leader(self, block_height: int, old_block_hash: bytes, new_block_hash: bytes):
         self.icon_service_engine.commit(block_height, old_block_hash, new_block_hash)
         self._block_height += 1
         assert block_height == self._block_height

--- a/tests/integrate_test/test_integrate_base.py
+++ b/tests/integrate_test/test_integrate_base.py
@@ -226,6 +226,36 @@ class TestIntegrateBase(TestCase):
         self.add_tx_result(tx_results)
         return block, self.get_hash_list_from_tx_list(tx_list)
 
+    def make_and_req_block_for_2_depth_invocation(self,
+                           tx_list: list,
+                           prev_block: 'Block',
+                           prev_block_generator: Optional['Address'] = None,
+                           prev_block_validators: Optional[List['Address']] = None,
+                           prev_block_votes: Optional[List[Tuple['Address', int]]] = None,
+    ) -> Tuple['Block', List[bytes]]:
+        block_height: int = prev_block.height + 1
+        block_hash = create_block_hash()
+        timestamp_us = create_timestamp()
+
+        block = Block(block_height, block_hash, timestamp_us, prev_block.hash, 0)
+        context = IconScoreContext(IconScoreContextType.DIRECT)
+
+        is_block_editable = False
+        self.icon_service_engine._set_revision_to_context(context)
+        if context.is_decentralized():
+            is_block_editable = True
+
+        tx_results, state_root_hash, added_transactions, main_prep_as_dict = \
+            self.icon_service_engine.invoke(block=block,
+                                            tx_requests=tx_list,
+                                            prev_block_generator=prev_block_generator,
+                                            prev_block_validators=prev_block_validators,
+                                            prev_block_votes=prev_block_votes,
+                                            is_block_editable=is_block_editable)
+
+        self.add_tx_result(tx_results)
+        return block, self.get_hash_list_from_tx_list(tx_list)
+
     def debug_make_and_req_block(self,
                                  tx_list: list,
                                  prev_block_generator: Optional['Address'] = None,

--- a/tests/integrate_test/test_integrate_icon_service_engine.py
+++ b/tests/integrate_test/test_integrate_icon_service_engine.py
@@ -75,7 +75,7 @@ class TestIconServiceEngine(TestIntegrateBase):
             self.genesis_block,
             [tx]
         )
-        self.icon_service_engine.commit(self.genesis_block.height, self.genesis_block.hash, None)
+        self.icon_service_engine.commit(self.genesis_block.height, self.genesis_block.hash, self.genesis_block.hash)
         self._block_height += 1
         self._prev_block_hash = block_hash
 
@@ -139,7 +139,7 @@ class TestIconServiceEngine(TestIntegrateBase):
         self.assertNotEqual(tx_result.step_used, 0)
         self.assertEqual(tx_result.step_price, 0)
 
-        self.icon_service_engine.commit(block.height, block_hash, None)
+        self.icon_service_engine.commit(block.height, block_hash, block_hash)
 
         # Check whether fee charging works well
         from_balance: int = self.get_balance(self._admin.address)
@@ -187,7 +187,7 @@ class TestIconServiceEngine(TestIntegrateBase):
         self.assertEqual(tx_result.step_price, 0)
 
         # Write updated states to levelDB
-        self.icon_service_engine.commit(block.height, block.hash, None)
+        self.icon_service_engine.commit(block.height, block.hash, block.hash)
 
         # Check whether fee charging works well
         from_balance: int = self.get_balance(self._admin.address)
@@ -237,7 +237,7 @@ class TestIconServiceEngine(TestIntegrateBase):
         self.assertEqual(tx_result.step_price, 0)
 
         # Write updated states to levelDB
-        self.icon_service_engine.commit(block.height, block.hash, None)
+        self.icon_service_engine.commit(block.height, block.hash, block.hash)
 
         # Check whether fee charging works well
         from_balance: int = self.get_balance(self._admin.address)
@@ -293,7 +293,7 @@ class TestIconServiceEngine(TestIntegrateBase):
         self.assertEqual(tx_result.step_used, 10**6)
         self.assertEqual(tx_result.step_price, 0)
 
-        self.icon_service_engine.commit(block.height, block.hash, None)
+        self.icon_service_engine.commit(block.height, block.hash, block.hash)
 
         # Check whether fee charging works well
         from_balance: int = self.get_balance(self._admin.address)
@@ -364,7 +364,7 @@ class TestIconServiceEngine(TestIntegrateBase):
         #     self.assertEqual(step_price, 0)
         # self.assertEqual(tx_result.step_price, step_price)
 
-        self.icon_service_engine.commit(block.height, block.hash, None)
+        self.icon_service_engine.commit(block.height, block.hash, block.hash)
 
         # Check whether fee charging works well
         after_from_balance: int = self.get_balance(self._admin.address)
@@ -438,7 +438,7 @@ class TestIconServiceEngine(TestIntegrateBase):
         #     self.assertEqual(step_price, 0)
         # self.assertEqual(tx_result.step_price, step_price)
 
-        self.icon_service_engine.commit(block.height, block.hash, None)
+        self.icon_service_engine.commit(block.height, block.hash, block.hash)
 
         # Check whether fee charging works well
         after_from_balance: int = self.get_balance(self._admin.address)
@@ -550,7 +550,7 @@ class TestIconServiceEngine(TestIntegrateBase):
             cumulative_fee=0)
 
         with self.assertRaises(InvalidParamsException) as cm:
-            self.icon_service_engine.commit(block.height, block.hash, None)
+            self.icon_service_engine.commit(block.height, block.hash, block.hash)
         e = cm.exception
         self.assertEqual(ExceptionCode.INVALID_PARAMETER, e.code)
         self.assertTrue(e.message.startswith('No precommit data'))
@@ -588,21 +588,6 @@ class TestIconServiceEngine(TestIntegrateBase):
 
         self.assertEqual(self.icon_service_engine._get_last_block().hash, block_hash)
         self.assertEqual(IconScoreContext.storage.icx.last_block.hash, block_hash)
-
-    def test_rollback(self):
-        block = Block(
-            block_height=1,
-            block_hash=create_block_hash(),
-            timestamp=0,
-            prev_hash=self.genesis_block.hash,
-            cumulative_fee=0)
-
-        block_result, state_root_hash, _, _ = self.icon_service_engine.invoke(block, [])
-        self.assertIsInstance(block_result, list)
-        self.assertEqual(state_root_hash, hashlib.sha3_256(b'').digest())
-
-        self.icon_service_engine.remove_precommit_state(block.height, block.hash)
-        self.assertIsNone(self.icon_service_engine._precommit_data_manager.get(block.hash))
 
     def test_invoke_v2_with_malformed_to_address_and_type_converter(self):
         to = ''
@@ -671,7 +656,7 @@ class TestIconServiceEngine(TestIntegrateBase):
         self.assertEqual(tx_result.step_price, 0)
 
         # Write updated states to levelDB
-        self.icon_service_engine.commit(block.height, block.hash, None)
+        self.icon_service_engine.commit(block.height, block.hash, block.hash)
 
         # Check whether fee charging works well
         from_balance: int = self.get_balance(self._admin.address)

--- a/tests/legacy_unittest/mock_generator.py
+++ b/tests/legacy_unittest/mock_generator.py
@@ -30,8 +30,9 @@ from iconservice.icon_service_engine import IconServiceEngine
 from iconservice.iconscore.icon_score_context import IconScoreContext
 from iconservice.icx import IcxEngine, IcxStorage
 from iconservice.icx.issue import IssueEngine, IssueStorage
-from iconservice.iiss import IISSEngine, IISSStorage
+from iconservice.iiss.engine import Engine as IISSEngine
 from iconservice.iiss.reward_calc import RewardCalcStorage
+from iconservice.iiss.storage import Storage as IISSStorage
 from iconservice.meta import MetaDBStorage
 from iconservice.prep import PRepEngine, PRepStorage
 from iconservice.inv import INVEngine, INVStorage

--- a/tests/legacy_unittest/test_icon_inner_service.py
+++ b/tests/legacy_unittest/test_icon_inner_service.py
@@ -47,7 +47,8 @@ class TestIconInnerService(unittest.TestCase):
         self.mocked_invoke_request = {"block": block, "transactions": []}
         self.mocked_write_precommit_request = {
             ConstantKeys.BLOCK_HEIGHT: hex(0),
-            ConstantKeys.BLOCK_HASH: create_block_hash().hex()
+            ConstantKeys.OLD_BLOCK_HASH: create_block_hash().hex(),
+            ConstantKeys.NEW_BLOCK_HASH: create_block_hash().hex()
         }
         self.mocked_query_request = {
             ConstantKeys.METHOD: "icx_call",
@@ -63,45 +64,6 @@ class TestIconInnerService(unittest.TestCase):
     def tearDown(self):
         self.icon_inner_task_open_patcher.stop()
         self.icon_inner_task_close_patcher.stop()
-
-    def test_get_block_info_for_precommit_state(self):
-        block_height = 10
-        instant_block_hash = create_block_hash()
-        block_hash = create_block_hash()
-
-        # success case: when input prev write pre-commit data format, block_hash should be None
-        prev_precommit_data_format = {
-            ConstantKeys.BLOCK_HEIGHT: block_height,
-            ConstantKeys.BLOCK_HASH: instant_block_hash
-        }
-        actual_block_height, actual_instant_block_hash, actual_block_hash = \
-            IconScoreInnerTask._get_block_info_for_precommit_state(prev_precommit_data_format)
-
-        self.assertEqual(block_height, actual_block_height)
-        self.assertEqual(instant_block_hash, actual_instant_block_hash)
-        self.assertIsNone(actual_block_hash)
-
-        # success case: when input new write-pre-commit data format, block_hash should be hash
-        new_precommit_data_format = {
-            ConstantKeys.BLOCK_HEIGHT: block_height,
-            ConstantKeys.OLD_BLOCK_HASH: instant_block_hash,
-            ConstantKeys.NEW_BLOCK_HASH: block_hash
-        }
-        actual_block_height, actual_instant_block_hash, actual_block_hash = \
-            IconScoreInnerTask._get_block_info_for_precommit_state(new_precommit_data_format)
-
-        self.assertEqual(block_height, actual_block_height)
-        self.assertEqual(instant_block_hash, actual_instant_block_hash)
-        self.assertEqual(block_hash, actual_block_hash)
-
-        # failure case: when input invalid data format, should raise key error
-        invalid_precommit_data_format = {
-            ConstantKeys.BLOCK_HEIGHT: block_height,
-            ConstantKeys.OLD_BLOCK_HASH: instant_block_hash,
-        }
-        self.assertRaises(KeyError,
-                          IconScoreInnerTask._get_block_info_for_precommit_state,
-                          invalid_precommit_data_format)
 
     def test_fatal_exception_catch_on_invoke(self):
         # invoke thread: invoke, write_precommit_state, remove_precommit_state

--- a/tests/test_precommit_data_manager.py
+++ b/tests/test_precommit_data_manager.py
@@ -1,0 +1,192 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 ICON Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import time
+from typing import Iterable
+from unittest.mock import Mock
+
+import pytest
+
+from iconservice.base.block import Block
+from iconservice.base.block import NULL_BLOCK
+from iconservice.precommit_data_manager import PrecommitDataManager
+
+
+class TestPrecommitDataManager(object):
+    @pytest.fixture(scope="function")
+    def manager(self, create_precommit_data_manager):
+        return create_precommit_data_manager(NULL_BLOCK)
+
+    @pytest.fixture(scope="class")
+    def create_precommit_data_manager(self):
+        def func(block: "Block"):
+            manager = PrecommitDataManager()
+            manager.init(block)
+            return manager
+
+        return func
+
+    @pytest.fixture(scope="function")
+    def create_dummy_precommit_data(self):
+        def func(block: 'Block'):
+            data = Mock()
+            data.block_batch.block = block
+            return data
+
+        return func
+
+    @staticmethod
+    def tx_hash() -> bytes:
+        """Returns 32 length random tx_hash in bytes
+
+        :return: tx_hash in bytes
+        """
+        print("tx_hash()")
+        return os.urandom(32)
+
+    @staticmethod
+    def block_hash() -> bytes:
+        """Returns 32 length random block_hash in bytes
+
+        :return: block_hash in bytes
+        """
+        print("block_hash()")
+        return os.urandom(32)
+
+    @staticmethod
+    def timestamp() -> int:
+        return int(time.time() * 1_000_000)
+
+    def test_init_with_null_block(self, manager: 'PrecommitDataManager'):
+        precommit_data = manager.get(bytes(32))
+        assert precommit_data is None
+
+        block: 'Block' = manager.last_block
+        assert block == NULL_BLOCK
+        assert manager.get(block.hash) is None
+        assert len(manager) == 1
+
+    def test_with_genesis_block(self, manager: 'PrecommitDataManager', create_dummy_precommit_data):
+        block_hash = bytes(32)
+        block = Block(
+            block_height=0,
+            timestamp=1234,
+            block_hash=block_hash,
+            prev_hash=None,
+        )
+        precommit_data = create_dummy_precommit_data(block)
+
+        # TEST: push
+        # null_block -> genesis_block
+        manager.push(precommit_data)
+        assert manager.last_block == NULL_BLOCK
+        assert len(manager) == 2
+
+        # TEST: get
+        # null_block -> genesis_block
+        assert manager.get(block_hash) == precommit_data
+        assert len(manager) == 2
+
+        # TEST: commit
+        # genesis_block only
+        manager.commit(block)
+        assert manager.last_block == block
+        assert len(manager) == 1
+
+        # TEST clear
+        manager.clear()
+        assert manager.last_block == block
+        assert len(manager) == 1
+
+    def test_get(self, create_precommit_data_manager, create_dummy_precommit_data):
+        """
+              parent0 - child0
+             /
+        root - parent1 - child1
+             \
+              parent2 - child2
+
+        :param create_precommit_data_manager:
+        :return:
+        """
+        block_height = 100
+        root = Block(
+            block_height=block_height,
+            timestamp=self.timestamp(),
+            block_hash=self.block_hash(),
+            prev_hash=self.block_hash()
+        )
+
+        parents = []
+        for i in range(3):
+            block = Block(
+                block_height=root.height + 1,
+                timestamp=self.timestamp(),
+                block_hash=self.block_hash(),
+                prev_hash=root.hash
+            )
+            parents.append(block)
+
+        children = []
+        for i in range(3):
+            parent = parents[i]
+            block = Block(
+                block_height=parent.height + 1,
+                prev_hash=parent.hash,
+                timestamp=self.timestamp(),
+                block_hash=self.block_hash(),
+            )
+            children.append(block)
+
+        manager = create_precommit_data_manager(root)
+
+        # Push parent blocks
+        for block in parents:
+            precommit_data = create_dummy_precommit_data(block)
+            manager.push(precommit_data)
+        assert len(manager) == 4
+
+        # Push child blocks
+        for block in children:
+            precommit_data = create_dummy_precommit_data(block)
+            manager.push(precommit_data)
+        assert len(manager) == 7
+
+        # There is no precommit_data for root, because root block has been already committed.
+        assert manager.get(root.hash) is None
+
+        for block in parents:
+            precommit_data = manager.get(block.hash)
+            assert precommit_data.block_batch.block == block
+
+        for block in children:
+            precommit_data = manager.get(block.hash)
+            assert precommit_data.block_batch.block == block
+
+    def test_push(self, manager):
+        pass
+
+    def test_commit(self, manager):
+        pass
+
+    def validate_block_to_invoke(self, manager):
+        pass
+
+    def validate_block_to_commit(self, manager):
+        pass
+
+    def clear(self):
+        pass

--- a/tests/unittest/base/test_type_converter.py
+++ b/tests/unittest/base/test_type_converter.py
@@ -829,22 +829,6 @@ def test_write_precommit_convert_new_format():
     assert old_block_hash == ret_params[ConstantKeys.OLD_BLOCK_HASH]
     assert new_block_hash == ret_params[ConstantKeys.NEW_BLOCK_HASH]
 
-
-def test_remove_precommit_convert():
-    block_height = 1001
-    block_hash = create_block_hash()
-
-    request = {
-        ConstantKeys.BLOCK_HEIGHT: hex(block_height),
-        ConstantKeys.BLOCK_HASH: bytes.hex(block_hash)
-    }
-
-    ret_params = TypeConverter.convert(request, ParamType.REMOVE_PRECOMMIT)
-
-    assert block_height == ret_params[ConstantKeys.BLOCK_HEIGHT]
-    assert block_hash == ret_params[ConstantKeys.BLOCK_HASH]
-
-
 def test_validate_tx_convert():
     method = "icx_sendTransaction"
     from_addr = create_address()

--- a/tests/unittest/iiss/test_iiss_engine.py
+++ b/tests/unittest/iiss/test_iiss_engine.py
@@ -32,7 +32,7 @@ from iconservice.icx.delegation_part import DelegationPart
 from iconservice.icx.icx_account import Account
 from iconservice.icx.stake_part import StakePart
 from iconservice.icx.storage import Intent, AccountPartFlag
-from iconservice.iiss import IISSEngine
+from iconservice.iiss.engine import Engine as IISSEngine
 from iconservice.iiss.listener import EngineListener as IISSEngineListener
 from iconservice.utils import icx_to_loop
 


### PR DESCRIPTION
* Mgr is managed like tree
* rename main_prep_as_dict to next_preps
* remove remove_precommit
* unittest fix