### PR TITLE
Fix stateDB synchronization failure due to system SCORE

### DIFF
--- a/iconservice/iconscore/internal_call.py
+++ b/iconservice/iconscore/internal_call.py
@@ -47,13 +47,6 @@ class InternalCall(object):
         if func_name is None:
             func_name = STR_FALLBACK
 
-        # System SCORE inter-call enabled after Revision.SYSTEM_SCORE_ENABLED
-        # Exception
-        #   - Governance SCORE can call system SCORE inter-call
-        if addr_to == SYSTEM_SCORE_ADDRESS and context.revision < Revision.SYSTEM_SCORE_ENABLED.value :
-            if addr_from != GOVERNANCE_SCORE_ADDRESS:
-                raise ScoreNotFoundException(f"{SYSTEM_SCORE_ADDRESS} is not found")
-
         return InternalCall._call(context, addr_from, addr_to, amount, func_name, arg_params, kw_params)
 
     @staticmethod
@@ -78,6 +71,13 @@ class InternalCall(object):
                 InternalCall.emit_event_log_for_icx_transfer(context, addr_from, addr_to, amount)
 
             if addr_to.is_contract:
+                # System SCORE inter-call enabled after Revision.SYSTEM_SCORE_ENABLED
+                # Exception
+                #   - Governance SCORE can call system SCORE inter-call
+                if addr_to == SYSTEM_SCORE_ADDRESS and context.revision < Revision.SYSTEM_SCORE_ENABLED.value :
+                    if addr_from != GOVERNANCE_SCORE_ADDRESS:
+                        raise ScoreNotFoundException(f"{SYSTEM_SCORE_ADDRESS} is not found")
+
                 return InternalCall._other_score_call(
                     context, addr_from, addr_to, amount, func_name, arg_params, kw_params)
 

--- a/iconservice/iconscore/internal_call.py
+++ b/iconservice/iconscore/internal_call.py
@@ -74,7 +74,7 @@ class InternalCall(object):
                 # System SCORE inter-call enabled after Revision.SYSTEM_SCORE_ENABLED
                 # Exception
                 #   - Governance SCORE can call system SCORE inter-call
-                if addr_to == SYSTEM_SCORE_ADDRESS and context.revision < Revision.SYSTEM_SCORE_ENABLED.value :
+                if addr_to == SYSTEM_SCORE_ADDRESS and context.revision < Revision.SYSTEM_SCORE_ENABLED.value:
                     if addr_from != GOVERNANCE_SCORE_ADDRESS:
                         raise ScoreNotFoundException(f"{SYSTEM_SCORE_ADDRESS} is not found")
 

--- a/iconservice/iconscore/internal_call.py
+++ b/iconservice/iconscore/internal_call.py
@@ -21,10 +21,10 @@ from .icon_score_context_util import IconScoreContextUtil
 from .icon_score_event_log import EventLogEmitter
 from .icon_score_step import StepType
 from .icon_score_trace import Trace, TraceType
-from ..base.address import Address
-from ..base.exception import StackOverflowException
+from ..base.address import Address, SYSTEM_SCORE_ADDRESS, GOVERNANCE_SCORE_ADDRESS
+from ..base.exception import StackOverflowException, ScoreNotFoundException
 from ..base.message import Message
-from ..icon_constant import ICX_TRANSFER_EVENT_LOG, MAX_CALL_STACK_SIZE, IconScoreContextType
+from ..icon_constant import ICX_TRANSFER_EVENT_LOG, MAX_CALL_STACK_SIZE, IconScoreContextType, Revision
 
 if TYPE_CHECKING:
     from .icon_score_context import IconScoreContext
@@ -46,6 +46,14 @@ class InternalCall(object):
                             kw_params: Optional[dict] = None) -> Any:
         if func_name is None:
             func_name = STR_FALLBACK
+
+        # System SCORE inter-call enabled after Revision.SYSTEM_SCORE_ENABLED
+        # Exception
+        #   - Governance SCORE can call system SCORE inter-call
+        if addr_to == SYSTEM_SCORE_ADDRESS and context.revision < Revision.SYSTEM_SCORE_ENABLED.value :
+            if addr_from != GOVERNANCE_SCORE_ADDRESS:
+                raise ScoreNotFoundException(f"{SYSTEM_SCORE_ADDRESS} is not found")
+
         return InternalCall._call(context, addr_from, addr_to, amount, func_name, arg_params, kw_params)
 
     @staticmethod

