### PR TITLE
IS-1089: Write the log of precommit data to the seperated file

### DIFF
--- a/iconservice/base/block.py
+++ b/iconservice/base/block.py
@@ -67,22 +67,35 @@ class Block(object):
         # set default value for compatibility with t-bears
         self.cumulative_fee = cumulative_fee
 
+    def to_dict(self, casing: Optional[callable] = None) -> dict:
+        """
+        Returns properties as `dict`
+        :return: a dict
+        """
+        new_dict = {}
+        for key, value in self.__dict__.items():
+            if key.startswith("_"):
+                key = key[1:]
+            new_dict[casing(key) if casing else key] = value
+
+        return new_dict
+
     def __str__(self) -> str:
         return f"Block(height={self._height}, " \
-                f"hash={bytes_to_hex(self._hash)}, " \
-                f"prev_hash={bytes_to_hex(self._prev_hash)}, " \
-                f"timestamp={self._timestamp}, " \
-                f"cumulative_fee={self.cumulative_fee})"
+               f"hash={bytes_to_hex(self._hash)}, " \
+               f"prev_hash={bytes_to_hex(self._prev_hash)}, " \
+               f"timestamp={self._timestamp}, " \
+               f"cumulative_fee={self.cumulative_fee})"
 
     def __repr__(self) -> str:
         return self.__str__()
 
     def __eq__(self, other):
         return isinstance(other, Block) \
-            and self._height == other._height \
-            and self._timestamp == other._timestamp \
-            and self._prev_hash == other._prev_hash \
-            and self.cumulative_fee == other.cumulative_fee
+               and self._height == other._height \
+               and self._timestamp == other._timestamp \
+               and self._prev_hash == other._prev_hash \
+               and self.cumulative_fee == other.cumulative_fee
 
     @property
     def height(self) -> int:

--- a/iconservice/database/batch.py
+++ b/iconservice/database/batch.py
@@ -39,14 +39,6 @@ class BatchValue:
     def include_state_root_hash(self):
         return self._include_state_root_hash
 
-    @value.setter
-    def value(self, _):
-        raise AccessDeniedException(f"Cannot set the value")
-
-    @include_state_root_hash.setter
-    def include_state_root_hash(self, _):
-        raise AccessDeniedException(f"Cannot set the include_state_root_hash")
-
     def to_dict(self, casing: Optional[callable] = None) -> dict:
         new_dict = {}
         for key, value in self.__dict__.items():
@@ -58,7 +50,7 @@ class BatchValue:
 
 
 class TransactionBatchValue(BatchValue):
-    def __init__(self, value: Optional[bytes], include_state_root_hash: bool, tx_index: Optional[int] = -1):
+    def __init__(self, value: Optional[bytes], include_state_root_hash: bool, tx_index: int = -1):
         super().__init__(value, include_state_root_hash)
         self._tx_index: int = tx_index
 
@@ -72,12 +64,8 @@ class TransactionBatchValue(BatchValue):
         # Fixme: Correct tx index should be set on deploying score (not -1)
         return self._tx_index
 
-    @tx_index.setter
-    def tx_index(self, _):
-        raise AccessDeniedException(f"Cannot set the tx index")
-
     def __repr__(self):
-        return 'TransactionBatchValue(%s, %d, %s)' % (self.value.hex(), self.include_state_root_hash, self.tx_index)
+        return 'TransactionBatchValue(%s, %d, %d)' % (self.value.hex(), self.include_state_root_hash, self.tx_index)
 
     def __eq__(self, other: 'TransactionBatchValue'):
         return self.value == other.value and \
@@ -86,12 +74,12 @@ class TransactionBatchValue(BatchValue):
 
 
 class BlockBatchValue(BatchValue):
-    def __init__(self, value: Optional[bytes], include_state_root_hash: bool, tx_indexes: List):
+    def __init__(self, value: Optional[bytes], include_state_root_hash: bool, tx_indexes: List[int]):
         super().__init__(value, include_state_root_hash)
-        self._tx_indexes: list = tx_indexes
+        self._tx_indexes: List[int] = tx_indexes
 
     @property
-    def tx_indexes(self) -> list:
+    def tx_indexes(self) -> List[int]:
         return copy(self._tx_indexes)
 
     def __repr__(self):

--- a/iconservice/database/batch.py
+++ b/iconservice/database/batch.py
@@ -65,7 +65,7 @@ class TransactionBatchValue(BatchValue):
         return self._tx_index
 
     def __repr__(self):
-        return 'TransactionBatchValue(%s, %d, %d)' % (self.value.hex(), self.include_state_root_hash, self.tx_index)
+        return f'TransactionBatchValue({self.value.hex()}, {self.include_state_root_hash}, {self.tx_index})'
 
     def __eq__(self, other: 'TransactionBatchValue'):
         return self.value == other.value and \
@@ -83,7 +83,7 @@ class BlockBatchValue(BatchValue):
         return copy(self._tx_indexes)
 
     def __repr__(self):
-        return 'BlockBatchValue(%s, %d, %s)' % (self.value.hex(), self.include_state_root_hash, self.tx_indexes)
+        return f'BlockBatchValue({self.value.hex()}, {self.include_state_root_hash}, {self.tx_indexes})'
 
     def __eq__(self, other: 'BlockBatchValue'):
         return self.value == other.value and \

--- a/iconservice/database/batch.py
+++ b/iconservice/database/batch.py
@@ -41,6 +41,12 @@ class TransactionBatchValue:
 
     @property
     def tx_index(self):
+        """
+        Transaction index information for debugging
+        index -1 means deploying score or the data being been recorded outside of the transaction
+        :return:
+        """
+        # Fixme: Correct tx index should be set on deploying score (not -1)
         return self._tx_index
 
     @value.setter

--- a/iconservice/database/batch.py
+++ b/iconservice/database/batch.py
@@ -27,9 +27,36 @@ from ..utils import sha3_256
 
 class TransactionBatchValue:
     def __init__(self, value: Optional[bytes], include_state_root_hash: bool, tx_index: int = -1):
-        self.value: bytes = value
-        self.include_state_root_hash: bool = include_state_root_hash
-        self.tx_index: int = tx_index
+        self._value: bytes = value
+        self._include_state_root_hash: bool = include_state_root_hash
+        self._tx_index: int = tx_index
+
+    @property
+    def value(self):
+        return self._value
+
+    @property
+    def include_state_root_hash(self):
+        return self._include_state_root_hash
+
+    @property
+    def tx_index(self):
+        return self._tx_index
+
+    @value.setter
+    def value(self, _):
+        raise AccessDeniedException(f"Cannot set the value")
+
+    @include_state_root_hash.setter
+    def include_state_root_hash(self, _):
+        raise AccessDeniedException(f"Cannot set the include_state_root_hash")
+
+    @tx_index.setter
+    def tx_index(self, _):
+        raise AccessDeniedException(f"Cannot set the tx_index")
+
+    def __repr__(self):
+        return 'TransactionBatchValue(%s, %d, %d)' % (self.value.hex(), self.include_state_root_hash, self.tx_index)
 
     def __eq__(self, other: 'TransactionBatchValue'):
         return self.value == other.value and \

--- a/iconservice/database/batch.py
+++ b/iconservice/database/batch.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 
-from collections import OrderedDict, namedtuple
+from collections import OrderedDict
 from collections.abc import MutableMapping
 from typing import Optional
 
@@ -24,7 +24,17 @@ from ..base.exception import DatabaseException, AccessDeniedException
 from ..icx import IcxStorage
 from ..utils import sha3_256
 