--- a/iconservice/iiss/engine.py
+++ b/iconservice/iiss/engine.py
@@ -272,6 +272,9 @@ class Engine(EngineBase):
         handler(context, **params)
 
     def query(self, context: 'IconScoreContext', method: str, params: dict) -> Any:
+        if context.revision < Revision.SYSTEM_SCORE_ENABLED.value and \
+                context.type == IconScoreContextType.INVOKE:
+            raise InvalidRequestException(f"Do not call readonly method '{method}' with 'icx_sendTransaction'")
         handler: callable = self._query_handler[method]
         ret = handler(context, **params)
         return ret

--- a/tests/integrate_test/iiss/prevote/test_iiss.py
+++ b/tests/integrate_test/iiss/prevote/test_iiss.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 ICON Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""IconScoreEngine testcase
+"""
+from unittest.mock import Mock
+
+from iconservice.base.address import SYSTEM_SCORE_ADDRESS
+from iconservice.icon_constant import Revision, ICX_IN_LOOP
+from iconservice.iiss import IISSMethod
+from iconservice.iiss.reward_calc.ipc.reward_calc_proxy import RewardCalcProxy
+from tests.integrate_test.iiss.test_iiss_base import TestIISSBase
+
+
+class TestIISS(TestIISSBase):
+    def test_iiss_query_via_icx_sendtransaction(self):
+        self.update_governance()
+
+        # set Revision REV_IISS
+        self.set_revision(Revision.IISS.value)
+
+        # gain 100 icx
+        balance: int = 100 * ICX_IN_LOOP
+        self.distribute_icx(accounts=self._accounts[:1],
+                            init_balance=balance)
+
+        # IScore query mocking
+        block_height = 10 ** 2
+        icx = 10 ** 3
+        iscore = icx * 10 ** 3
+        RewardCalcProxy.query_iscore = Mock(return_value=(iscore, block_height))
+
+        iiss_query_method = [IISSMethod.QUERY_ISCORE, IISSMethod.GET_DELEGATION, IISSMethod.GET_STAKE]
+
+        # TEST : query via icx_sendTransaction (revision < ALLOW_INVOKE_SYSTEM_SCORE_READONLY)
+        for method in iiss_query_method:
+            self.check_query_via_icx_sendtransaction(method, False)
+
+        # TEST : query via icx_sendTransaction (revision >= ALLOW_INVOKE_SYSTEM_SCORE_READONLY)
+        self.set_revision(Revision.SYSTEM_SCORE_ENABLED.value)
+        for method in iiss_query_method:
+            self.check_query_via_icx_sendtransaction(method, True)
+
+    def check_query_via_icx_sendtransaction(self, method: str, expected_status: bool):
+        tx = self.create_score_call_tx(from_=self._admin,
+                                       to_=SYSTEM_SCORE_ADDRESS,
+                                       func_name=method,
+                                       params={"address": str(self._accounts[0].address)})
+        return self.process_confirm_block_tx([tx], expected_status=expected_status)
+

--- a/tests/integrate_test/test_integrate_base.py
+++ b/tests/integrate_test/test_integrate_base.py
@@ -349,15 +349,21 @@ class TestIntegrateBase(TestCase):
                                  prev_block_votes: Optional[List[Tuple['Address', int]]] = None,
                                  block_height: int = None) -> List['TransactionResult']:
 
+        org_tx_list = copy.deepcopy(tx_list)
+
         prev_block, hash_list = self.make_and_req_block(tx_list,
                                                         block_height,
                                                         prev_block_generator,
                                                         prev_block_validators,
                                                         prev_block_votes)
         self._write_precommit_state(prev_block)
+
+        # do not check status of added TX
+        check_tx_results = self.get_tx_results(self.get_hash_list_from_tx_list(org_tx_list))
+        for tx_result in check_tx_results:
+            self.assertEqual(int(expected_status), tx_result.status, tx_result)
+
         tx_results: List['TransactionResult'] = self.get_tx_results(hash_list)
-        for tx_result in tx_results:
-            self.assertEqual(int(expected_status), tx_result.status)
         return tx_results
 
     def process_confirm_block(self,


### PR DESCRIPTION
1. Drop TX calling IISS and P-Rep query (getStake, getPRep ...)
2. Allow Governance SCORE to call system SCORE inter-call before revision 9