-TransactionBatchValue = namedtuple('TransactionBatchValue', ['value', 'include_state_root_hash'])
+
+class TransactionBatchValue:
+    def __init__(self, value: Optional[bytes], include_state_root_hash: bool, tx_index: int = -1):
+        self.value: bytes = value
+        self.include_state_root_hash: bool = include_state_root_hash
+        self.tx_index: int = tx_index
+
+    def __eq__(self, other: 'TransactionBatchValue'):
+        return self.value == other.value and \
+               self.include_state_root_hash == other.include_state_root_hash and \
+               self.tx_index == other.tx_index
 
 
 def digest(ordered_dict: OrderedDict):
@@ -71,7 +81,8 @@ class TransactionBatch(MutableMapping):
     key: Score Address
     value: IconScoreBatch
     """
-    def __init__(self, tx_hash: Optional[bytes]=None) -> None:
+
+    def __init__(self, tx_hash: Optional[bytes] = None) -> None:
         """Constructor
 
         :param tx_hash: tx_hash
@@ -148,6 +159,7 @@ class BlockBatch(Batch):
     key: Address
     value: IconScoreBatch
     """
+
     def __init__(self, block: Optional['Block'] = None):
         """Constructor
 
@@ -173,7 +185,7 @@ class BlockBatch(Batch):
     def set_block_to_batch(self, revision: int):
         # Logger.debug(tag="DB", msg=f"set_block_to_batch() block={self.block}")
         block_key: bytes = IcxStorage.LAST_BLOCK_KEY
-        block_value: tuple = TransactionBatchValue(self.block.to_bytes(revision), False)
+        block_value: 'TransactionBatchValue' = TransactionBatchValue(self.block.to_bytes(revision), False)
 
         super().__setitem__(block_key, block_value)
 

--- a/iconservice/database/db.py
+++ b/iconservice/database/db.py
@@ -273,7 +273,8 @@ class ContextDatabase(object):
             self.key_value_db.put(key, value)
         else:
             self._check_tx_batch_value(context, key, include_state_root_hash)
-            context.tx_batch[key] = TransactionBatchValue(value, include_state_root_hash)
+            tx_index: int = context.tx.index if context.tx is not None else -1
+            context.tx_batch[key] = TransactionBatchValue(value, include_state_root_hash, tx_index)
 
     def delete(self,
                context: Optional['IconScoreContext'],
@@ -298,7 +299,8 @@ class ContextDatabase(object):
             self.key_value_db.delete(key)
         else:
             self._check_tx_batch_value(context, key, include_state_root_hash)
-            context.tx_batch[key] = TransactionBatchValue(None, include_state_root_hash)
+            tx_index: int = context.tx.index if context.tx is not None else -1
+            context.tx_batch[key] = TransactionBatchValue(None, include_state_root_hash, tx_index)
 
     def close(self, context: 'IconScoreContext') -> None:
         """close db

--- a/iconservice/database/wal.py
+++ b/iconservice/database/wal.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 from enum import Flag, auto
 
+from .batch import BlockBatchValue
 from ..icon_constant import DATA_BYTE_ORDER
 from ..iiss.reward_calc.msg_data import TxData
 from ..iiss.reward_calc.storage import Storage, get_rc_version
@@ -75,10 +76,10 @@ class WALState(Flag):
     ALL = 0xFFFFFFFF
 
 
-def tx_batch_value_to_bytes(tx_batch_value: 'TransactionBatchValue') -> Optional[bytes]:
-    if not isinstance(tx_batch_value, TransactionBatchValue):
-        raise InvalidParamsException(f"Invalid value type: {type(tx_batch_value)}")
-    return tx_batch_value.value
+def block_batch_value_to_bytes(block_batch_value: 'BlockBatchValue') -> Optional[bytes]:
+    if not isinstance(block_batch_value, BlockBatchValue):
+        raise InvalidParamsException(f"Invalid value type: {type(block_batch_value)}")
+    return block_batch_value.value
 
 
 class WALogable(metaclass=ABCMeta):
@@ -87,7 +88,7 @@ class WALogable(metaclass=ABCMeta):
 
 
 class StateWAL(WALogable):
-    def __init__(self, block_batch: 'BlockBatch', converter: Optional[callable] = tx_batch_value_to_bytes):
+    def __init__(self, block_batch: 'BlockBatch', converter: Optional[callable] = block_batch_value_to_bytes):
         self.block_batch: 'BlockBatch' = block_batch
         self.converter: callable = converter
 

--- a/iconservice/iconscore/icon_score_context.py
+++ b/iconservice/iconscore/icon_score_context.py
@@ -86,7 +86,6 @@ class IconScoreContext(ABC):
         self.current_address: Optional['Address'] = None
         self.block_batch: Optional['BlockBatch'] = None
         self.tx_batch: Optional['TransactionBatch'] = None
-        self.block_batch: Optional['BlockBatch'] = None
         # For 2-depth block invocation
         self._prev_block_batches: Optional[List['BlockBatch']] = \
             [] if context_type == IconScoreContextType.INVOKE else None

--- a/iconservice/precommit_data_manager.py
+++ b/iconservice/precommit_data_manager.py
@@ -57,11 +57,6 @@ def write_precommit_data_to_file(precommit_data: 'PrecommitData', path: str):
             f.write(_convert_rc_block_batch_to_string(precommit_data.rc_block_batch))
         except Exception as e:
             f.write(f"Exception raised during writing the precommit-data: {e}")
-            Logger.warning(
-                tag=_TAG,
-                msg=f"Exception raised during writing the precommit-data: {e}"
-            )
-            pass
 
 
 def _convert_block_batch_to_string(block_batch: 'BlockBatch') -> str:

--- a/iconservice/precommit_data_manager.py
+++ b/iconservice/precommit_data_manager.py
@@ -28,6 +28,7 @@ from .iiss.reward_calc.msg_data import TxData
 from .inv.container import Container as INVContainer
 from .prep.prep_address_converter import PRepAddressConverter
 from .utils import bytes_to_hex, sha3_256, to_camel_case
+from . import __version__
 
 if TYPE_CHECKING:
     from .base.address import Address
@@ -37,6 +38,9 @@ _TAG = "PRECOMMIT"
 
 
 class PrecommitDataWriter:
+    """
+    Write Precommit data to the file for debugging
+    """
     VERSION = 0
     DIR_NAME = "precommit"
 
@@ -54,14 +58,19 @@ class PrecommitDataWriter:
             :return:
             """
         filename: str = f"{precommit_data.block.height}-{self._filename_suffix}"
-
+        Logger.info(
+            tag=_TAG,
+            msg=f"Start writing precommit data:{precommit_data})"
+        )
         with open(os.path.join(self._dir_path, filename), 'w') as f:
             try:
                 block = precommit_data.block
                 json_dict = {
+                    "iconservice": __version__,
                     "revision": precommit_data.revision,
                     "block": block if block is None else block.to_dict(to_camel_case),
                     "isStateRootHash": precommit_data.is_state_root_hash,
+                    "rcStateRootHash": precommit_data.rc_state_root_hash,
                     "stateRootHash": precommit_data.state_root_hash,
                     "prevBlockGenerator": precommit_data.prev_block_generator,
                     "blockBatch": precommit_data.block_batch.to_list(),
@@ -76,6 +85,9 @@ class PrecommitDataWriter:
 
     @classmethod
     def _json_default(cls, obj):
+        # json package do not  Address obj
+        from iconservice import Address
+
         if isinstance(obj, bytes):
             return bytes_to_hex(obj)
         elif isinstance(obj, Address):

--- a/iconservice/precommit_data_manager.py
+++ b/iconservice/precommit_data_manager.py
@@ -48,7 +48,7 @@ class PrecommitDataWriter:
         self._dir_path: str = os.path.join(path, self.DIR_NAME)
         if not os.path.exists(self._dir_path):
             os.makedirs(self._dir_path)
-        self._filename_suffix = f"precommit-data-v{self.VERSION}.json"
+        self._filename_suffix = f"precommit-v{self.VERSION}.json"
 
     def write(self, precommit_data: 'PrecommitData'):
         """
@@ -57,7 +57,9 @@ class PrecommitDataWriter:
             :param path: path to record
             :return:
             """
-        filename: str = f"{precommit_data.block.height}-{self._filename_suffix}"
+        filename: str = f"{precommit_data.block.height}" \
+                        f"-{precommit_data.state_root_hash.hex()[:8]}" \
+                        f"-{self._filename_suffix}"
         Logger.info(
             tag=_TAG,
             msg=f"PrecommitDataWriter.write() start (precommit: {precommit_data})"
@@ -68,7 +70,7 @@ class PrecommitDataWriter:
                 json_dict = {
                     "iconservice": __version__,
                     "revision": precommit_data.revision,
-                    "block": block if block is None else block.to_dict(to_camel_case),
+                    "block": block.to_dict(to_camel_case) if block is not None else None,
                     "isStateRootHash": precommit_data.is_state_root_hash,
                     "rcStateRootHash": precommit_data.rc_state_root_hash,
                     "stateRootHash": precommit_data.state_root_hash,
@@ -78,7 +80,7 @@ class PrecommitDataWriter:
                 }
                 json.dump(json_dict, f, default=self._json_default)
             except Exception as e:
-                Logger.warning(
+                Logger.exception(
                     tag=_TAG,
                     msg=f"Exception raised during writing the precommit-data: {e}"
                 )

--- a/iconservice/precommit_data_manager.py
+++ b/iconservice/precommit_data_manager.py
@@ -38,7 +38,7 @@ _TAG = "PRECOMMIT"
 
 def write_precommit_data_to_file(precommit_data: 'PrecommitData', path: str):
     """
-    Write the precommit data for debugging
+    Write the human readable precommit data to the file for debugging
     :param precommit_data:
     :param path: path to record
     :return:
@@ -56,6 +56,7 @@ def write_precommit_data_to_file(precommit_data: 'PrecommitData', path: str):
             f.write(f"\n------------rc-precommit-data---------------\n")
             f.write(_convert_rc_block_batch_to_string(precommit_data.rc_block_batch))
         except Exception as e:
+            f.write(f"Exception raised during writing the precommit-data: {e}")
             Logger.warning(
                 tag=_TAG,
                 msg=f"Exception raised during writing the precommit-data: {e}"
@@ -64,21 +65,16 @@ def write_precommit_data_to_file(precommit_data: 'PrecommitData', path: str):
 
 
 def _convert_block_batch_to_string(block_batch: 'BlockBatch') -> str:
-    """Print the latest updated states stored in IconServiceEngine
-    :return:
-    """
-    lines = []
-    lines.append(f" * 'TX: -1' It means deploying score or the data being been recorded outside of the transaction\n")
-    for i, key in enumerate(block_batch):
-        value = block_batch[key]
+    lines = [f" * 'TX: -1' means deploying score or the data being been recorded outside of the transaction\n"]
 
-        if isinstance(value, TransactionBatchValue):
-            lines.append(
-                "TX: {:<3} | {:<3}: {} - {} - {}".format(
-                    value.tx_index, i, key.hex(),
-                    bytes_to_hex(value.value),
-                    value.include_state_root_hash)
-            )
+    for i, key in enumerate(block_batch):
+        value: 'TransactionBatchValue' = block_batch[key]
+        lines.append(
+            "TX: {:<3} | {:<3}: {} - {} - {}".format(
+                value.tx_index, i, key.hex(),
+                bytes_to_hex(value.value),
+                value.include_state_root_hash)
+        )
     return "\n".join(lines)
 
 

--- a/iconservice/precommit_data_manager.py
+++ b/iconservice/precommit_data_manager.py
@@ -60,7 +60,7 @@ class PrecommitDataWriter:
         filename: str = f"{precommit_data.block.height}-{self._filename_suffix}"
         Logger.info(
             tag=_TAG,
-            msg=f"Start writing precommit data:{precommit_data})"
+            msg=f"PrecommitDataWriter.write() start (precommit: {precommit_data})"
         )
         with open(os.path.join(self._dir_path, filename), 'w') as f:
             try:
@@ -82,6 +82,10 @@ class PrecommitDataWriter:
                     tag=_TAG,
                     msg=f"Exception raised during writing the precommit-data: {e}"
                 )
+        Logger.info(
+            tag=_TAG,
+            msg=f"PrecommitDataWriter.write() end"
+        )
 
     @classmethod
     def _json_default(cls, obj):

--- a/iconservice/precommit_data_manager.py
+++ b/iconservice/precommit_data_manager.py
@@ -56,7 +56,10 @@ def write_precommit_data_to_file(precommit_data: 'PrecommitData', path: str):
             f.write(f"\n------------rc-precommit-data---------------\n")
             f.write(_convert_rc_block_batch_to_string(precommit_data.rc_block_batch))
         except Exception as e:
-            f.write(f"Exception raised during writing the precommit-data: {e}")
+            Logger.warning(
+                tag=_TAG,
+                msg=f"Exception raised during writing the precommit-data: {e}"
+            )
 
 
 def _convert_block_batch_to_string(block_batch: 'BlockBatch') -> str:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -78,10 +78,11 @@ def rmtree(path: str) -> None:
     shutil.rmtree(path, ignore_errors=True)
 
 
-def root_clear(score_path: str, state_db_path: str, iiss_db_path: str):
+def root_clear(score_path: str, state_db_path: str, iiss_db_path: str, precommit_log_path: str):
     rmtree(score_path)
     rmtree(state_db_path)
     rmtree(iiss_db_path)
+    rmtree(precommit_log_path)
 
 
 def create_timestamp():

--- a/tests/integrate_test/test_integrate_base.py
+++ b/tests/integrate_test/test_integrate_base.py
@@ -57,6 +57,7 @@ class TestIntegrateBase(TestCase):
         cls._score_root_path = '.score'
         cls._state_db_root_path = '.statedb'
         cls._iiss_db_root_path = '.iissdb'
+        cls._precommit_log_path = 'precommit'
 
         cls._test_sample_root = "samples"
         cls._signature = "VAia7YZ2Ji6igKWzjR2YsGa2m53nKPrfK7uXYW78QLE+ATehAVZPC40szvAiA6NEU5gCYB4c4qaQzqDh2ugcHgA="
@@ -72,7 +73,7 @@ class TestIntegrateBase(TestCase):
         cls._tx_results: dict = {}
 
     def setUp(self):
-        root_clear(self._score_root_path, self._state_db_root_path, self._iiss_db_root_path)
+        root_clear(self._score_root_path, self._state_db_root_path, self._iiss_db_root_path, self._precommit_log_path)
 
         self._block_height = -1
         self._prev_block_hash = None
@@ -126,7 +127,7 @@ class TestIntegrateBase(TestCase):
 
     def tearDown(self):
         self.icon_service_engine.close()
-        root_clear(self._score_root_path, self._state_db_root_path, self._iiss_db_root_path)
+        root_clear(self._score_root_path, self._state_db_root_path, self._iiss_db_root_path, self._precommit_log_path)
 
     def _make_init_config(self) -> dict:
         return {}

--- a/tests/integrate_test/test_integrate_existent_scores.py
+++ b/tests/integrate_test/test_integrate_existent_scores.py
@@ -42,7 +42,7 @@ class TestIntegrateExistentScores(TestIntegrateBase):
 
     # override setUp method for making directory before begin tests.
     def setUp(self):
-        root_clear(self._score_root_path, self._state_db_root_path, self._iiss_db_root_path)
+        root_clear(self._score_root_path, self._state_db_root_path, self._iiss_db_root_path, self._precommit_log_path)
         self._block_height = -1
         self._prev_block_hash = None
 

--- a/tests/integrate_test/test_integrate_existent_scores_audit.py
+++ b/tests/integrate_test/test_integrate_existent_scores_audit.py
@@ -43,7 +43,7 @@ class TestIntegrateExistentScoresAudit(TestIntegrateBase):
 
     # override setUp method for making directory before begin tests.
     def setUp(self):
-        root_clear(self._score_root_path, self._state_db_root_path, self._iiss_db_root_path)
+        root_clear(self._score_root_path, self._state_db_root_path, self._iiss_db_root_path, self._precommit_log_path)
         self._block_height = -1
         self._prev_block_hash = None
 

--- a/tests/integrate_test/test_integrate_fee_sharing.py
+++ b/tests/integrate_test/test_integrate_fee_sharing.py
@@ -40,7 +40,7 @@ MIN_DEPOSIT_TERM = FeeEngine._MIN_DEPOSIT_TERM
 
 class TestIntegrateFeeSharing(TestIntegrateBase):
     def setUp(self):
-        root_clear(self._score_root_path, self._state_db_root_path, self._iiss_db_root_path)
+        root_clear(self._score_root_path, self._state_db_root_path, self._iiss_db_root_path, self._precommit_log_path)
 
         self._block_height = -1
         self._prev_block_hash = None

--- a/tests/legacy_unittest/database/test_db_batch.py
+++ b/tests/legacy_unittest/database/test_db_batch.py
@@ -19,7 +19,7 @@ import unittest
 
 from iconservice.base.block import Block
 from iconservice.base.exception import AccessDeniedException
-from iconservice.database.batch import BlockBatch, TransactionBatch, TransactionBatchValue
+from iconservice.database.batch import BlockBatch, TransactionBatch, TransactionBatchValue, BlockBatchValue
 from iconservice.utils import sha3_256
 from tests import create_hash_256
 
@@ -86,14 +86,12 @@ class TestBatch(unittest.TestCase):
         tx_batch = TransactionBatch(create_hash_256())
         tx_batch[key] = TransactionBatchValue(b'value', True)
         self.block_batch.update(tx_batch)
-        self.assertEqual(TransactionBatchValue(b'value', True), self.block_batch[key])
+        self.assertEqual(BlockBatchValue(b'value', True, [-1]), self.block_batch[key])
 
         value = 100
         tx_batch[key] = TransactionBatchValue(value.to_bytes(8, byteorder), True)
         self.block_batch.update(tx_batch)
-        self.assertEqual(
-            value,
-            int.from_bytes(self.block_batch[key].value, byteorder))
+        self.assertEqual(value, int.from_bytes(self.block_batch[key].value, byteorder))
 
     def test_put_tx_batch(self):
         tx_hash = create_hash_256()

--- a/tests/legacy_unittest/database/test_db_batch.py
+++ b/tests/legacy_unittest/database/test_db_batch.py
@@ -84,45 +84,45 @@ class TestBatch(unittest.TestCase):
 
         key = create_hash_256()
         tx_batch = TransactionBatch(create_hash_256())
-        tx_batch[key] = (b'value', True)
+        tx_batch[key] = TransactionBatchValue(b'value', True)
         self.block_batch.update(tx_batch)
-        self.assertEqual((b'value', True), self.block_batch[key])
+        self.assertEqual(TransactionBatchValue(b'value', True), self.block_batch[key])
 
         value = 100
-        tx_batch[key] = (value.to_bytes(8, byteorder), True)
+        tx_batch[key] = TransactionBatchValue(value.to_bytes(8, byteorder), True)
         self.block_batch.update(tx_batch)
         self.assertEqual(
             value,
-            int.from_bytes(self.block_batch[key][0], byteorder))
+            int.from_bytes(self.block_batch[key].value, byteorder))
 
     def test_put_tx_batch(self):
         tx_hash = create_hash_256()
         tx_batch = TransactionBatch(tx_hash)
 
         key = create_hash_256()
-        tx_batch[key] = (b'value', True)
+        tx_batch[key] = TransactionBatchValue(b'value', True)
 
         key0 = create_hash_256()
-        tx_batch[key0] = (b'value0', True)
+        tx_batch[key0] = TransactionBatchValue(b'value0', True)
         key1 = create_hash_256()
-        tx_batch[key1] = (b'value1', True)
+        tx_batch[key1] = TransactionBatchValue(b'value1', True)
         key2 = create_hash_256()
-        tx_batch[key2] = (b'value2', True)
+        tx_batch[key2] = TransactionBatchValue(b'value2', True)
 
         self.assertEqual(4, len(tx_batch))
 
         tx_batch_2 = TransactionBatch(tx_hash)
-        tx_batch_2[key] = (b'haha', True)
+        tx_batch_2[key] = TransactionBatchValue(b'haha', True)
         self.block_batch.update(tx_batch_2)
         self.assertEqual(1, len(self.block_batch))
 
         self.block_batch.update(tx_batch)
 
         self.assertEqual(4, len(self.block_batch))
-        self.assertEqual((b'value0', True), self.block_batch[key0])
-        self.assertEqual((b'value1', True), self.block_batch[key1])
-        self.assertEqual((b'value2', True), self.block_batch[key2])
-        self.assertEqual((b'value', True), self.block_batch[key])
+        self.assertEqual(TransactionBatchValue(b'value0', True).value, self.block_batch[key0].value)
+        self.assertEqual(TransactionBatchValue(b'value1', True).value, self.block_batch[key1].value)
+        self.assertEqual(TransactionBatchValue(b'value2', True).value, self.block_batch[key2].value)
+        self.assertEqual(TransactionBatchValue(b'value', True).value, self.block_batch[key].value)
 
     def test_digest(self):
         block_batch = self.block_batch
@@ -173,3 +173,28 @@ class TestBatch(unittest.TestCase):
         expected = sha3_256(b'|'.join(data))
         ret = block_batch.digest()
         self.assertEqual(expected, ret)
+
+    def test_block_batch_update_tx_index(self):
+        block_batch = self.block_batch
+
+        overwrite_key = create_hash_256()
+        last_value = None
+
+        for i in range(3):
+            last_value = b'value' + i.to_bytes(1, 'big')
+            tx_batch = TransactionBatch(create_hash_256())
+            tx_batch[overwrite_key] = TransactionBatchValue(last_value, True, i)
+            block_batch.update(tx_batch)
+        tx_batch = TransactionBatch(create_hash_256())
+        tx_batch[overwrite_key] = TransactionBatchValue(b'reverted_value1', True, 3)
+        tx_batch.revert_call()
+        block_batch.update(tx_batch)
+
+        tx_batch = TransactionBatch(create_hash_256())
+        tx_batch[overwrite_key] = TransactionBatchValue(b'reverted_value2', True, 4)
+        tx_batch.clear()
+        block_batch.update(tx_batch)
+
+        actual_overwrite_value: 'TransactionBatchValue' = block_batch.get(overwrite_key)
+        assert actual_overwrite_value.value == last_value
+        assert actual_overwrite_value.tx_indexes == [0, 1, 2]

--- a/tests/legacy_unittest/database/test_db_db.py
+++ b/tests/legacy_unittest/database/test_db_db.py
@@ -21,7 +21,7 @@ from unittest.mock import patch
 
 from iconservice.base.address import Address, AddressPrefix
 from iconservice.base.exception import DatabaseException, InvalidParamsException
-from iconservice.database.batch import BlockBatch, TransactionBatch, TransactionBatchValue
+from iconservice.database.batch import BlockBatch, TransactionBatch, TransactionBatchValue, BlockBatchValue
 from iconservice.database.db import ContextDatabase, MetaContextDatabase
 from iconservice.database.db import IconScoreDatabase
 from iconservice.database.db import KeyValueDatabase
@@ -57,8 +57,8 @@ class TestKeyValueDatabase(unittest.TestCase):
 
     def test_write_batch(self):
         data = {
-            b'key0': TransactionBatchValue(b'value0', True),
-            b'key1': TransactionBatchValue(b'value1', True)
+            b'key0': BlockBatchValue(b'value0', True, [-1]),
+            b'key1': BlockBatchValue(b'value1', True, [-1])
         }
         db = self.db
 
@@ -150,8 +150,8 @@ class TestContextDatabaseOnWriteMode(unittest.TestCase):
     def test_write_batch(self):
         context = self.context
         data = {
-            b'key0': TransactionBatchValue(b'value0', True),
-            b'key1': TransactionBatchValue(b'value1', True)
+            b'key0': BlockBatchValue(b'value0', True, [-1]),
+            b'key1': BlockBatchValue(b'value1', True, [-1])
         }
         db = self.context_db
         db.write_batch(context, StateWAL(data))
@@ -212,15 +212,19 @@ class TestContextDatabaseOnWriteMode(unittest.TestCase):
         context = self.context
         db = self.context_db
         tx_batch = context.tx_batch
-        state_wal = StateWAL(tx_batch)
+        block_batch = context.block_batch
 
         db._put(context, b'key0', b'value0', True)
         db._put(context, b'key1', b'value1', True)
         self.assertEqual(b'value0', db.get(context, b'key0'))
         self.assertEqual(TransactionBatchValue(b'value0', True), tx_batch[b'key0'])
 
+        block_batch.update(tx_batch)
+        state_wal = StateWAL(block_batch)
         db.write_batch(context, state_wal)
         tx_batch.clear()
+        block_batch.clear()
+
         self.assertEqual(0, len(tx_batch))
         self.assertEqual(b'value0', db.get(context, b'key0'))
 
@@ -230,8 +234,11 @@ class TestContextDatabaseOnWriteMode(unittest.TestCase):
         self.assertEqual(None, db.get(context, b'key1'))
         self.assertEqual(TransactionBatchValue(None, True), tx_batch[b'key0'])
         self.assertEqual(TransactionBatchValue(None, False), tx_batch[b'key1'])
+        block_batch.update(tx_batch)
         db.write_batch(context, state_wal)
         tx_batch.clear()
+        block_batch.clear()
+
         self.assertEqual(0, len(tx_batch))
         self.assertIsNone(db.get(context, b'key0'))
         self.assertIsNone(db.get(context, b'key1'))

--- a/tests/legacy_unittest/database/test_db_db.py
+++ b/tests/legacy_unittest/database/test_db_db.py
@@ -115,14 +115,14 @@ class TestContextDatabaseOnWriteMode(unittest.TestCase):
         self.assertEqual(b'value0', value)
 
         batch = self.context.tx_batch
-        self.assertEqual((b'value0', True), batch[b'key0'])
+        self.assertEqual(TransactionBatchValue(b'value0', True), batch[b'key0'])
 
         self.context_db._put(context, b'key0', b'value1', True)
         self.context_db._put(context, b'key1', b'value1', True)
 
         self.assertEqual(len(batch), 2)
-        self.assertEqual(batch[b'key0'], (b'value1', True))
-        self.assertEqual(batch[b'key1'], (b'value1', True))
+        self.assertEqual(batch[b'key0'], TransactionBatchValue(b'value1', True))
+        self.assertEqual(batch[b'key1'], TransactionBatchValue(b'value1', True))
 
         self.context_db._put(context, b'key2', b'value2', False)
         self.context_db._put(context, b'key3', b'value3', False)
@@ -133,8 +133,8 @@ class TestContextDatabaseOnWriteMode(unittest.TestCase):
         self.assertEqual(b'value3', value3)
 
         self.assertEqual(len(batch), 4)
-        self.assertEqual(batch[b'key2'], (b'value2', False))
-        self.assertEqual(batch[b'key3'], (b'value3', False))
+        self.assertEqual(batch[b'key2'], TransactionBatchValue(b'value2', False))
+        self.assertEqual(batch[b'key3'], TransactionBatchValue(b'value3', False))
 
         # overwrite
         self.assertRaises(DatabaseException, self.context_db._put, context, b'key3', b'value3', True)
@@ -217,7 +217,7 @@ class TestContextDatabaseOnWriteMode(unittest.TestCase):
         db._put(context, b'key0', b'value0', True)
         db._put(context, b'key1', b'value1', True)
         self.assertEqual(b'value0', db.get(context, b'key0'))
-        self.assertEqual((b'value0', True), tx_batch[b'key0'])
+        self.assertEqual(TransactionBatchValue(b'value0', True), tx_batch[b'key0'])
 
         db.write_batch(context, state_wal)
         tx_batch.clear()
@@ -228,8 +228,8 @@ class TestContextDatabaseOnWriteMode(unittest.TestCase):
         db._delete(context, b'key1', False)
         self.assertEqual(None, db.get(context, b'key0'))
         self.assertEqual(None, db.get(context, b'key1'))
-        self.assertEqual((None, True), tx_batch[b'key0'])
-        self.assertEqual((None, False), tx_batch[b'key1'])
+        self.assertEqual(TransactionBatchValue(None, True), tx_batch[b'key0'])
+        self.assertEqual(TransactionBatchValue(None, False), tx_batch[b'key1'])
         db.write_batch(context, state_wal)
         tx_batch.clear()
         self.assertEqual(0, len(tx_batch))
@@ -243,7 +243,7 @@ class TestContextDatabaseOnWriteMode(unittest.TestCase):
 
         db._put(context, b'key0', b'value0', True)
         self.assertEqual(b'value0', db.get(context, b'key0'))
-        self.assertEqual((b'value0', True), tx_batch[b'key0'])
+        self.assertEqual(TransactionBatchValue(b'value0', True), tx_batch[b'key0'])
 
         context.func_type = IconScoreFuncType.READONLY
         with self.assertRaises(DatabaseException):
@@ -252,7 +252,7 @@ class TestContextDatabaseOnWriteMode(unittest.TestCase):
         context.func_type = IconScoreFuncType.WRITABLE
         db._delete(context, b'key0', True)
         self.assertIsNone(db.get(context, b'key0'))
-        self.assertEqual((None, True), tx_batch[b'key0'])
+        self.assertEqual(TransactionBatchValue(None, True), tx_batch[b'key0'])
 
     def test_put_and_delete_of_meta_context_db(self):
         context = self.context
@@ -261,13 +261,13 @@ class TestContextDatabaseOnWriteMode(unittest.TestCase):
 
         context_db.put(context, b'c_key', b'value0')
         meta_context_db.put(context, b'm_key', b'value0')
-        self.assertEqual((b'value0', True), context.tx_batch[b'c_key'])
-        self.assertEqual((b'value0', False), context.tx_batch[b'm_key'])
+        self.assertEqual(TransactionBatchValue(b'value0', True), context.tx_batch[b'c_key'])
+        self.assertEqual(TransactionBatchValue(b'value0', False), context.tx_batch[b'm_key'])
 
         context_db.delete(context, b'c_key')
         meta_context_db.delete(context, b'm_key')
-        self.assertEqual((None, True), context.tx_batch[b'c_key'])
-        self.assertEqual((None, False), context.tx_batch[b'm_key'])
+        self.assertEqual(TransactionBatchValue(None, True), context.tx_batch[b'c_key'])
+        self.assertEqual(TransactionBatchValue(None, False), context.tx_batch[b'm_key'])
 
 
 class TestIconScoreDatabase(unittest.TestCase):

--- a/tests/legacy_unittest/database/test_transaction_batch.py
+++ b/tests/legacy_unittest/database/test_transaction_batch.py
@@ -16,7 +16,7 @@
 import unittest
 
 from iconservice.base.exception import DatabaseException
-from iconservice.database.batch import BlockBatch, TransactionBatch, TransactionBatchValue
+from iconservice.database.batch import BlockBatch, TransactionBatch, TransactionBatchValue, BlockBatchValue
 
 
 class TestTransactionBatch(unittest.TestCase):
@@ -149,4 +149,4 @@ class TestTransactionBatch(unittest.TestCase):
 
         block_batch = BlockBatch()
         block_batch.update(tx_batch)
-        self.assertEqual(TransactionBatchValue(b'value0', True), block_batch[b'key0'])
+        self.assertEqual(BlockBatchValue(b'value0', True, [-1]), block_batch[b'key0'])

--- a/tests/legacy_unittest/database/test_transaction_batch.py
+++ b/tests/legacy_unittest/database/test_transaction_batch.py
@@ -16,48 +16,48 @@
 import unittest
 
 from iconservice.base.exception import DatabaseException
-from iconservice.database.batch import BlockBatch, TransactionBatch
+from iconservice.database.batch import BlockBatch, TransactionBatch, TransactionBatchValue
 
 
 class TestTransactionBatch(unittest.TestCase):
     def test_enter_call(self):
         tx_batch = TransactionBatch()
-        call_count:int = tx_batch.call_count
+        call_count: int = tx_batch.call_count
         self.assertEqual(1, call_count)
 
         tx_batch.enter_call()
         self.assertEqual(call_count + 1, tx_batch.call_count)
 
-        tx_batch[b'key'] = b'value'
-        self.assertEqual(b'value', tx_batch[b'key'])
+        tx_batch[b'key'] = TransactionBatchValue(b'value', True)
+        self.assertEqual(TransactionBatchValue(b'value', True), tx_batch[b'key'])
 
         tx_batch.leave_call()
         self.assertEqual(call_count, tx_batch.call_count)
-        self.assertEqual(b'value', tx_batch[b'key'])
+        self.assertEqual(TransactionBatchValue(b'value', True), tx_batch[b'key'])
 
         tx_batch.enter_call()
         self.assertEqual(call_count + 1, tx_batch.call_count)
 
-        tx_batch[b'id'] = b'hello'
-        self.assertEqual(b'hello', tx_batch[b'id'])
-        self.assertEqual(b'value', tx_batch[b'key'])
+        tx_batch[b'id'] = TransactionBatchValue(b'hello', True)
+        self.assertEqual(TransactionBatchValue(b'hello', True), tx_batch[b'id'])
+        self.assertEqual(TransactionBatchValue(b'value', True), tx_batch[b'key'])
 
         tx_batch.revert_call()
         self.assertEqual(None, tx_batch[b'id'])
-        self.assertEqual(b'value', tx_batch[b'key'])
+        self.assertEqual(TransactionBatchValue(b'value', True), tx_batch[b'key'])
         self.assertEqual(call_count + 1, tx_batch.call_count)
 
         tx_batch.leave_call()
         self.assertEqual(None, tx_batch[b'id'])
-        self.assertEqual(b'value', tx_batch[b'key'])
+        self.assertEqual(TransactionBatchValue(b'value', True), tx_batch[b'key'])
         self.assertEqual(call_count, tx_batch.call_count)
 
     def test_iter(self):
         tx_batch = TransactionBatch()
-        tx_batch[b'key0'] = b'value0'
+        tx_batch[b'key0'] = TransactionBatchValue(b'value0', True)
 
         tx_batch.enter_call()
-        tx_batch[b'key1'] = b'value1'
+        tx_batch[b'key1'] = TransactionBatchValue(b'value1', True)
 
         keys = []
         for key in tx_batch:
@@ -72,36 +72,36 @@ class TestTransactionBatch(unittest.TestCase):
         self.assertEqual(0, len(tx_batch))
         self.assertEqual(1, init_call_count)
 
-        tx_batch[b'key0'] = b'value0'
+        tx_batch[b'key0'] = TransactionBatchValue(b'value0', True)
         self.assertEqual(1, len(tx_batch))
 
         tx_batch.enter_call()
-        tx_batch[b'key1'] = b'value1'
+        tx_batch[b'key1'] = TransactionBatchValue(b'value1', True)
         self.assertEqual(2, len(tx_batch))
         self.assertEqual(init_call_count + 1, tx_batch.call_count)
 
         tx_batch.enter_call()
-        tx_batch[b'key0'] = None
-        tx_batch[b'key1'] = b'key1'
-        tx_batch[b'key2'] = b'value2'
+        tx_batch[b'key0'] = TransactionBatchValue(None, True)
+        tx_batch[b'key1'] = TransactionBatchValue(b'key1', True)
+        tx_batch[b'key2'] = TransactionBatchValue(b'value2', True)
         self.assertEqual(5, len(tx_batch))
         self.assertEqual(init_call_count + 2, tx_batch.call_count)
 
         tx_batch.leave_call()
         self.assertEqual(4, len(tx_batch))
-        self.assertEqual(b'key1', tx_batch[b'key1'])
+        self.assertEqual(TransactionBatchValue(b'key1', True), tx_batch[b'key1'])
         self.assertEqual(init_call_count + 1, tx_batch.call_count)
 
         tx_batch.leave_call()
         self.assertEqual(3, len(tx_batch))
-        self.assertEqual(None, tx_batch[b'key0'])
-        self.assertEqual(b'key1', tx_batch[b'key1'])
-        self.assertEqual(b'value2', tx_batch[b'key2'])
+        self.assertEqual(TransactionBatchValue(None, True), tx_batch[b'key0'])
+        self.assertEqual(TransactionBatchValue(b'key1', True), tx_batch[b'key1'])
+        self.assertEqual(TransactionBatchValue(b'value2', True), tx_batch[b'key2'])
         self.assertEqual(init_call_count, tx_batch.call_count)
 
     def test_delitem(self):
         tx_batch = TransactionBatch()
-        tx_batch[b'key0'] = b'value0'
+        tx_batch[b'key0'] = TransactionBatchValue(b'value0', True)
 
         with self.assertRaises(DatabaseException):
             del tx_batch[b'key0']
@@ -112,18 +112,18 @@ class TestTransactionBatch(unittest.TestCase):
         self.assertEqual(0, len(tx_batch))
         self.assertEqual(1, init_call_count)
 
-        tx_batch[b'key0'] = b'value0'
+        tx_batch[b'key0'] = TransactionBatchValue(b'value0', True)
         self.assertEqual(1, len(tx_batch))
 
         tx_batch.enter_call()
-        tx_batch[b'key1'] = b'value1'
+        tx_batch[b'key1'] = TransactionBatchValue(b'value1', True)
         self.assertEqual(2, len(tx_batch))
         self.assertEqual(init_call_count + 1, tx_batch.call_count)
 
         tx_batch.enter_call()
-        tx_batch[b'key0'] = None
-        tx_batch[b'key1'] = b'key1'
-        tx_batch[b'key2'] = b'value2'
+        tx_batch[b'key0'] = TransactionBatchValue(None, True)
+        tx_batch[b'key1'] = TransactionBatchValue(b'key1', True)
+        tx_batch[b'key2'] = TransactionBatchValue(b'value2', True)
         self.assertEqual(5, len(tx_batch))
         self.assertEqual(init_call_count + 2, tx_batch.call_count)
 
@@ -144,9 +144,9 @@ class TestTransactionBatch(unittest.TestCase):
         self.assertEqual(0, len(tx_batch))
         self.assertEqual(1, init_call_count)
 
-        tx_batch[b'key0'] = (b'value0', True)
+        tx_batch[b'key0'] = TransactionBatchValue(b'value0', True)
         self.assertEqual(1, len(tx_batch))
 
         block_batch = BlockBatch()
         block_batch.update(tx_batch)
-        self.assertEqual((b'value0', True), block_batch[b'key0'])
+        self.assertEqual(TransactionBatchValue(b'value0', True), block_batch[b'key0'])

--- a/tests/unittest/test_precommit_data_manager.py
+++ b/tests/unittest/test_precommit_data_manager.py
@@ -1,61 +1,165 @@
+import json
 import os
 import shutil
 from unittest.mock import Mock
 
 import pytest
 
+from iconservice import __version__, Address
 from iconservice.base.block import Block
 from iconservice.database.batch import BlockBatch, TransactionBatch, TransactionBatchValue
-from iconservice.precommit_data_manager import PrecommitData, write_precommit_data_to_file
-from tests import create_hash_256
+from iconservice.iiss.reward_calc.msg_data import TxData, TxType, PRepRegisterTx, GovernanceVariable
+from iconservice.precommit_data_manager import PrecommitData, PrecommitDataWriter
+from iconservice.utils import bytes_to_hex
+from tests import create_hash_256, create_timestamp, create_block_hash, create_address
+from tests.unittest.iiss.test_reward_calc_data_storage import DUMMY_BLOCK_HEIGHT, CONFIG_MAIN_PREP_COUNT, \
+    CONFIG_SUB_PREP_COUNT
 
-PRECOMMIT_LOG_PATH = "precommit"
+PRECOMMIT_LOG_PATH = os.path.join(os.getcwd(), PrecommitDataWriter.DIR_NAME)
+
+DATA_LIST = [1, b'bytes', 'string', create_address(), True, None]
 
 
 @pytest.fixture
 def block_batch():
-    block = Mock(spec=Block)
-    block.height = 1
-    block_batch: 'BlockBatch' = BlockBatch(Mock(spec=Block))
+    block = Block(block_height=1,
+                  block_hash=create_block_hash(),
+                  timestamp=create_timestamp(),
+                  prev_hash=create_block_hash(),
+                  cumulative_fee=5)
+    block_batch: 'BlockBatch' = BlockBatch(block)
+    block_batch.block = block
     tx_batch: 'TransactionBatch' = TransactionBatch()
 
-    block_batch.block = block
-    for i in range(3):
-        tx_batch[create_hash_256()] = TransactionBatchValue(create_hash_256(), True, i)
+    for i, data in enumerate(DATA_LIST):
+        tx_batch[create_hash_256()] = TransactionBatchValue(data, True, i)
     block_batch.update(tx_batch)
 
     return block_batch
 
 
 @pytest.fixture
-def precommit_data(block_batch):
+def rc_block_batch():
+    rc_block_batch: list = []
+    gv = GovernanceVariable()
+    gv.block_height = DUMMY_BLOCK_HEIGHT
+    gv.config_main_prep_count = CONFIG_MAIN_PREP_COUNT
+    gv.config_sub_prep_count = CONFIG_SUB_PREP_COUNT
+    gv.calculated_irep = 1
+    gv.reward_rep = 1000
+    rc_block_batch.append(gv)
+    for i in range(2):
+        tx = TxData()
+        tx.address = create_address()
+        tx.block_height = DUMMY_BLOCK_HEIGHT
+        tx.type = TxType.PREP_REGISTER
+        tx.data = PRepRegisterTx()
+        rc_block_batch.append(tx)
+    return rc_block_batch
+
+
+@pytest.fixture
+def precommit_data(block_batch, rc_block_batch):
     precommit_data: 'PrecommitData' = Mock(spec=PrecommitData)
     precommit_data.block = block_batch.block
+    precommit_data.revision = 1
+    precommit_data.is_state_root_hash = create_hash_256()
+    precommit_data.rc_state_root_hash = None
+    precommit_data.state_root_hash = create_hash_256()
+    precommit_data.prev_block_generator = create_address()
     precommit_data.block_batch = block_batch
-    precommit_data.rc_block_batch = []
+    precommit_data.rc_block_batch = rc_block_batch
     return precommit_data
+
+
+@pytest.fixture
+def expected_json_data(precommit_data):
+    def expected_encoder(data):
+        if isinstance(data, bytes):
+            return bytes_to_hex(data)
+        elif isinstance(data, Address):
+            return str(data)
+        return data
+
+    block = precommit_data.block
+
+    json_dict = {
+        "iconservice": __version__,
+        "revision": precommit_data.revision,
+        "block": {
+            "height": block.height,
+            "hash": bytes_to_hex(block.hash),
+            "timestamp": block.timestamp,
+            "prevHash": bytes_to_hex(block.prev_hash),
+            "cumulativeFee": block.cumulative_fee
+        },
+        "isStateRootHash": bytes_to_hex(precommit_data.is_state_root_hash),
+        "rcStateRootHash": None,
+        "stateRootHash": bytes_to_hex(precommit_data.state_root_hash),
+        "prevBlockGenerator": str(precommit_data.prev_block_generator),
+        "blockBatch": [
+            {"key": bytes_to_hex(k),
+             "value": expected_encoder(v.value),
+             "includeStateRootHash": v.include_state_root_hash,
+             "txIndexes": v.tx_indexes}
+            for k, v in precommit_data.block_batch.items()
+        ],
+        "rcBlockBatch": [
+            {
+                "key": bytes_to_hex(precommit_data.rc_block_batch[0].make_key()),
+                "value": bytes_to_hex(precommit_data.rc_block_batch[0].make_value())
+            },
+            {
+                "key": bytes_to_hex(precommit_data.rc_block_batch[1].make_key(0)),
+                "value": bytes_to_hex(precommit_data.rc_block_batch[1].make_value())
+            },
+            {
+                "key": bytes_to_hex(precommit_data.rc_block_batch[2].make_key(1)),
+                "value": bytes_to_hex(precommit_data.rc_block_batch[2].make_value())
+            }
+        ]
+    }
+    return json_dict
 
 
 def teardown_function():
     shutil.rmtree(PRECOMMIT_LOG_PATH, ignore_errors=True)
 
 
-def test_write_precommit_data(precommit_data):
-    expected_file_name: str = f"{precommit_data.block.height}-precommit-data.txt"
+def test_precommit_data_dir_and_file_name(precommit_data):
+    expected_dir_path = PRECOMMIT_LOG_PATH
+    expected_file_name: str = f"{precommit_data.block.height}-precommit-data-v{PrecommitDataWriter.VERSION}.json"
+    writer = PrecommitDataWriter(os.getcwd())
 
-    write_precommit_data_to_file(precommit_data, "")
+    # Acts
+    writer.write(precommit_data)
 
-    assert os.path.exists(PRECOMMIT_LOG_PATH)
+    assert os.path.exists(expected_dir_path)
     assert os.path.exists(os.path.join(PRECOMMIT_LOG_PATH, expected_file_name))
 
 
-def test_write_precommit_data_when_raising_exception_should_catch_it(precommit_data):
-    expected_file_name: str = f"{precommit_data.block.height}-precommit-data.txt"
-    # Set the invalid data to rc block batch (it is going to be a reason of the exception)
+def test_precommit_data_check_the_written_json_data(precommit_data, expected_json_data):
+    file_name: str = f"{precommit_data.block.height}-precommit-data-v{PrecommitDataWriter.VERSION}.json"
+    writer = PrecommitDataWriter(os.getcwd())
+
+    # Acts
+    writer.write(precommit_data)
+
+    with open(os.path.join(PRECOMMIT_LOG_PATH, file_name), "r") as f:
+        actual_precommit_data = json.load(f)
+        for key in expected_json_data.keys():
+            assert expected_json_data[key] == actual_precommit_data[key]
+
+
+def test_precommit_data_when_raising_exception_should_catch_it(precommit_data):
+    file_name: str = f"{precommit_data.block.height}-precommit-data-v{PrecommitDataWriter.VERSION}.json"
     precommit_data.rc_block_batch.append("invalid data")
 
+    writer = PrecommitDataWriter(os.getcwd())
+    # Set the invalid data to rc block batch (it is going to be a reason of the exception)
+
     # Act
-    write_precommit_data_to_file(precommit_data, "")
+    writer.write(precommit_data)
 
     assert os.path.exists(PRECOMMIT_LOG_PATH)
-    assert os.path.exists(os.path.join(PRECOMMIT_LOG_PATH, expected_file_name))
+    assert os.path.exists(os.path.join(PRECOMMIT_LOG_PATH, file_name))

--- a/tests/unittest/test_precommit_data_manager.py
+++ b/tests/unittest/test_precommit_data_manager.py
@@ -1,0 +1,63 @@
+import os
+import shutil
+from unittest.mock import Mock
+
+import pytest
+
+from iconservice.base.block import Block
+from iconservice.database.batch import BlockBatch, TransactionBatch, TransactionBatchValue
+from iconservice.precommit_data_manager import PrecommitData, write_precommit_data_to_file
+from tests import create_hash_256
+
+PRECOMMIT_LOG_PATH = "precommit"
+
+
+@pytest.fixture
+def block_batch():
+    block = Mock(spec=Block)
+    block.height = 1
+    block_batch: 'BlockBatch' = BlockBatch(Mock(spec=Block))
+    tx_batch: 'TransactionBatch' = TransactionBatch()
+
+    block_batch.block = block
+    for i in range(3):
+        tx_batch[create_hash_256()] = TransactionBatchValue(create_hash_256(), True, i)
+    block_batch.update(tx_batch)
+
+    return block_batch
+
+
+@pytest.fixture
+def precommit_data(block_batch):
+    precommit_data: 'PrecommitData' = Mock(spec=PrecommitData)
+    precommit_data.block = block_batch.block
+    precommit_data.block_batch = block_batch
+    precommit_data.rc_block_batch = []
+    return precommit_data
+
+
+def teardown_function():
+    shutil.rmtree(PRECOMMIT_LOG_PATH, ignore_errors=True)
+
+
+def test_write_precommit_data(precommit_data):
+    expected_file_name: str = f"{precommit_data.block.height}-precommit-data.txt"
+
+    write_precommit_data_to_file(precommit_data, "")
+
+    assert os.path.exists(PRECOMMIT_LOG_PATH)
+    assert os.path.exists(os.path.join(PRECOMMIT_LOG_PATH, expected_file_name))
+
+
+def test_write_precommit_data_when_raising_exception_should_print_exception(precommit_data):
+    expected_file_name: str = f"{precommit_data.block.height}-precommit-data.txt"
+    # Set the invalid data to rc block batch (it is going to be a reason of the exception)
+    precommit_data.rc_block_batch.append("invalid data")
+
+    # Act
+    write_precommit_data_to_file(precommit_data, "")
+
+    assert os.path.exists(PRECOMMIT_LOG_PATH)
+    assert os.path.exists(os.path.join(PRECOMMIT_LOG_PATH, expected_file_name))
+    with open(os.path.join(PRECOMMIT_LOG_PATH, expected_file_name), "rt") as f:
+        assert "Exception raised during writing the precommit-data" in f.read()

--- a/tests/unittest/test_precommit_data_manager.py
+++ b/tests/unittest/test_precommit_data_manager.py
@@ -128,7 +128,9 @@ def teardown_function():
 
 def test_precommit_data_dir_and_file_name(precommit_data):
     expected_dir_path = PRECOMMIT_LOG_PATH
-    expected_file_name: str = f"{precommit_data.block.height}-precommit-data-v{PrecommitDataWriter.VERSION}.json"
+    expected_file_name: str = f"{precommit_data.block.height}" \
+                              f"-{precommit_data.state_root_hash.hex()[:8]}" \
+                              f"-precommit-v{PrecommitDataWriter.VERSION}.json"
     writer = PrecommitDataWriter(os.getcwd())
 
     # Acts
@@ -139,7 +141,9 @@ def test_precommit_data_dir_and_file_name(precommit_data):
 
 
 def test_precommit_data_check_the_written_json_data(precommit_data, expected_json_data):
-    file_name: str = f"{precommit_data.block.height}-precommit-data-v{PrecommitDataWriter.VERSION}.json"
+    file_name: str = f"{precommit_data.block.height}" \
+                     f"-{precommit_data.state_root_hash.hex()[:8]}" \
+                     f"-precommit-v{PrecommitDataWriter.VERSION}.json"
     writer = PrecommitDataWriter(os.getcwd())
 
     # Acts
@@ -152,7 +156,9 @@ def test_precommit_data_check_the_written_json_data(precommit_data, expected_jso
 
 
 def test_precommit_data_when_raising_exception_should_catch_it(precommit_data):
-    file_name: str = f"{precommit_data.block.height}-precommit-data-v{PrecommitDataWriter.VERSION}.json"
+    file_name: str = f"{precommit_data.block.height}" \
+                     f"-{precommit_data.state_root_hash.hex()[:8]}" \
+                     f"-precommit-v{PrecommitDataWriter.VERSION}.json"
     precommit_data.rc_block_batch.append("invalid data")
 
     writer = PrecommitDataWriter(os.getcwd())

--- a/tests/unittest/test_precommit_data_manager.py
+++ b/tests/unittest/test_precommit_data_manager.py
@@ -49,7 +49,7 @@ def test_write_precommit_data(precommit_data):
     assert os.path.exists(os.path.join(PRECOMMIT_LOG_PATH, expected_file_name))
 
 
-def test_write_precommit_data_when_raising_exception_should_print_exception(precommit_data):
+def test_write_precommit_data_when_raising_exception_should_catch_it(precommit_data):
     expected_file_name: str = f"{precommit_data.block.height}-precommit-data.txt"
     # Set the invalid data to rc block batch (it is going to be a reason of the exception)
     precommit_data.rc_block_batch.append("invalid data")

--- a/tests/unittest/test_precommit_data_manager.py
+++ b/tests/unittest/test_precommit_data_manager.py
@@ -59,5 +59,3 @@ def test_write_precommit_data_when_raising_exception_should_print_exception(prec
 
     assert os.path.exists(PRECOMMIT_LOG_PATH)
     assert os.path.exists(os.path.join(PRECOMMIT_LOG_PATH, expected_file_name))
-    with open(os.path.join(PRECOMMIT_LOG_PATH, expected_file_name), "rt") as f:
-        assert "Exception raised during writing the precommit-data" in f.read()


### PR DESCRIPTION
## Summary
- format: JSON
- file path & file name: {LOG PATH}/precommit/{block height}-precommit-data-v{version num}.json
- Add tx_index field to TransactionBatchValue for debugging
  -  There is some issue about retrieve index from the context in case of deploy (In deploy, context.tx is set to None temporally)
- Check assert when set items (i.e. __setitem__) on TransactionBatch (must be TransactionBatchValue)
  - Only TransactionBatchValue type can be set on TransactionBatch

## Information
- I have left the comments on the major change point

## Format 
```
{
  "iconservice": "1.6.1",
  "revision": 5,
  "block": {
    "height": 2,
    "hash": "0xbf1ba1fcc5894f900a2424c7c23f5b4df52ddfa512aa6611554cffa63af3c885",
    "timestamp": 1591318988717094,
    "prevHash": "0x7833cedff6814fef8dc5f818d6307ef537e6d79087620629b73de8bf91caa283",
    "cumulativeFee": 1318800000000000
  },
  "isStateRootHash": "0x44ee9cd260abf6ff2be79ef10d8bfc8ae7a4da32e5fe4bb850873f7060dc2453",
  "rcStateRootHash": "0x44ee9cd260abf6ff2be79ef10d8bfc8ae7a4da32e5fe4bb850873f7060dc2453",
  "stateRootHash": "0x44ee9cd260abf6ff2be79ef10d8bfc8ae7a4da32e5fe4bb850873f7060dc2453",
  "prevBlockGenerator": null,
  "blockBatch": [
    {
      "key": "0x0100000000000000000000000000000000000000017c027c7265766973696f6e5f636f6465",
      "value": "0x05",
      "includeStateRootHash": true,
      "txIndexes": [
        0
      ]
    },
    ..
    {
      "key": "0x696973737272",
      "value": "0x9200cd04b0",
      "includeStateRootHash": true,
      "txIndexes": [
        0
      ]
    }
  ],
  "rcBlockBatch": [
    {
      "key": "0x4844",
      "value": "0x920002"
    }
  ]
}
```