### PR TITLE
IS-1107: Fix Container DB Seperator (RLP)

### DIFF
--- a/iconservice/__init__.py
+++ b/iconservice/__init__.py
@@ -24,7 +24,7 @@ from .base.address import Address, AddressPrefix, SYSTEM_SCORE_ADDRESS, ZERO_SCO
 from .base.exception import IconScoreException
 from .icon_constant import IconServiceFlag
 from .iconscore.icon_container_db import VarDB, DictDB, ArrayDB
-from .iconscore.icon_score_base import interface, eventlog, external, payable, IconScoreBase, IconScoreDatabase
+from .iconscore.icon_score_base import interface, eventlog, external, payable, IconScoreBase
 from .iconscore.icon_score_base2 import (
     InterfaceScore, revert, sha3_256, sha_256, json_loads, json_dumps,
     get_main_prep_info, get_sub_prep_info, recover_key,
@@ -33,4 +33,9 @@ from .iconscore.icon_score_base2 import (
 
 from .iconscore.icon_system_score_base import IconSystemScoreBase
 from .iconscore.system_score import InterfaceSystemScore
+from .iconscore.container_db.score_db import ScoreDatabase
+
 from .__version__ import __version__
+
+# legacy
+from .database.db import IconScoreDatabase

--- a/iconservice/__init__.py
+++ b/iconservice/__init__.py
@@ -33,9 +33,6 @@ from .iconscore.icon_score_base2 import (
 
 from .iconscore.icon_system_score_base import IconSystemScoreBase
 from .iconscore.system_score import InterfaceSystemScore
-from .iconscore.container_db.score_db import ScoreDatabase
+from .iconscore.container_db.score_db import IconScoreDatabase
 
 from .__version__ import __version__
-
-# legacy
-from .database.db import IconScoreDatabase

--- a/iconservice/database/db.py
+++ b/iconservice/database/db.py
@@ -560,14 +560,14 @@ class IconScoreDatabase(ContextGetter):
     ) -> bytes:
         bytes_list = [] if is_legacy else [keys[-1].container_id]
         for ke in keys:
-            v: List[bytes] = ke.to_bytes(is_legacy=is_legacy)
-            bytes_list.extend(v)
+            v: bytes = ke.to_bytes(is_legacy=is_legacy)
+            bytes_list.append(v)
         separator: bytes = b'|' if is_legacy else b''
         return separator.join([self._prefix] + bytes_list)
 
     @classmethod
     def _to_bytes_for_observer_key(cls, keys: List['KeyElement']) -> bytes:
-        return keys[0].to_bytes(is_legacy=True)[0]
+        return keys[0].to_bytes(is_legacy=True)
 
 
 class IconScoreSubDatabase:

--- a/iconservice/database/score_db/__init__.py
+++ b/iconservice/database/score_db/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2020 ICON Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/iconservice/database/score_db/utils.py
+++ b/iconservice/database/score_db/utils.py
@@ -25,12 +25,14 @@ V = TypeVar('V', int, str, Address, bytes, bool)
 ARRAY_DB_ID = b'\x00'
 DICT_DB_ID = b'\x01'
 VAR_DB_ID = b'\x02'
+CUSTOM_DB_ID = b'\x03'
 
 
 class KeyElementState(enum.Flag):
     NONE = 0
     IS_CONSTRUCTOR = 1
     IS_CONTAINER = 2
+    USE_CUSTOM_SUB_DB = 4
 
 
 class ScoreDBBase:
@@ -70,7 +72,11 @@ class KeyElement:
             else:
                 return self._keys[0]
         else:
-            return self._rlp_encode_bytes(self._keys[0])
+            if self._state == KeyElementState.USE_CUSTOM_SUB_DB:
+                # TODO return specific bytes
+                return self._rlp_encode_bytes(CUSTOM_DB_ID) + self._rlp_encode_bytes(self._keys[0])
+            else:
+                return self._rlp_encode_bytes(self._keys[0])
 
     @classmethod
     def _rlp_encode_bytes(cls, b: bytes) -> bytes:

--- a/iconservice/database/score_db/utils.py
+++ b/iconservice/database/score_db/utils.py
@@ -33,6 +33,10 @@ class KeyElementState(enum.Flag):
     IS_CONTAINER = 2
 
 
+class ScoreDBBase:
+    pass
+
+
 class KeyElement:
     def __init__(
             self,

--- a/iconservice/database/score_db/utils.py
+++ b/iconservice/database/score_db/utils.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2020 ICON Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import TypeVar
+
+from iconservice import Address
+
+K = TypeVar('K', int, str, Address, bytes)
+V = TypeVar('V', int, str, Address, bytes, bool)
+
+ARRAY_DB_ID = b'\x00'
+DICT_DB_ID = b'\x01'
+VAR_DB_ID = b'\x02'
+
+
+class KeyElement:
+    def __init__(
+            self,
+            key: bytes,
+            legacy_key: bytes = None,
+            is_append_container_id: bool = False
+    ):
+        """
+
+        :param key:
+        :param legacy_key: for arrayDB size branch logic
+        :param is_append_container_id: for dictDB depth bug
+        """
+
+        self._key: bytes = key
+        self._is_append_container_id: bool = is_append_container_id
+
+        if legacy_key:
+            self._legacy_key: bytes = legacy_key
+        else:
+            self._legacy_key: bytes = key
+
+    def __bytes__(self) -> bytes:
+        return self.rlp_encode_bytes(self._key)
+
+    @property
+    def legacy_key(self) -> bytes:
+        return self._legacy_key
+
+    @property
+    def is_append_container_id(self) -> bool:
+        return self._is_append_container_id
+
+    @classmethod
+    def rlp_encode_bytes(cls, b: bytes) -> bytes:
+        blen = len(b)
+        if blen == 1 and b[0] < 0x80:
+            return b
+        elif blen <= 55:
+            return bytes([blen + 0x80]) + b
+        len_bytes = cls.rlp_get_bytes(blen)
+        return bytes([len(len_bytes) + 0x80 + 55]) + len_bytes + b
+
+    @classmethod
+    def rlp_get_bytes(cls, x: int) -> bytes:
+        if x == 0:
+            return b''
+        else:
+            return cls.rlp_get_bytes(int(x / 256)) + bytes([x % 256])

--- a/iconservice/database/score_db/utils.py
+++ b/iconservice/database/score_db/utils.py
@@ -73,7 +73,6 @@ class KeyElement:
                 return self._keys[0]
         else:
             if self._state == KeyElementState.USE_CUSTOM_SUB_DB:
-                # TODO return specific bytes
                 return self._rlp_encode_bytes(CUSTOM_DB_ID) + self._rlp_encode_bytes(self._keys[0])
             else:
                 return self._rlp_encode_bytes(self._keys[0])

--- a/iconservice/database/score_db/utils.py
+++ b/iconservice/database/score_db/utils.py
@@ -55,16 +55,18 @@ class KeyElement:
     def container_id(self) -> bytes:
         return self._container_id
 
-    def to_bytes(self, is_legacy: bool) -> List[bytes]:
+    def to_bytes(self, is_legacy: bool) -> bytes:
         if is_legacy:
             if self._state == KeyElementState.IS_CONSTRUCTOR | KeyElementState.IS_CONTAINER:
-                return [self._container_id, self._keys[0]]
+                # 1. Bug DictDB (is appended container_id whenever make sub db in DictDB)
+                return b'|'.join((self._container_id, self._keys[0]))
             elif self._container_id == ARRAY_DB_ID and len(self._keys) == 2:
-                return [self._keys[1]]
+                # 2. Consider array size key
+                return self._keys[1]
             else:
-                return [self._keys[0]]
+                return self._keys[0]
         else:
-            return [self._rlp_encode_bytes(self._keys[0])]
+            return self._rlp_encode_bytes(self._keys[0])
 
     @classmethod
     def _rlp_encode_bytes(cls, b: bytes) -> bytes:

--- a/iconservice/database/score_db/utils.py
+++ b/iconservice/database/score_db/utils.py
@@ -42,7 +42,7 @@ class KeyElement:
     ):
         """
 
-        :param keys:
+        :param keys: contain with legacy key
         :param container_id:
         :param state:
         """

--- a/iconservice/icon_constant.py
+++ b/iconservice/icon_constant.py
@@ -139,7 +139,9 @@ class Revision(Enum):
 
     FIX_BALANCE_BUG = 11
 
-    LATEST = 11
+    CONTAINER_DB_RLP = 12
+
+    LATEST = 12
 
 
 RC_DB_VERSION_0 = 0

--- a/iconservice/icon_service_engine.py
+++ b/iconservice/icon_service_engine.py
@@ -342,7 +342,7 @@ class IconServiceEngine(ContextContainer):
     def _load_builtin_scores(self, context: 'IconScoreContext', builtin_score_owner: 'Address'):
         context.icon_score_mapper.clear()
 
-        current_address: 'Address' = context.current_address
+        prev_current_address: 'Address' = context.current_address
         context.current_address = GOVERNANCE_SCORE_ADDRESS
 
         try:
@@ -351,7 +351,7 @@ class IconServiceEngine(ContextContainer):
         finally:
             self._pop_context()
 
-        context.current_address = current_address
+        context.current_address = prev_current_address
 
     def close(self) -> None:
         """Free all resources occupied by IconServiceEngine

--- a/iconservice/iconscore/container_db/__init__.py
+++ b/iconservice/iconscore/container_db/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2020 ICON Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/iconservice/iconscore/container_db/score_db.py
+++ b/iconservice/iconscore/container_db/score_db.py
@@ -2,9 +2,6 @@ from typing import Optional, TYPE_CHECKING
 
 from ...database.score_db.utils import (
     KeyElement,
-    DICT_DB_ID,
-    CUSTOM_DB_ID,
-    KeyElementState,
 )
 
 if TYPE_CHECKING:
@@ -13,9 +10,8 @@ if TYPE_CHECKING:
 
 
 class IconScoreDatabase:
-    def __init__(self, db: 'ScoreSubDatabase', is_container_db: bool = False):
+    def __init__(self, db: 'ScoreSubDatabase'):
         self._db: 'ScoreSubDatabase' = db
-        self._is_container_db: bool = is_container_db
 
     @property
     def address(self) -> 'Address':
@@ -53,10 +49,7 @@ class IconScoreDatabase:
         self._db.delete(key)
 
     def get_sub_db(self, prefix: bytes) -> 'IconScoreDatabase':
-        if self._is_container_db:
-            key: 'KeyElement' = self._make_key_element(key=prefix)
-        else:
-            key: 'KeyElement' = self._make_key_element_in_custom(key=prefix)
+        key: 'KeyElement' = self._make_key_element(key=prefix)
         db: 'ScoreSubDatabase' = self._db.get_sub_db(key=key)
         return IconScoreDatabase(db=db)
 
@@ -64,13 +57,5 @@ class IconScoreDatabase:
     def _make_key_element(cls, key: bytes) -> 'KeyElement':
         return KeyElement(
             keys=[key],
-            container_id=DICT_DB_ID
-        )
-
-    @classmethod
-    def _make_key_element_in_custom(cls, key: bytes) -> 'KeyElement':
-        return KeyElement(
-            keys=[key],
-            container_id=DICT_DB_ID,
-            state=KeyElementState.USE_CUSTOM_SUB_DB
+            tag=None,
         )

--- a/iconservice/iconscore/container_db/score_db.py
+++ b/iconservice/iconscore/container_db/score_db.py
@@ -1,14 +1,15 @@
-from typing import Optional, TYPE_CHECKING, List
+from typing import Optional, TYPE_CHECKING
+
 from ...database.score_db.utils import KeyElement, DICT_DB_ID
 
 if TYPE_CHECKING:
     from ...base.address import Address
-    from ...database.db import IconScoreDatabase, IconScoreSubDatabase
+    from ...database.db import ScoreSubDatabase
 
 
-class ScoreDatabase:
-    def __init__(self, db: 'IconScoreDatabase'):
-        self._db: 'IconScoreDatabase' = db
+class IconScoreDatabase:
+    def __init__(self, db: 'ScoreSubDatabase'):
+        self._db: 'ScoreSubDatabase' = db
 
     @property
     def address(self) -> 'Address':
@@ -23,8 +24,8 @@ class ScoreDatabase:
         :return: value for the specified key, or None if not found
         """
 
-        keys: List['KeyElement'] = self._make_key_elements(key=key)
-        return self._db.get(keys=keys)
+        key: 'KeyElement' = self._make_key_element(key=key)
+        return self._db.get(key=key)
 
     def put(self, key: bytes, value: bytes):
         """
@@ -33,8 +34,8 @@ class ScoreDatabase:
         :param key: key to set
         :param value: value to set
         """
-        keys: List['KeyElement'] = self._make_key_elements(key=key)
-        self._db.put(keys=keys, value=value)
+        key: 'KeyElement' = self._make_key_element(key=key)
+        self._db.put(key=key, value=value)
 
     def delete(self, key: bytes):
         """
@@ -42,65 +43,14 @@ class ScoreDatabase:
 
         :param key: key to delete
         """
-        key: List['KeyElement'] = self._make_key_elements(key=key)
+        key: 'KeyElement' = self._make_key_element(key=key)
         self._db.delete(key)
 
-    def get_sub_db(self, prefix: bytes) -> 'ScoreSubDatabase':
-        keys: List['KeyElement'] = self._make_key_elements(key=prefix)
-        db: 'IconScoreSubDatabase' = self._db.get_sub_db(keys=keys)
-        return ScoreSubDatabase(db=db)
+    def get_sub_db(self, prefix: bytes) -> 'IconScoreDatabase':
+        key: 'KeyElement' = self._make_key_element(key=prefix)
+        db: 'ScoreSubDatabase' = self._db.get_sub_db(key=key)
+        return IconScoreDatabase(db=db)
 
     @classmethod
-    def _make_key_elements(cls, key: bytes) -> List['KeyElement']:
-        return [KeyElement(keys=[key], container_id=DICT_DB_ID)]
-
-
-class ScoreSubDatabase:
-    def __init__(self, db: 'IconScoreSubDatabase'):
-        self._db: 'IconScoreSubDatabase' = db
-
-    @property
-    def address(self) -> 'Address':
-        return self._db.address
-
-    def get(self, key: bytes) -> Optional[bytes]:
-        """
-        Gets the value for the specified key
-
-        :param key: key to retrieve
-        :return: value for the specified key, or None if not found
-        """
-        keys: List['KeyElement'] = self._make_key_elements(key=key)
-        return self._db.get(keys=keys)
-
-    def put(self, key: bytes, value: bytes):
-        """
-        Sets a value for the specified key.
-
-        :param key: key to set
-        :param value: value to set
-        """
-        keys: List['KeyElement'] = self._make_key_elements(key=key)
-        self._db.put(keys=keys, value=value)
-
-    def delete(self, key: bytes):
-        """
-        Deletes the key/value pair for the specified key.
-
-        :param key: key to delete
-        """
-        keys: List['KeyElement'] = self._make_key_elements(key=key)
-        self._db.delete(keys=keys)
-
-    def get_sub_db(
-            self,
-            prefix: bytes,
-    ) -> 'ScoreSubDatabase':
-
-        keys: List['KeyElement'] = self._make_key_elements(key=prefix)
-        db: 'IconScoreSubDatabase' = self._db.get_sub_db(keys=keys)
-        return ScoreSubDatabase(db=db)
-
-    @classmethod
-    def _make_key_elements(cls, key: bytes) -> List['KeyElement']:
-        return [KeyElement(keys=[key], container_id=DICT_DB_ID)]
+    def _make_key_element(cls, key: bytes) -> 'KeyElement':
+        return KeyElement(keys=[key], container_id=DICT_DB_ID)

--- a/iconservice/iconscore/container_db/score_db.py
+++ b/iconservice/iconscore/container_db/score_db.py
@@ -1,0 +1,106 @@
+from typing import Optional, TYPE_CHECKING, List
+from ...database.score_db.utils import KeyElement, DICT_DB_ID
+
+if TYPE_CHECKING:
+    from ...base.address import Address
+    from ...database.db import IconScoreDatabase, IconScoreSubDatabase
+
+
+class ScoreDatabase:
+    def __init__(self, db: 'IconScoreDatabase'):
+        self._db: 'IconScoreDatabase' = db
+
+    @property
+    def address(self) -> 'Address':
+        return self._db.address
+
+    def get(self, key: bytes) -> Optional[bytes]:
+
+        """
+        Gets the value for the specified key
+
+        :param key: key to retrieve
+        :return: value for the specified key, or None if not found
+        """
+
+        keys: List['KeyElement'] = self._make_key_elements(key=key)
+        return self._db.get(keys=keys)
+
+    def put(self, key: bytes, value: bytes):
+        """
+        Sets a value for the specified key.
+
+        :param key: key to set
+        :param value: value to set
+        """
+        keys: List['KeyElement'] = self._make_key_elements(key=key)
+        self._db.put(keys=keys, value=value)
+
+    def delete(self, key: bytes):
+        """
+        Deletes the key/value pair for the specified key.
+
+        :param key: key to delete
+        """
+        key: List['KeyElement'] = self._make_key_elements(key=key)
+        self._db.delete(key)
+
+    def get_sub_db(self, prefix: bytes) -> 'ScoreSubDatabase':
+        keys: List['KeyElement'] = self._make_key_elements(key=prefix)
+        db: 'IconScoreSubDatabase' = self._db.get_sub_db(keys=keys)
+        return ScoreSubDatabase(db=db)
+
+    @classmethod
+    def _make_key_elements(cls, key: bytes) -> List['KeyElement']:
+        return [KeyElement(keys=[key], container_id=DICT_DB_ID)]
+
+
+class ScoreSubDatabase:
+    def __init__(self, db: 'IconScoreSubDatabase'):
+        self._db: 'IconScoreSubDatabase' = db
+
+    @property
+    def address(self) -> 'Address':
+        return self._db.address
+
+    def get(self, key: bytes) -> Optional[bytes]:
+        """
+        Gets the value for the specified key
+
+        :param key: key to retrieve
+        :return: value for the specified key, or None if not found
+        """
+        keys: List['KeyElement'] = self._make_key_elements(key=key)
+        return self._db.get(keys=keys)
+
+    def put(self, key: bytes, value: bytes):
+        """
+        Sets a value for the specified key.
+
+        :param key: key to set
+        :param value: value to set
+        """
+        keys: List['KeyElement'] = self._make_key_elements(key=key)
+        self._db.put(keys=keys, value=value)
+
+    def delete(self, key: bytes):
+        """
+        Deletes the key/value pair for the specified key.
+
+        :param key: key to delete
+        """
+        keys: List['KeyElement'] = self._make_key_elements(key=key)
+        self._db.delete(keys=keys)
+
+    def get_sub_db(
+            self,
+            prefix: bytes,
+    ) -> 'ScoreSubDatabase':
+
+        keys: List['KeyElement'] = self._make_key_elements(key=prefix)
+        db: 'IconScoreSubDatabase' = self._db.get_sub_db(keys=keys)
+        return ScoreSubDatabase(db=db)
+
+    @classmethod
+    def _make_key_elements(cls, key: bytes) -> List['KeyElement']:
+        return [KeyElement(keys=[key], container_id=DICT_DB_ID)]

--- a/iconservice/iconscore/container_db/score_db.py
+++ b/iconservice/iconscore/container_db/score_db.py
@@ -1,6 +1,11 @@
 from typing import Optional, TYPE_CHECKING
 
-from ...database.score_db.utils import KeyElement, DICT_DB_ID, KeyElementState
+from ...database.score_db.utils import (
+    KeyElement,
+    DICT_DB_ID,
+    CUSTOM_DB_ID,
+    KeyElementState,
+)
 
 if TYPE_CHECKING:
     from ...base.address import Address
@@ -57,8 +62,15 @@ class IconScoreDatabase:
 
     @classmethod
     def _make_key_element(cls, key: bytes) -> 'KeyElement':
-        return KeyElement(keys=[key], container_id=DICT_DB_ID)
+        return KeyElement(
+            keys=[key],
+            container_id=DICT_DB_ID
+        )
 
     @classmethod
     def _make_key_element_in_custom(cls, key: bytes) -> 'KeyElement':
-        return KeyElement(keys=[key], container_id=DICT_DB_ID, state=KeyElementState.USE_CUSTOM_SUB_DB)
+        return KeyElement(
+            keys=[key],
+            container_id=DICT_DB_ID,
+            state=KeyElementState.USE_CUSTOM_SUB_DB
+        )

--- a/iconservice/iconscore/container_db/score_db.py
+++ b/iconservice/iconscore/container_db/score_db.py
@@ -1,6 +1,6 @@
 from typing import Optional, TYPE_CHECKING
 
-from ...database.score_db.utils import KeyElement, DICT_DB_ID
+from ...database.score_db.utils import KeyElement, DICT_DB_ID, KeyElementState
 
 if TYPE_CHECKING:
     from ...base.address import Address
@@ -8,8 +8,9 @@ if TYPE_CHECKING:
 
 
 class IconScoreDatabase:
-    def __init__(self, db: 'ScoreSubDatabase'):
+    def __init__(self, db: 'ScoreSubDatabase', is_container_db: bool = False):
         self._db: 'ScoreSubDatabase' = db
+        self._is_container_db: bool = is_container_db
 
     @property
     def address(self) -> 'Address':
@@ -47,10 +48,17 @@ class IconScoreDatabase:
         self._db.delete(key)
 
     def get_sub_db(self, prefix: bytes) -> 'IconScoreDatabase':
-        key: 'KeyElement' = self._make_key_element(key=prefix)
+        if self._is_container_db:
+            key: 'KeyElement' = self._make_key_element(key=prefix)
+        else:
+            key: 'KeyElement' = self._make_key_element_in_custom(key=prefix)
         db: 'ScoreSubDatabase' = self._db.get_sub_db(key=key)
         return IconScoreDatabase(db=db)
 
     @classmethod
     def _make_key_element(cls, key: bytes) -> 'KeyElement':
         return KeyElement(keys=[key], container_id=DICT_DB_ID)
+
+    @classmethod
+    def _make_key_element_in_custom(cls, key: bytes) -> 'KeyElement':
+        return KeyElement(keys=[key], container_id=DICT_DB_ID, state=KeyElementState.USE_CUSTOM_SUB_DB)

--- a/iconservice/iconscore/container_db/utils.py
+++ b/iconservice/iconscore/container_db/utils.py
@@ -1,0 +1,170 @@
+from typing import Optional, Any, Union, TYPE_CHECKING
+
+from ...base.address import Address
+from ...base.exception import InvalidParamsException
+from ...database.score_db.utils import K, V
+from ...utils import int_to_bytes, bytes_to_int
+
+if TYPE_CHECKING:
+    from ...database.db import IconScoreDatabase, IconScoreSubDatabase
+    from . import ContainerDBBase
+
+
+class Utils:
+    @classmethod
+    def get_container_id(cls, container: 'ContainerDBBase') -> bytes:
+        return container.get_container_id()
+
+    @classmethod
+    def encode_key(cls, key: K) -> bytes:
+        """Create a key passed to DB
+
+        :param key:
+        :return:
+        """
+        if key is None:
+            raise InvalidParamsException('key is None')
+
+        if isinstance(key, int):
+            bytes_key = int_to_bytes(key)
+        elif isinstance(key, str):
+            bytes_key = key.encode('utf-8')
+        elif isinstance(key, Address):
+            bytes_key = key.to_bytes()
+        elif isinstance(key, bytes):
+            bytes_key = key
+        else:
+            raise InvalidParamsException(f'Unsupported key type: {type(key)}')
+        return bytes_key
+
+    @classmethod
+    def encode_value(cls, value: V) -> bytes:
+        if isinstance(value, int):
+            byte_value = int_to_bytes(value)
+        elif isinstance(value, str):
+            byte_value = value.encode('utf-8')
+        elif isinstance(value, Address):
+            byte_value = value.to_bytes()
+        elif isinstance(value, bool):
+            byte_value = int_to_bytes(int(value))
+        elif isinstance(value, bytes):
+            byte_value = value
+        else:
+            raise InvalidParamsException(f'Unsupported value type: {type(value)}')
+        return byte_value
+
+    @classmethod
+    def decode_object(cls, value: bytes, value_type: type) -> Optional[Union[K, V]]:
+        if value is None:
+            return cls.get_default_value(value_type)
+
+        obj_value = None
+        if value_type == int:
+            obj_value = bytes_to_int(value)
+        elif value_type == str:
+            obj_value = value.decode()
+        elif value_type == Address:
+            obj_value = Address.from_bytes(value)
+        if value_type == bool:
+            obj_value = bool(bytes_to_int(value))
+        elif value_type == bytes:
+            obj_value = value
+        return obj_value
+
+    @classmethod
+    def get_default_value(cls, value_type: type) -> Any:
+        if value_type == int:
+            return 0
+        elif value_type == str:
+            return ""
+        elif value_type == bool:
+            return False
+        return None
+
+    @classmethod
+    def remove_prefix_from_iters(cls, iter_items: iter) -> iter:
+        return ((cls.__remove_prefix_from_key(key), value) for key, value in iter_items)
+
+    @classmethod
+    def __remove_prefix_from_key(cls, key_from_bytes: bytes) -> bytes:
+        return key_from_bytes[:-1]
+
+    @classmethod
+    def put_to_db(
+            cls,
+            db: 'IconScoreDatabase',
+            db_key: str,
+            container: iter
+    ):
+        """
+        Only V1 supported.
+
+        TODO V2 support.
+
+        :param db:
+        :param db_key:
+        :param container:
+        :return:
+        """
+        sub_db = db.get_sub_db(cls.encode_key(db_key))
+        if isinstance(container, dict):
+            cls.__put_to_db_internal(sub_db, container.items())
+        elif isinstance(container, (list, set, tuple)):
+            cls.__put_to_db_internal(sub_db, enumerate(container))
+
+    @classmethod
+    def get_from_db(
+            cls,
+            db: 'IconScoreDatabase',
+            db_key: str,
+            *args,
+            value_type: type
+    ) -> Optional[K]:
+        """
+        Only V1 supported.
+
+        TODO V2 support.
+
+        :param db:
+        :param db_key:
+        :param args:
+        :param value_type:
+        :return:
+        """
+
+        sub_db = db.get_sub_db(cls.encode_key(db_key))
+        *args, last_arg = args
+        for arg in args:
+            sub_db = sub_db.get_sub_db(cls.encode_key(arg))
+
+        byte_key = sub_db.get(cls.encode_key(last_arg))
+        if byte_key is None:
+            return cls.get_default_value(value_type)
+        return cls.decode_object(byte_key, value_type)
+
+    @classmethod
+    def __put_to_db_internal(
+            cls,
+            db: Union['IconScoreDatabase', 'IconScoreSubDatabase'],
+            iters: iter
+    ):
+        """
+        Only V1 supported.
+
+        TODO V2 support.
+
+        :param db:
+        :param iters:
+        :return:
+        """
+
+        for key, value in iters:
+            sub_db = db.get_sub_db(cls.encode_key(key))
+            if isinstance(value, dict):
+                cls.__put_to_db_internal(sub_db, value.items())
+            elif isinstance(value, (list, set, tuple)):
+                cls.__put_to_db_internal(sub_db, enumerate(value))
+            else:
+                db_key = cls.encode_key(key)
+                db_value = cls.encode_value(value)
+                db.put(db_key, db_value)

--- a/iconservice/iconscore/container_db/utils.py
+++ b/iconservice/iconscore/container_db/utils.py
@@ -7,14 +7,9 @@ from ...utils import int_to_bytes, bytes_to_int
 
 if TYPE_CHECKING:
     from ...database.db import IconScoreDatabase, IconScoreSubDatabase
-    from . import ContainerDBBase
 
 
 class Utils:
-    @classmethod
-    def get_container_id(cls, container: 'ContainerDBBase') -> bytes:
-        return container.get_container_id()
-
     @classmethod
     def encode_key(cls, key: K) -> bytes:
         """Create a key passed to DB

--- a/iconservice/iconscore/icon_container_db.py
+++ b/iconservice/iconscore/icon_container_db.py
@@ -123,7 +123,7 @@ class DictDB:
         if not self._is_leaf:
             return DictDB(
                 key=key,
-                db=IconScoreDatabase(db=self._db),
+                db=IconScoreDatabase(db=self._db, is_container_db=True),
                 value_type=self.__value_type,
                 depth=self.__depth - 1
             )
@@ -211,7 +211,7 @@ class ArrayDB:
         if not self._is_leaf:
             return ArrayDB(
                 key=index,
-                db=IconScoreDatabase(db=self._db),
+                db=IconScoreDatabase(db=self._db, is_container_db=True),
                 value_type=self.__value_type,
                 depth=self.__depth - 1
             )

--- a/iconservice/iconscore/icon_score_base.py
+++ b/iconservice/iconscore/icon_score_base.py
@@ -20,7 +20,7 @@ from functools import partial, wraps
 from inspect import isfunction, signature, Parameter
 from typing import TYPE_CHECKING, Callable, Any, List, Tuple, Mapping
 
-from .container_db.score_db import ScoreDatabase
+from .container_db.score_db import IconScoreDatabase
 from .context.context import ContextGetter, ContextContainer
 from .icon_score_base2 import InterfaceScore, revert, Block
 from .icon_score_constant import (
@@ -52,7 +52,7 @@ from .typing.element import create_score_element_metadatas
 from ..base.address import Address
 from ..base.address import GOVERNANCE_SCORE_ADDRESS
 from ..base.exception import *
-from ..database.db import IconScoreDatabase, DatabaseObserver
+from ..database.db import ScoreDatabase, DatabaseObserver
 from ..icon_constant import ICX_TRANSFER_EVENT_LOG, Revision, IconScoreContextType
 from ..utils import get_main_type_from_annotations_type
 
@@ -379,7 +379,7 @@ class IconScoreBase(IconScoreObject, ContextGetter,
         super().on_update(**kwargs)
 
     @abstractmethod
-    def __init__(self, db: 'ScoreDatabase') -> None:
+    def __init__(self, db: 'IconScoreDatabase') -> None:
         """
         A Python init function. Invoked when the contract is loaded at each node.
         Do not put state-changing works in here.
@@ -394,7 +394,8 @@ class IconScoreBase(IconScoreObject, ContextGetter,
         if elements.externals == 0:
             raise InvalidExternalException('There is no external method in the SCORE')
 
-        db._db.set_observer(self.__create_db_observer())
+        root_db: 'ScoreDatabase' = db._db._score_db
+        root_db.set_observer(self.__create_db_observer())
 
     def fallback(self) -> None:
         """
@@ -584,7 +585,7 @@ class IconScoreBase(IconScoreObject, ContextGetter,
         return Block(self._context.block.height, self._context.block.timestamp)
 
     @property
-    def db(self) -> 'ScoreDatabase':
+    def db(self) -> 'IconScoreDatabase':
         """
         An instance used to access state DB
 

--- a/iconservice/iconscore/icon_score_base.py
+++ b/iconservice/iconscore/icon_score_base.py
@@ -20,6 +20,7 @@ from functools import partial, wraps
 from inspect import isfunction, signature, Parameter
 from typing import TYPE_CHECKING, Callable, Any, List, Tuple, Mapping
 
+from .container_db.score_db import ScoreDatabase
 from .context.context import ContextGetter, ContextContainer
 from .icon_score_base2 import InterfaceScore, revert, Block
 from .icon_score_constant import (
@@ -378,7 +379,7 @@ class IconScoreBase(IconScoreObject, ContextGetter,
         super().on_update(**kwargs)
 
     @abstractmethod
-    def __init__(self, db: 'IconScoreDatabase') -> None:
+    def __init__(self, db: 'ScoreDatabase') -> None:
         """
         A Python init function. Invoked when the contract is loaded at each node.
         Do not put state-changing works in here.
@@ -393,7 +394,7 @@ class IconScoreBase(IconScoreObject, ContextGetter,
         if elements.externals == 0:
             raise InvalidExternalException('There is no external method in the SCORE')
 
-        self.__db.set_observer(self.__create_db_observer())
+        db._db.set_observer(self.__create_db_observer())
 
     def fallback(self) -> None:
         """
@@ -583,11 +584,11 @@ class IconScoreBase(IconScoreObject, ContextGetter,
         return Block(self._context.block.height, self._context.block.timestamp)
 
     @property
-    def db(self) -> 'IconScoreDatabase':
+    def db(self) -> 'ScoreDatabase':
         """
         An instance used to access state DB
 
-        :return: :class:`.IconScoreDatabase` db
+        :return: :class:`ScoreDatabase` db
         """
         return self.__db
 

--- a/iconservice/iconscore/icon_score_context.py
+++ b/iconservice/iconscore/icon_score_context.py
@@ -158,6 +158,9 @@ class IconScoreContext(ABC):
         old: 'INVContainer' = self.engine.inv.inv_container
         new: 'INVContainer' = self.inv_container
 
+        if old is None or new is None:
+            return False
+
         return old.revision_code != new.revision_code and new.revision_code == target_rev
 
     def get_batches(self) -> Iterable['Batch']:

--- a/iconservice/iconscore/icon_score_context_util.py
+++ b/iconservice/iconscore/icon_score_context_util.py
@@ -24,7 +24,7 @@ from .utils import get_package_name_by_address_and_tx_hash, get_score_deploy_pat
 from ..base.address import Address
 from ..base.address import SYSTEM_SCORE_ADDRESS
 from ..base.exception import ScoreNotFoundException, AccessDeniedException, FatalException
-from ..database.db import IconScoreDatabase
+from ..database.db import ScoreDatabase
 from ..database.factory import ContextDatabaseFactory
 from ..icon_constant import IconScoreContextType, IconServiceFlag, DeployState, BUILTIN_SCORE_IMPORT_WHITE_LIST
 from ..utils import is_builtin_score
@@ -133,14 +133,14 @@ class IconScoreContextUtil(object):
     @staticmethod
     def create_score_info(
             context: 'IconScoreContext', score_address: 'Address',
-            tx_hash: bytes, score_db: 'IconScoreDatabase' = None) -> 'IconScoreInfo':
+            tx_hash: bytes, score_db: 'ScoreDatabase' = None) -> 'IconScoreInfo':
 
         score_class: type = IconScoreClassLoader.run(
             score_address, tx_hash, context.score_root_path)
 
         if score_db is None:
             context_db = ContextDatabaseFactory.create_by_address(score_address)
-            score_db = IconScoreDatabase(score_address, context_db)
+            score_db = ScoreDatabase(score_address, context_db)
 
         # Cache a new IconScoreInfo instance
         return IconScoreInfo(score_class, score_db, tx_hash)

--- a/iconservice/iconscore/icon_score_mapper_object.py
+++ b/iconservice/iconscore/icon_score_mapper_object.py
@@ -16,7 +16,7 @@
 
 from typing import TYPE_CHECKING
 
-from .container_db.score_db import ScoreDatabase
+from ..iconscore.container_db.score_db import IconScoreDatabase
 from ..base.address import Address
 from ..base.exception import InvalidParamsException
 from ..icon_constant import Revision
@@ -24,7 +24,7 @@ from ..utils import is_builtin_score
 
 if TYPE_CHECKING:
     from .icon_score_base import IconScoreBase
-    from ..database.db import IconScoreDatabase
+    from ..database.db import ScoreDatabase
 
 
 class IconScoreInfo(object):
@@ -33,7 +33,7 @@ class IconScoreInfo(object):
     If this class is not necessary anymore, Remove it
     """
 
-    def __init__(self, score_class: type, score_db: 'IconScoreDatabase', tx_hash: bytes) -> None:
+    def __init__(self, score_class: type, score_db: 'ScoreDatabase', tx_hash: bytes) -> None:
         """Constructor
 
         :param score_class:
@@ -54,7 +54,7 @@ class IconScoreInfo(object):
         return self._score_class
 
     @property
-    def score_db(self) -> 'IconScoreDatabase':
+    def score_db(self) -> 'ScoreDatabase':
         return self._score_db
 
     @property
@@ -76,7 +76,7 @@ class IconScoreInfo(object):
         return self.create_score()
 
     def create_score(self) -> 'IconScoreBase':
-        return self._score_class(ScoreDatabase(self._score_db))
+        return self._score_class(db=IconScoreDatabase(db=self._score_db.get_sub_db()))
 
 
 class IconScoreMapperObject(dict):

--- a/iconservice/iconscore/icon_score_mapper_object.py
+++ b/iconservice/iconscore/icon_score_mapper_object.py
@@ -16,6 +16,7 @@
 
 from typing import TYPE_CHECKING
 
+from .container_db.score_db import ScoreDatabase
 from ..base.address import Address
 from ..base.exception import InvalidParamsException
 from ..icon_constant import Revision
@@ -71,13 +72,11 @@ class IconScoreInfo(object):
         if revision <= Revision.TWO.value or is_builtin_score(str(self.address)):
             if self._score is None:
                 self._score = self.create_score()
-
             return self._score
-
         return self.create_score()
 
     def create_score(self) -> 'IconScoreBase':
-        return self._score_class(self._score_db)
+        return self._score_class(ScoreDatabase(self._score_db))
 
 
 class IconScoreMapperObject(dict):

--- a/iconservice/iconscore/icon_system_score_base.py
+++ b/iconservice/iconscore/icon_system_score_base.py
@@ -48,7 +48,7 @@ class IconSystemScoreBase(IconScoreBase):
         super().on_update(**kwargs)
 
     @abstractmethod
-    def __init__(self, db: 'IconScoreDatabase') -> None:
+    def __init__(self, db: 'ScoreDatabase') -> None:
         super().__init__(db)
         if not util_is_builtin_score(str(self.address)):
             raise AccessDeniedException(f"Not a system SCORE ({self.address})")

--- a/tests/integrate_test/iiss/decentralized/test_rc_db_data.py
+++ b/tests/integrate_test/iiss/decentralized/test_rc_db_data.py
@@ -40,7 +40,7 @@ class TestRCDatabase(TestIISSBase):
     def get_last_rc_db_data(rc_data_path):
         return sorted([dir_name for dir_name in os.listdir(rc_data_path)
                        if dir_name.startswith(RewardCalcStorage.IISS_RC_DB_NAME_PREFIX)],
-                      key=lambda rc_dir: int(rc_dir[len(RewardCalcStorage.IISS_RC_DB_NAME_PREFIX)+1:]),
+                      key=lambda rc_dir: int(rc_dir[len(RewardCalcStorage.IISS_RC_DB_NAME_PREFIX) + 1:]),
                       reverse=True)[0]
 
     def _check_the_name_of_rc_db(self, actual_rc_db_name: str):
@@ -155,8 +155,10 @@ class TestRCDatabase(TestIISSBase):
 
         self.set_revision(Revision.DECENTRALIZATION.value)
         expected_gv_block_height = expected_hd_block_height
-        expected_hd_block_height: int = self.make_blocks_to_end_calculation(prev_block_generator=main_preps_address[0],
-                                                                            prev_block_validators=main_preps_address[1:])
+        expected_hd_block_height: int = self.make_blocks_to_end_calculation(
+            prev_block_generator=main_preps_address[0],
+            prev_block_validators=main_preps_address[1:]
+        )
         # ################## term 1 End #####################
         # ################## term 2 Start #####################
         self.make_blocks(self._block_height + 1,
@@ -199,8 +201,10 @@ class TestRCDatabase(TestIISSBase):
                 raise AssertionError
 
         expected_gv_block_height: int = expected_hd_block_height
-        expected_hd_block_height: int = self.make_blocks_to_end_calculation(prev_block_generator=main_preps_address[0],
-                                                                            prev_block_validators=main_preps_address[1:])
+        expected_hd_block_height: int = self.make_blocks_to_end_calculation(
+            prev_block_generator=main_preps_address[0],
+            prev_block_validators=main_preps_address[1:]
+        )
         # ################## term 2 End #####################
         self.make_blocks(self._block_height + 1,
                          prev_block_generator=main_preps_address[0],

--- a/tests/legacy_unittest/database/test_db_custom.py
+++ b/tests/legacy_unittest/database/test_db_custom.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 ICON Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import Mock, patch, PropertyMock
+
+import pytest
+
+from iconservice import IconScoreDatabase
+from iconservice.base.address import AddressPrefix, Address
+from iconservice.database.db import ContextDatabase
+from iconservice.database.db import DatabaseObserver
+from iconservice.database.score_db.utils import DICT_DB_ID, KeyElement
+from iconservice.icon_constant import IconScoreContextType
+from iconservice.iconscore.context.context import ContextContainer
+from iconservice.iconscore.icon_score_context import IconScoreContext
+from tests import create_address
+
+
+@pytest.fixture(scope="function")
+def score_db(context_db):
+    patch.object(IconScoreDatabase, '_is_v2', new_callable=PropertyMock)
+    db = IconScoreDatabase(create_address(), context_db)
+    type(db)._is_v2 = PropertyMock(return_value=False)
+    return db
+
+
+@pytest.fixture(scope="function")
+def context(score_db):
+    context = IconScoreContext(IconScoreContextType.DIRECT)
+    context.current_address = score_db.address
+    ContextContainer._push_context(context)
+    yield context
+    ContextContainer._clear_context()
+
+
+def test_custom_db_v1(context, score_db):
+    # ROOT DB
+    key1: bytes = b"key1"
+    value1: bytes = b"value1"
+    score_db.put(key1, value1)
+    ret: bytes = score_db.get(key1)
+    assert value1 == ret
+
+    # SUB DB
+    prefix1: bytes = b"prefix1"
+    key2: bytes = b'key2'
+    value2: bytes = b'value2'
+    sub_db = score_db.get_sub_db(prefix1)
+    sub_db.put(key2, value2)
+    ret: bytes = sub_db.get(key2)
+
+    assert value2 == ret
+
+
+def test_custom_db_v2(context, score_db):
+    type(score_db)._is_v2 = PropertyMock(return_value=True)
+
+    # ROOT DB
+    key1: bytes = b"key1"
+    value1: bytes = b"value1"
+    score_db.put(key1, value1)
+    ret: bytes = score_db.get(key1)
+    assert value1 == ret
+
+    # SUB DB
+    prefix1: bytes = b"prefix1"
+    key2: bytes = b'key2'
+    value2: bytes = b'value2'
+    sub_db = score_db.get_sub_db(prefix1)
+    sub_db.put(key2, value2)
+    ret: bytes = sub_db.get(key2)
+
+    assert value2 == ret
+
+
+def test_migration(context, score_db):
+    # ROOT DB
+    key1: bytes = b"key1"
+    value1: bytes = b"value1"
+    score_db.put(key1, value1)
+    ret: bytes = score_db.get(key1)
+    assert value1 == ret
+
+    # SUB DB
+    prefix1: bytes = b"prefix1"
+    key2: bytes = b'key2'
+    value2: bytes = b'value2'
+    sub_db = score_db.get_sub_db(prefix1)
+    sub_db.put(key2, value2)
+    ret: bytes = sub_db.get(key2)
+
+    assert value2 == ret
+
+    type(score_db)._is_v2 = PropertyMock(return_value=True)
+
+    ret: bytes = score_db.get(key1)
+    assert value1 == ret
+
+    sub_db = score_db.get_sub_db(prefix1)
+    ret: bytes = sub_db.get(key2)
+    assert value2 == ret

--- a/tests/legacy_unittest/database/test_db_custom.py
+++ b/tests/legacy_unittest/database/test_db_custom.py
@@ -18,13 +18,13 @@ from unittest.mock import Mock, patch, PropertyMock
 
 import pytest
 
-from iconservice import IconScoreDatabase
+from iconservice.database.db import ScoreDatabase
 from iconservice.base.address import AddressPrefix, Address
 from iconservice.database.db import ContextDatabase
 from iconservice.database.db import DatabaseObserver
 from iconservice.database.score_db.utils import DICT_DB_ID, KeyElement
 from iconservice.icon_constant import IconScoreContextType
-from iconservice.iconscore.container_db.score_db import ScoreDatabase
+from iconservice.iconscore.container_db.score_db import IconScoreDatabase
 from iconservice.iconscore.context.context import ContextContainer
 from iconservice.iconscore.icon_score_context import IconScoreContext
 from tests import create_address
@@ -33,9 +33,9 @@ from tests import create_address
 @pytest.fixture(scope="function")
 def score_db(context_db):
     patch.object(IconScoreDatabase, '_is_v2', new_callable=PropertyMock)
-    db = IconScoreDatabase(create_address(), context_db)
+    db = ScoreDatabase(create_address(), context_db)
     type(db)._is_v2 = PropertyMock(return_value=False)
-    return ScoreDatabase(db=db)
+    return IconScoreDatabase(db=db.get_sub_db())
 
 
 @pytest.fixture(scope="function")

--- a/tests/legacy_unittest/database/test_db_custom.py
+++ b/tests/legacy_unittest/database/test_db_custom.py
@@ -24,6 +24,7 @@ from iconservice.database.db import ContextDatabase
 from iconservice.database.db import DatabaseObserver
 from iconservice.database.score_db.utils import DICT_DB_ID, KeyElement
 from iconservice.icon_constant import IconScoreContextType
+from iconservice.iconscore.container_db.score_db import ScoreDatabase
 from iconservice.iconscore.context.context import ContextContainer
 from iconservice.iconscore.icon_score_context import IconScoreContext
 from tests import create_address
@@ -34,7 +35,7 @@ def score_db(context_db):
     patch.object(IconScoreDatabase, '_is_v2', new_callable=PropertyMock)
     db = IconScoreDatabase(create_address(), context_db)
     type(db)._is_v2 = PropertyMock(return_value=False)
-    return db
+    return ScoreDatabase(db=db)
 
 
 @pytest.fixture(scope="function")

--- a/tests/legacy_unittest/database/test_db_db.py
+++ b/tests/legacy_unittest/database/test_db_db.py
@@ -317,7 +317,7 @@ class TestIconScoreDatabase(unittest.TestCase):
         key = self.address.body
         value = 100
 
-        keys: List['KeyElement'] = [KeyElement(keys=[key], container_id=DICT_DB_ID)]
+        keys: List['KeyElement'] = [KeyElement(keys=[key], tag=DICT_DB_ID)]
         self.assertIsNone(db.get(keys=keys))
 
         context.readonly = False

--- a/tests/legacy_unittest/database/test_db_db.py
+++ b/tests/legacy_unittest/database/test_db_db.py
@@ -17,6 +17,7 @@
 
 import os
 import unittest
+from typing import List
 from unittest import mock
 from unittest.mock import patch
 
@@ -26,6 +27,7 @@ from iconservice.database.batch import BlockBatch, TransactionBatch, Transaction
 from iconservice.database.db import ContextDatabase, MetaContextDatabase
 from iconservice.database.db import IconScoreDatabase
 from iconservice.database.db import KeyValueDatabase
+from iconservice.database.score_db.utils import KeyElement, DICT_DB_ID
 from iconservice.icon_constant import DATA_BYTE_ORDER
 from iconservice.iconscore.context.context import ContextContainer
 from iconservice.iconscore.icon_score_context import IconScoreContextType, IconScoreContext
@@ -315,9 +317,10 @@ class TestIconScoreDatabase(unittest.TestCase):
         key = self.address.body
         value = 100
 
-        self.assertIsNone(db.get(key))
+        keys: List['KeyElement'] = [KeyElement(keys=[key], container_id=DICT_DB_ID)]
+        self.assertIsNone(db.get(keys=keys))
 
         context.readonly = False
         context.type = IconScoreContextType.DIRECT
-        db.put(key, value.to_bytes(32, DATA_BYTE_ORDER))
-        self.assertEqual(value.to_bytes(32, DATA_BYTE_ORDER), db.get(key))
+        db.put(keys=keys, value=value.to_bytes(32, DATA_BYTE_ORDER))
+        self.assertEqual(value.to_bytes(32, DATA_BYTE_ORDER), db.get(keys=keys))

--- a/tests/legacy_unittest/database/test_db_db.py
+++ b/tests/legacy_unittest/database/test_db_db.py
@@ -25,7 +25,7 @@ from iconservice.base.address import Address, AddressPrefix
 from iconservice.base.exception import DatabaseException, InvalidParamsException
 from iconservice.database.batch import BlockBatch, TransactionBatch, TransactionBatchValue, BlockBatchValue
 from iconservice.database.db import ContextDatabase, MetaContextDatabase
-from iconservice.database.db import IconScoreDatabase
+from iconservice.database.db import ScoreDatabase
 from iconservice.database.db import KeyValueDatabase
 from iconservice.database.score_db.utils import KeyElement, DICT_DB_ID
 from iconservice.icon_constant import DATA_BYTE_ORDER
@@ -296,7 +296,7 @@ class TestIconScoreDatabase(unittest.TestCase):
         context = IconScoreContext(IconScoreContextType.INVOKE)
         context.is_revision_changed = mock.Mock(return_value=False)
         ContextContainer._push_context(context)
-        self.db = IconScoreDatabase(address, context_db=context_db)
+        self.db = ScoreDatabase(address, context_db=context_db)
         ContextContainer._clear_context()
 
         self.address = address

--- a/tests/legacy_unittest/database/test_db_observer.py
+++ b/tests/legacy_unittest/database/test_db_observer.py
@@ -111,7 +111,7 @@ def test_database_observer_v2(context, score_db, database_observer):
     expected_key = b''.join((
         score_db.address.to_bytes(),
         DICT_DB_ID,
-        KeyElement.rlp_encode_bytes(key)
+        KeyElement._rlp_encode_bytes(key)
     ))
 
     assert expected_key == args[1]

--- a/tests/legacy_unittest/database/test_db_observer.py
+++ b/tests/legacy_unittest/database/test_db_observer.py
@@ -111,7 +111,6 @@ def test_database_observer_v2(context, score_db, database_observer):
 
     expected_key = b''.join((
         score_db.address.to_bytes(),
-        DICT_DB_ID,
         KeyElement._rlp_encode_bytes(key)
     ))
 

--- a/tests/legacy_unittest/database/test_db_observer.py
+++ b/tests/legacy_unittest/database/test_db_observer.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, PropertyMock
 
 import pytest
 
@@ -22,6 +22,7 @@ from iconservice import IconScoreDatabase
 from iconservice.base.address import AddressPrefix, Address
 from iconservice.database.db import ContextDatabase
 from iconservice.database.db import DatabaseObserver
+from iconservice.database.score_db.utils import DICT_DB_ID, KeyElement
 from iconservice.icon_constant import IconScoreContextType
 from iconservice.iconscore.context.context import ContextContainer
 from iconservice.iconscore.icon_score_context import IconScoreContext
@@ -35,8 +36,10 @@ def database_observer():
 
 @pytest.fixture(scope="function")
 def score_db(context_db, database_observer):
+    patch.object(IconScoreDatabase, '_is_v2', new_callable=PropertyMock)
     db = IconScoreDatabase(create_address(), context_db)
     db.set_observer(database_observer)
+    type(db)._is_v2 = PropertyMock(return_value=False)
     return db
 
 
@@ -49,10 +52,9 @@ def context(score_db):
     ContextContainer._clear_context()
 
 
-def test_database_observer(context, score_db, database_observer):
+def test_database_observer_v1(context, score_db, database_observer):
     # PUT
     key: bytes = b"key1"
-
     value: bytes = b"value1"
 
     score_db.put(key, value)
@@ -92,4 +94,58 @@ def test_database_observer(context, score_db, database_observer):
     args, _ = database_observer.on_delete.call_args
 
     assert key == args[1]
+    assert last_value is args[2]
+
+
+def test_database_observer_v2(context, score_db, database_observer):
+    type(score_db)._is_v2 = PropertyMock(return_value=True)
+
+    # PUT
+    key: bytes = b"key1"
+    value: bytes = b"value1"
+
+    score_db.put(key, value)
+    database_observer.on_put.assert_called()
+    args, _ = database_observer.on_put.call_args
+
+    expected_key = b''.join((
+        score_db.address.to_bytes(),
+        DICT_DB_ID,
+        KeyElement.rlp_encode_bytes(key)
+    ))
+
+    assert expected_key == args[1]
+    assert None is args[2]
+    assert value == args[3]
+    last_value = value
+
+    # UPDATE
+    value: bytes = b"value2"
+
+    score_db.put(key, value)
+    database_observer.on_put.assert_called()
+    args, _ = database_observer.on_put.call_args
+
+    assert expected_key == args[1]
+    assert last_value is args[2]
+    assert value == args[3]
+    last_value = value
+
+    # GET
+    key: bytes = b"key1"
+    value: bytes = score_db.get(key)
+    database_observer.on_get.assert_called()
+    args, _ = database_observer.on_get.call_args
+
+    assert expected_key == args[1]
+    assert last_value is args[2]
+    assert value == last_value
+
+    # DELETE
+    key: bytes = b"key1"
+    score_db.delete(key)
+    database_observer.on_delete.assert_called()
+    args, _ = database_observer.on_delete.call_args
+
+    assert expected_key == args[1]
     assert last_value is args[2]

--- a/tests/legacy_unittest/database/test_db_observer.py
+++ b/tests/legacy_unittest/database/test_db_observer.py
@@ -18,13 +18,13 @@ from unittest.mock import Mock, patch, PropertyMock
 
 import pytest
 
-from iconservice import IconScoreDatabase
+from iconservice.database.db import ScoreDatabase
 from iconservice.base.address import AddressPrefix, Address
 from iconservice.database.db import ContextDatabase
 from iconservice.database.db import DatabaseObserver
 from iconservice.database.score_db.utils import DICT_DB_ID, KeyElement
 from iconservice.icon_constant import IconScoreContextType
-from iconservice.iconscore.container_db.score_db import ScoreDatabase
+from iconservice.iconscore.container_db.score_db import IconScoreDatabase
 from iconservice.iconscore.context.context import ContextContainer
 from iconservice.iconscore.icon_score_context import IconScoreContext
 from tests import create_address
@@ -38,10 +38,10 @@ def database_observer():
 @pytest.fixture(scope="function")
 def score_db(context_db, database_observer):
     patch.object(IconScoreDatabase, '_is_v2', new_callable=PropertyMock)
-    db = IconScoreDatabase(create_address(), context_db)
+    db = ScoreDatabase(create_address(), context_db)
     db.set_observer(database_observer)
     type(db)._is_v2 = PropertyMock(return_value=False)
-    return ScoreDatabase(db=db)
+    return IconScoreDatabase(db=db.get_sub_db())
 
 
 @pytest.fixture(scope="function")
@@ -99,7 +99,7 @@ def test_database_observer_v1(context, score_db, database_observer):
 
 
 def test_database_observer_v2(context, score_db, database_observer):
-    type(score_db._db)._is_v2 = PropertyMock(return_value=True)
+    type(score_db._db._score_db)._is_v2 = PropertyMock(return_value=True)
 
     # PUT
     key: bytes = b"key1"

--- a/tests/legacy_unittest/database/test_db_observer.py
+++ b/tests/legacy_unittest/database/test_db_observer.py
@@ -24,6 +24,7 @@ from iconservice.database.db import ContextDatabase
 from iconservice.database.db import DatabaseObserver
 from iconservice.database.score_db.utils import DICT_DB_ID, KeyElement
 from iconservice.icon_constant import IconScoreContextType
+from iconservice.iconscore.container_db.score_db import ScoreDatabase
 from iconservice.iconscore.context.context import ContextContainer
 from iconservice.iconscore.icon_score_context import IconScoreContext
 from tests import create_address
@@ -40,7 +41,7 @@ def score_db(context_db, database_observer):
     db = IconScoreDatabase(create_address(), context_db)
     db.set_observer(database_observer)
     type(db)._is_v2 = PropertyMock(return_value=False)
-    return db
+    return ScoreDatabase(db=db)
 
 
 @pytest.fixture(scope="function")
@@ -98,7 +99,7 @@ def test_database_observer_v1(context, score_db, database_observer):
 
 
 def test_database_observer_v2(context, score_db, database_observer):
-    type(score_db)._is_v2 = PropertyMock(return_value=True)
+    type(score_db._db)._is_v2 = PropertyMock(return_value=True)
 
     # PUT
     key: bytes = b"key1"

--- a/tests/legacy_unittest/test_icon_score_event.py
+++ b/tests/legacy_unittest/test_icon_score_event.py
@@ -34,12 +34,15 @@ from iconservice.iconscore.icon_score_step import IconScoreStepCounter
 from iconservice.icx import IcxEngine, IcxStorage
 from iconservice.utils import int_to_bytes, ContextEngine, ContextStorage
 from iconservice.utils import to_camel_case
+from iconservice.iconscore.container_db.score_db import ScoreDatabase
 
 
 class TestEventlog(unittest.TestCase):
     def setUp(self):
         address = Address.from_data(AddressPrefix.CONTRACT, os.urandom(20))
-        db = Mock(spec=IconScoreDatabase)
+        icon_score_db = Mock(spec=IconScoreDatabase)
+        db = Mock(spec=ScoreDatabase)
+        db.attach_mock(icon_score_db, '_db')
         db.attach_mock(address, 'address')
         context = IconScoreContext()
         traces = Mock(spec=list)
@@ -352,7 +355,7 @@ class TestEventlog(unittest.TestCase):
 
 class EventlogScore(IconScoreBase):
 
-    def __init__(self, db: 'IconScoreDatabase') -> None:
+    def __init__(self, db: 'ScoreDatabase') -> None:
         super().__init__(db)
 
     def on_install(self) -> None:

--- a/tests/legacy_unittest/test_icon_score_event.py
+++ b/tests/legacy_unittest/test_icon_score_event.py
@@ -26,7 +26,7 @@ from iconservice.database.batch import TransactionBatch
 from iconservice.deploy import DeployEngine, DeployStorage
 from iconservice.icon_constant import DATA_BYTE_ORDER, ICX_TRANSFER_EVENT_LOG
 from iconservice.icon_service_engine import IconServiceEngine
-from iconservice.iconscore.icon_score_base import eventlog, IconScoreBase, IconScoreDatabase, external
+from iconservice.iconscore.icon_score_base import eventlog, IconScoreBase, external
 from iconservice.iconscore.context.context import ContextContainer
 from iconservice.iconscore.icon_score_context import IconScoreContext
 from iconservice.icon_constant import IconScoreContextType, IconScoreFuncType
@@ -34,15 +34,19 @@ from iconservice.iconscore.icon_score_step import IconScoreStepCounter
 from iconservice.icx import IcxEngine, IcxStorage
 from iconservice.utils import int_to_bytes, ContextEngine, ContextStorage
 from iconservice.utils import to_camel_case
-from iconservice.iconscore.container_db.score_db import ScoreDatabase
+from iconservice.database.db import ScoreDatabase, ScoreSubDatabase
+from iconservice.iconscore.container_db.score_db import IconScoreDatabase
 
 
 class TestEventlog(unittest.TestCase):
     def setUp(self):
         address = Address.from_data(AddressPrefix.CONTRACT, os.urandom(20))
-        icon_score_db = Mock(spec=IconScoreDatabase)
-        db = Mock(spec=ScoreDatabase)
-        db.attach_mock(icon_score_db, '_db')
+
+        score_db = Mock(spec=ScoreDatabase)
+        score_sub_db = Mock(spec=ScoreSubDatabase)
+        score_sub_db.attach_mock(score_db, '_score_db')
+        db = Mock(spec=IconScoreDatabase)
+        db.attach_mock(score_sub_db, '_db')
         db.attach_mock(address, 'address')
         context = IconScoreContext()
         traces = Mock(spec=list)
@@ -355,7 +359,7 @@ class TestEventlog(unittest.TestCase):
 
 class EventlogScore(IconScoreBase):
 
-    def __init__(self, db: 'ScoreDatabase') -> None:
+    def __init__(self, db: 'IconScoreDatabase') -> None:
         super().__init__(db)
 
     def on_install(self) -> None:

--- a/tests/legacy_unittest/test_icon_score_result.py
+++ b/tests/legacy_unittest/test_icon_score_result.py
@@ -20,6 +20,7 @@ from random import randrange
 from typing import Optional
 from unittest.mock import Mock, patch
 
+from iconservice import ScoreDatabase
 from iconservice.base.address import Address, AddressPrefix
 from iconservice.base.address import SYSTEM_SCORE_ADDRESS
 from iconservice.base.block import Block
@@ -218,7 +219,7 @@ class TestScoreResult(unittest.TestCase):
             context_db = inner_task._icon_service_engine._icx_context_db
 
             score_address = create_address(AddressPrefix.CONTRACT, b'address')
-            score = SampleScore(IconScoreDatabase(score_address, context_db))
+            score = SampleScore(ScoreDatabase(IconScoreDatabase(score_address, context_db)))
 
             address = create_address(AddressPrefix.EOA, b'address')
             score.SampleEvent(b'i_data', address, 10, b'data', 'text')
@@ -257,7 +258,7 @@ class TestScoreResult(unittest.TestCase):
 # noinspection PyPep8Naming
 class SampleScore(IconScoreBase):
 
-    def __init__(self, db: 'IconScoreDatabase') -> None:
+    def __init__(self, db: 'ScoreDatabase') -> None:
         super().__init__(db)
 
     def on_install(self) -> None:

--- a/tests/legacy_unittest/test_icon_score_result.py
+++ b/tests/legacy_unittest/test_icon_score_result.py
@@ -20,7 +20,7 @@ from random import randrange
 from typing import Optional
 from unittest.mock import Mock, patch
 
-from iconservice import ScoreDatabase
+from iconservice.database.db import ScoreDatabase
 from iconservice.base.address import Address, AddressPrefix
 from iconservice.base.address import SYSTEM_SCORE_ADDRESS
 from iconservice.base.block import Block
@@ -29,7 +29,7 @@ from iconservice.base.message import Message
 from iconservice.base.transaction import Transaction
 from iconservice.base.type_converter import TypeConverter
 from iconservice.database.batch import TransactionBatch
-from iconservice.database.db import IconScoreDatabase
+from iconservice.iconscore.container_db.score_db import IconScoreDatabase
 from iconservice.iconscore.icon_pre_validator import IconPreValidator
 from iconservice.iconscore.icon_score_base import IconScoreBase, eventlog, \
     external
@@ -219,7 +219,7 @@ class TestScoreResult(unittest.TestCase):
             context_db = inner_task._icon_service_engine._icx_context_db
 
             score_address = create_address(AddressPrefix.CONTRACT, b'address')
-            score = SampleScore(ScoreDatabase(IconScoreDatabase(score_address, context_db)))
+            score = SampleScore(IconScoreDatabase(ScoreDatabase(score_address, context_db).get_sub_db()))
 
             address = create_address(AddressPrefix.EOA, b'address')
             score.SampleEvent(b'i_data', address, 10, b'data', 'text')
@@ -258,7 +258,7 @@ class TestScoreResult(unittest.TestCase):
 # noinspection PyPep8Naming
 class SampleScore(IconScoreBase):
 
-    def __init__(self, db: 'ScoreDatabase') -> None:
+    def __init__(self, db: 'IconScoreDatabase') -> None:
         super().__init__(db)
 
     def on_install(self) -> None:

--- a/tests/unit_test/iconscore/test_external_payable_call_method.py
+++ b/tests/unit_test/iconscore/test_external_payable_call_method.py
@@ -22,7 +22,8 @@ from iconservice.base.block import Block
 from iconservice.base.exception import ExceptionCode, MethodNotFoundException
 from iconservice.base.message import Message
 from iconservice.base.transaction import Transaction
-from iconservice.database.db import IconScoreDatabase
+from iconservice.iconscore.container_db.score_db import IconScoreDatabase
+from iconservice.database.db import ScoreDatabase
 from iconservice.deploy import DeployEngine
 from iconservice.icon_constant import IconScoreContextType, IconScoreFuncType
 from iconservice.iconscore.context.context import ContextContainer

--- a/tests/unit_test/iconscore/test_icon_container_db.py
+++ b/tests/unit_test/iconscore/test_icon_container_db.py
@@ -13,6 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from unittest import mock
+from unittest.mock import PropertyMock, patch
 
 import pytest
 
@@ -20,15 +22,21 @@ from iconservice import Address
 from iconservice.base.address import AddressPrefix
 from iconservice.base.exception import InvalidParamsException
 from iconservice.database.db import IconScoreDatabase
+from iconservice.database.score_db.utils import DICT_DB_ID, KeyElement, ARRAY_DB_ID, VAR_DB_ID
+from iconservice.iconscore.container_db.utils import Utils as ContainerUtils
 from iconservice.iconscore.context.context import ContextContainer
-from iconservice.iconscore.icon_container_db import ContainerUtil, DictDB, ArrayDB, VarDB
+from iconservice.iconscore.icon_container_db import DictDB, ArrayDB, VarDB
 from iconservice.iconscore.icon_score_context import IconScoreContextType, IconScoreContext
+from iconservice.utils import int_to_bytes
 from tests import create_address
 
 
 @pytest.fixture(scope="function")
 def score_db(context_db):
-    return IconScoreDatabase(create_address(), context_db)
+    patch.object(IconScoreDatabase, '_is_v2', new_callable=PropertyMock)
+    db = IconScoreDatabase(create_address(), context_db)
+    type(db)._is_v2 = PropertyMock(return_value=False)
+    return db
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -62,12 +70,12 @@ class TestIconContainerDB:
     ])
     def test_nested_list(self, score_db, args, value_type, expected_value):
         test_list = [1, 2, 3, [4, 5, 6], [7, 8, 9, [10, 11, 12]], self.ADDRESS]
-        ContainerUtil.put_to_db(score_db, 'test_list', test_list)
+        ContainerUtils.put_to_db(score_db, 'test_list', test_list)
 
         if isinstance(args, tuple):
-            assert ContainerUtil.get_from_db(score_db, 'test_list', *args, value_type=value_type) == expected_value
+            assert ContainerUtils.get_from_db(score_db, 'test_list', *args, value_type=value_type) == expected_value
         else:
-            assert ContainerUtil.get_from_db(score_db, 'test_list', args, value_type=value_type) == expected_value
+            assert ContainerUtils.get_from_db(score_db, 'test_list', args, value_type=value_type) == expected_value
 
     @pytest.mark.parametrize("args, value_type, expected_value", [
         (1, str, 'a'),
@@ -80,12 +88,12 @@ class TestIconContainerDB:
     ])
     def test_nested_dict(self, score_db, args, value_type, expected_value):
         test_dict = {1: 'a', 2: ['a', 'b', ['c', 'd']], 3: {'a': 1}, 4: self.ADDRESS}
-        ContainerUtil.put_to_db(score_db, 'test_dict', test_dict)
+        ContainerUtils.put_to_db(score_db, 'test_dict', test_dict)
 
         if isinstance(args, tuple):
-            assert ContainerUtil.get_from_db(score_db, 'test_dict', *args, value_type=value_type) == expected_value
+            assert ContainerUtils.get_from_db(score_db, 'test_dict', *args, value_type=value_type) == expected_value
         else:
-            assert ContainerUtil.get_from_db(score_db, 'test_dict', args, value_type=value_type) == expected_value
+            assert ContainerUtils.get_from_db(score_db, 'test_dict', args, value_type=value_type) == expected_value
 
     @pytest.mark.parametrize("args, value_type, expected_value", [
         (0, int, 1),
@@ -95,19 +103,13 @@ class TestIconContainerDB:
     ])
     def test_tuple(self, score_db, args, value_type, expected_value):
         test_tuple = tuple([1, 2, 3, self.ADDRESS])
-        ContainerUtil.put_to_db(score_db, 'test_tuple', test_tuple)
+        ContainerUtils.put_to_db(score_db, 'test_tuple', test_tuple)
 
-        assert ContainerUtil.get_from_db(score_db, 'test_tuple', args, value_type=value_type) == expected_value
-
-    @staticmethod
-    def _check_the_db_prefix_format(name):
-        prefix: bytes = ContainerUtil.create_db_prefix(DictDB, name)
-        assert prefix == b'\x01|' + name.encode()
+        assert ContainerUtils.get_from_db(score_db, 'test_tuple', args, value_type=value_type) == expected_value
 
     def test_dict_depth1(self, score_db):
         name = 'test_dict'
         test_dict = DictDB(name, score_db, value_type=int)
-        self._check_the_db_prefix_format(name)
 
         test_dict['a'] = 1
         test_dict['b'] = 2
@@ -120,7 +122,6 @@ class TestIconContainerDB:
     def test_dict_other_Key(self, score_db):
         name = 'test_dict'
         test_dict = DictDB(name, score_db, depth=2, value_type=int)
-        self._check_the_db_prefix_format(name)
 
         addr1 = create_address(1)
         addr2 = create_address(0)
@@ -133,7 +134,6 @@ class TestIconContainerDB:
     def test_dict_depth2(self, score_db):
         name = 'test_dict'
         test_dict = DictDB(name, score_db, depth=3, value_type=int)
-        self._check_the_db_prefix_format(name)
 
         test_dict['a']['b']['c'] = 1
         test_dict['a']['b']['d'] = 2
@@ -141,6 +141,15 @@ class TestIconContainerDB:
         test_dict['a']['b']['f'] = 4
 
         assert test_dict['a']['b']['c'] == 1
+
+    def test_dict_depth_seperate(self, score_db):
+        name = 'test_dict'
+        test_dict = DictDB(name, score_db, value_type=bytes)
+        test_dict[b'a|b'] = b'a'
+
+        test_dict = DictDB(name, score_db, value_type=bytes)
+        v = test_dict[b'a|b']
+        print("result", v)
 
     def test_success_array1(self, score_db):
         test_array = ArrayDB('test_array', score_db, value_type=int)
@@ -225,8 +234,7 @@ class TestIconContainerDB:
     ])
     def test_var_db(self, score_db, value_type, expected_value):
         test_var = VarDB('test_var', score_db, value_type=value_type)
-        assert test_var._db != score_db
-        assert test_var._db._prefix == b'\x02'
+        assert test_var._db._prefix == score_db.address.to_bytes()
 
         test_var.set(expected_value)
 
@@ -244,9 +252,8 @@ class TestIconContainerDB:
     ])
     def test_default_value_of_container_db(self, score_db, value_type, expected_value, collection, key_or_index):
         # TEST: Check the default value of collection object (dict, list)
-        ContainerUtil.put_to_db(score_db, 'test_collection', collection)
-        actual_value = ContainerUtil.get_from_db(score_db, 'test_collection', key_or_index, value_type=value_type)
-
+        ContainerUtils.put_to_db(score_db, 'test_collection', collection)
+        actual_value = ContainerUtils.get_from_db(score_db, 'test_collection', key_or_index, value_type=value_type)
         assert actual_value == expected_value
 
     @pytest.mark.parametrize("value_type, expected_value", [
@@ -264,7 +271,6 @@ class TestIconContainerDB:
         name = "TEST"
         testarray = ArrayDB(name, score_db, value_type=int)
         assert testarray._db != score_db
-        assert testarray._db._prefix == ContainerUtil.create_db_prefix(ArrayDB, name)
 
         testarray.put(1)
         testarray.put(3)
@@ -279,7 +285,6 @@ class TestIconContainerDB:
         name = "TEST"
         testarray = ArrayDB(name, score_db, value_type=int)
         assert testarray._db != score_db
-        assert testarray._db._prefix == ContainerUtil.create_db_prefix(ArrayDB, name)
 
         testarray.put(1)
         testarray.put(2)
@@ -320,14 +325,271 @@ class TestIconContainerDB:
             testarray[5] = 1
             a = testarray[5]
 
-    @pytest.mark.parametrize("prefix, score_db_cls, expected_prefix", [
-        ('a', ArrayDB, b'\x00|a'),
-        ('dictdb', DictDB, b'\x01|dictdb'),
-    ])
-    def test_container_util(self, prefix, score_db_cls, expected_prefix):
-        actual_prefix: bytes = ContainerUtil.create_db_prefix(score_db_cls, prefix)
-        assert actual_prefix == expected_prefix
+    def test_dict_db_check_prefix_v1(self, score_db):
+        name = 'test_dict'
+        depth = 4
+        value = 1
+        test_dict = DictDB(name, score_db, value_type=int, depth=depth)
 
-    def test_when_create_var_db_prefix_using_container_util_should_raise_error(self):
-        with pytest.raises(InvalidParamsException):
-            ContainerUtil.create_db_prefix(VarDB, 'vardb')
+        score_db._context_db.put = mock.Mock()
+        score_db._context_db.get = mock.Mock(return_value=int_to_bytes(value))
+        score_db._context_db.delete = mock.Mock()
+
+        test_dict['aaaa']['bbbb']['cccc']['dddd'] = value
+
+        expected_key = b'|'.join((
+            score_db.address.to_bytes(),
+            DICT_DB_ID,
+            name.encode(),
+            DICT_DB_ID,
+            'aaaa'.encode(),
+            DICT_DB_ID,
+            'bbbb'.encode(),
+            DICT_DB_ID,
+            'cccc'.encode(),
+            'dddd'.encode()
+        ))
+        args, _ = score_db._context_db.put.call_args
+        assert expected_key == args[1]
+
+        ret = test_dict['aaaa']['bbbb']['cccc']['dddd']
+        args, _ = score_db._context_db.get.call_args
+        assert expected_key == args[1]
+
+        del test_dict['aaaa']['bbbb']['cccc']['dddd']
+        args, _ = score_db._context_db.get.call_args
+        assert expected_key == args[1]
+
+    def test_dict_db_check_prefix_v2(self, score_db):
+        type(score_db)._is_v2 = PropertyMock(return_value=True)
+
+        name = 'test_dict'
+        depth = 4
+        value = 1
+        test_dict = DictDB(name, score_db, value_type=int, depth=depth)
+
+        score_db._context_db.put = mock.Mock()
+        score_db._context_db.get = mock.Mock(return_value=int_to_bytes(value))
+        score_db._context_db.delete = mock.Mock()
+
+        test_dict['aaaa']['bbbb']['cccc']['dddd'] = 1
+
+        expected_key = b''.join((
+            score_db.address.to_bytes(),
+            DICT_DB_ID,
+            KeyElement.rlp_encode_bytes(name.encode()),
+            KeyElement.rlp_encode_bytes('aaaa'.encode()),
+            KeyElement.rlp_encode_bytes('bbbb'.encode()),
+            KeyElement.rlp_encode_bytes('cccc'.encode()),
+            KeyElement.rlp_encode_bytes('dddd'.encode())
+        ))
+        args, _ = score_db._context_db.put.call_args_list[0]
+        assert expected_key == args[1]
+
+        ret = test_dict['aaaa']['bbbb']['cccc']['dddd']
+        args, _ = score_db._context_db.put.call_args_list[0]
+        assert expected_key == args[1]
+
+        del test_dict['aaaa']['bbbb']['cccc']['dddd']
+        args, _ = score_db._context_db.put.call_args_list[0]
+        assert expected_key == args[1]
+
+    def test_array_db_check_prefix_v1(self, score_db):
+        name = 'test_array'
+        depth = 1
+        value = 1
+        size = 0
+        test_array = ArrayDB(name, score_db, value_type=int, depth=depth)
+
+        score_db._context_db.put = mock.Mock()
+
+        test_array.put(value)
+
+        expected_key = b'|'.join((
+            score_db.address.to_bytes(),
+            ARRAY_DB_ID,
+            name.encode(),
+            int_to_bytes(size)
+        ))
+        args, _ = score_db._context_db.put.call_args_list[0]
+        assert expected_key == args[1]
+
+        expected_key = b'|'.join((
+            score_db.address.to_bytes(),
+            ARRAY_DB_ID,
+            name.encode(),
+            b'size'
+        ))
+        args, _ = score_db._context_db.put.call_args_list[1]
+        assert expected_key == args[1]
+
+    def test_array_db_check_prefix_v2(self, score_db):
+        type(score_db)._is_v2 = PropertyMock(return_value=True)
+
+        name = 'test_array'
+        depth = 1
+        value = 1
+        size = 0
+        test_array = ArrayDB(name, score_db, value_type=int, depth=depth)
+
+        score_db._context_db.put = mock.Mock()
+
+        test_array.put(value)
+
+        expected_key = b''.join((
+            score_db.address.to_bytes(),
+            ARRAY_DB_ID,
+            KeyElement.rlp_encode_bytes(name.encode()),
+            KeyElement.rlp_encode_bytes(int_to_bytes(size))
+        ))
+        args, _ = score_db._context_db.put.call_args_list[0]
+        assert expected_key == args[1]
+
+        expected_key = b''.join((
+            score_db.address.to_bytes(),
+            ARRAY_DB_ID,
+            KeyElement.rlp_encode_bytes(name.encode()),
+            KeyElement.rlp_encode_bytes(b''),
+        ))
+        args, _ = score_db._context_db.put.call_args_list[1]
+        assert expected_key == args[1]
+
+    def test_var_db_check_prefix_v1(self, score_db):
+        name = 'test_var'
+        value = 1
+        test_var = VarDB(name, score_db, value_type=int)
+
+        score_db._context_db.put = mock.Mock()
+
+        test_var.set(value)
+
+        expected_key = b'|'.join((
+            score_db.address.to_bytes(),
+            VAR_DB_ID,
+            name.encode()
+        ))
+        args, _ = score_db._context_db.put.call_args_list[0]
+        assert expected_key == args[1]
+
+    def test_var_db_check_prefix_v2(self, score_db):
+        type(score_db)._is_v2 = PropertyMock(return_value=True)
+
+        name = 'test_var'
+        value = 1
+        test_var = VarDB(name, score_db, value_type=int)
+
+        score_db._context_db.put = mock.Mock()
+
+        test_var.set(value)
+
+        expected_key = b''.join((
+            score_db.address.to_bytes(),
+            VAR_DB_ID,
+            KeyElement.rlp_encode_bytes(name.encode())
+        ))
+        args, _ = score_db._context_db.put.call_args_list[0]
+        assert expected_key == args[1]
+
+    def test_sub_var_db_check_prefix_v1(self, score_db):
+        sub_prefix = b'sub'
+        sub_db = score_db.get_sub_db(sub_prefix)
+
+        name = 'test_var'
+        value = 1
+        test_var = VarDB(name, sub_db, value_type=int)
+
+        score_db._context_db.put = mock.Mock()
+
+        test_var.set(value)
+
+        expected_key = b'|'.join((
+            score_db.address.to_bytes(),
+            sub_prefix,
+            VAR_DB_ID,
+            name.encode()
+        ))
+        args, _ = score_db._context_db.put.call_args_list[0]
+        assert args[1] == expected_key
+
+    def test_sub_var_db_check_prefix_v2(self, score_db):
+        type(score_db)._is_v2 = PropertyMock(return_value=True)
+
+        sub_prefix = b'sub'
+        sub_db = score_db.get_sub_db(sub_prefix)
+
+        name = 'test_var'
+        value = 1
+        test_var = VarDB(name, sub_db, value_type=int)
+
+        score_db._context_db.put = mock.Mock()
+
+        test_var.set(value)
+
+        expected_key = b''.join((
+            score_db.address.to_bytes(),
+            VAR_DB_ID,
+            KeyElement.rlp_encode_bytes(sub_prefix),
+            KeyElement.rlp_encode_bytes(name.encode())
+        ))
+        args, _ = score_db._context_db.put.call_args_list[0]
+        assert args[1] == expected_key
+
+    def test_dict_db_migration(self, score_db):
+        name = 'test'
+        key1 = "aaaa"
+        key2 = "bbbb"
+        key3 = "cccc"
+        key4 = "dddd"
+        value = 1
+        depth = 4
+
+        test_db = DictDB(name, score_db, value_type=int, depth=depth)
+        test_db[key1][key2][key3][key4] = value
+        assert value == test_db[key1][key2][key3][key4]
+
+        type(score_db)._is_v2 = PropertyMock(return_value=True)
+
+        test_db = DictDB(name, score_db, value_type=int, depth=depth)
+        assert value == test_db[key1][key2][key3][key4]
+
+    def test_array_db_migration(self, score_db):
+        name = 'test'
+        value = 1
+
+        test_db = ArrayDB(name, score_db, value_type=int)
+        test_db.put(value)
+        assert value == test_db[0]
+
+        type(score_db)._is_v2 = PropertyMock(return_value=True)
+
+        test_db = ArrayDB(name, score_db, value_type=int)
+        assert value == test_db[0]
+
+    def test_var_db_migration(self, score_db):
+        name = 'test'
+        value = 1
+
+        test_db = VarDB(name, score_db, value_type=int)
+        test_db.set(value)
+        assert value == test_db.get()
+
+        type(score_db)._is_v2 = PropertyMock(return_value=True)
+
+        test_db = VarDB(name, score_db, value_type=int)
+        assert value == test_db.get()
+
+    def test_sub_var_db_migration(self, score_db):
+        name = 'test'
+        value = 1
+
+        sub_db = score_db.get_sub_db(b'sub')
+        test_db = VarDB(name, sub_db, value_type=int)
+        test_db.set(value)
+        assert value == test_db.get()
+
+        type(sub_db)._is_v2 = PropertyMock(return_value=True)
+
+        test_db = VarDB(name, sub_db, value_type=int)
+        assert value == test_db.get()
+
+

--- a/tests/unit_test/iconscore/test_icon_container_db.py
+++ b/tests/unit_test/iconscore/test_icon_container_db.py
@@ -377,11 +377,11 @@ class TestIconContainerDB:
         expected_key = b''.join((
             score_db.address.to_bytes(),
             DICT_DB_ID,
-            KeyElement.rlp_encode_bytes(name.encode()),
-            KeyElement.rlp_encode_bytes('aaaa'.encode()),
-            KeyElement.rlp_encode_bytes('bbbb'.encode()),
-            KeyElement.rlp_encode_bytes('cccc'.encode()),
-            KeyElement.rlp_encode_bytes('dddd'.encode())
+            KeyElement._rlp_encode_bytes(name.encode()),
+            KeyElement._rlp_encode_bytes('aaaa'.encode()),
+            KeyElement._rlp_encode_bytes('bbbb'.encode()),
+            KeyElement._rlp_encode_bytes('cccc'.encode()),
+            KeyElement._rlp_encode_bytes('dddd'.encode())
         ))
         args, _ = score_db._context_db.put.call_args_list[0]
         assert expected_key == args[1]
@@ -439,8 +439,8 @@ class TestIconContainerDB:
         expected_key = b''.join((
             score_db.address.to_bytes(),
             ARRAY_DB_ID,
-            KeyElement.rlp_encode_bytes(name.encode()),
-            KeyElement.rlp_encode_bytes(int_to_bytes(size))
+            KeyElement._rlp_encode_bytes(name.encode()),
+            KeyElement._rlp_encode_bytes(int_to_bytes(size))
         ))
         args, _ = score_db._context_db.put.call_args_list[0]
         assert expected_key == args[1]
@@ -448,8 +448,8 @@ class TestIconContainerDB:
         expected_key = b''.join((
             score_db.address.to_bytes(),
             ARRAY_DB_ID,
-            KeyElement.rlp_encode_bytes(name.encode()),
-            KeyElement.rlp_encode_bytes(b''),
+            KeyElement._rlp_encode_bytes(name.encode()),
+            KeyElement._rlp_encode_bytes(b''),
         ))
         args, _ = score_db._context_db.put.call_args_list[1]
         assert expected_key == args[1]
@@ -485,7 +485,7 @@ class TestIconContainerDB:
         expected_key = b''.join((
             score_db.address.to_bytes(),
             VAR_DB_ID,
-            KeyElement.rlp_encode_bytes(name.encode())
+            KeyElement._rlp_encode_bytes(name.encode())
         ))
         args, _ = score_db._context_db.put.call_args_list[0]
         assert expected_key == args[1]
@@ -528,8 +528,8 @@ class TestIconContainerDB:
         expected_key = b''.join((
             score_db.address.to_bytes(),
             VAR_DB_ID,
-            KeyElement.rlp_encode_bytes(sub_prefix),
-            KeyElement.rlp_encode_bytes(name.encode())
+            KeyElement._rlp_encode_bytes(sub_prefix),
+            KeyElement._rlp_encode_bytes(name.encode())
         ))
         args, _ = score_db._context_db.put.call_args_list[0]
         assert args[1] == expected_key

--- a/tests/unit_test/iconscore/test_icon_score_trace.py
+++ b/tests/unit_test/iconscore/test_icon_score_trace.py
@@ -22,14 +22,14 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from iconservice import ScoreDatabase
+from iconservice.iconscore.container_db.score_db import IconScoreDatabase
 from iconservice.base.address import Address, AddressPrefix
 from iconservice.base.block import Block
 from iconservice.base.exception import ExceptionCode, IconScoreException, InvalidParamsException
 from iconservice.base.message import Message
 from iconservice.base.transaction import Transaction
 from iconservice.database.batch import TransactionBatch
-from iconservice.database.db import IconScoreDatabase
+from iconservice.database.db import ScoreSubDatabase, ScoreDatabase
 from iconservice.deploy import DeployEngine, DeployStorage
 from iconservice.icon_constant import IconScoreContextType
 from iconservice.icon_service_engine import IconServiceEngine
@@ -49,9 +49,11 @@ from tests import raise_exception_start_tag, raise_exception_end_tag, create_add
 
 @pytest.fixture(scope="function")
 def score_db():
-    db = Mock(spec=IconScoreDatabase)
-    db.address = create_address(AddressPrefix.CONTRACT)
-    return ScoreDatabase(db)
+    score_db = Mock(spec=ScoreDatabase)
+    sub_score_db = Mock(spec=ScoreSubDatabase)
+    sub_score_db.attach_mock(score_db, "_score_db")
+    sub_score_db.address = create_address(AddressPrefix.CONTRACT)
+    return IconScoreDatabase(db=sub_score_db)
 
 
 @pytest.fixture(scope="function")

--- a/tests/unit_test/iconscore/test_icon_score_trace.py
+++ b/tests/unit_test/iconscore/test_icon_score_trace.py
@@ -22,6 +22,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from iconservice import ScoreDatabase
 from iconservice.base.address import Address, AddressPrefix
 from iconservice.base.block import Block
 from iconservice.base.exception import ExceptionCode, IconScoreException, InvalidParamsException
@@ -50,7 +51,7 @@ from tests import raise_exception_start_tag, raise_exception_end_tag, create_add
 def score_db():
     db = Mock(spec=IconScoreDatabase)
     db.address = create_address(AddressPrefix.CONTRACT)
-    return db
+    return ScoreDatabase(db)
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
ContainerDB and IconScoreSubDatabase are changed to Warp class of IconScoreDatabase.
IconScoreDatabase makes final final key value and accesses DB.

DictDB and ArrayDB are implemented using IconScoreSubDatabase.
* Multi depth enable.
* ArrayDB currently only allows depth=1.


The property "is_root" can be distinguished from IconScoreDatabase and IconScoreSubDatabase by isInstance, but this is inevitable due to circular reference issues.

VarDB directly accesses DB with IconScoreDatabase, not SubDB.

Key values ​​that require rlp conversion are wrapped in the RLPPrefix class.
* Rlp operation is performed when bytes are replaced with RLPPrefix.

The fee is made so that it can be transferred as it was before.
* example)
* 1. Store 1 as old_A key value before migration.
* 2. After migration, convert 1 to 2 with new_A key value
* * 1. When searching with old_A key, 1 is stored, so the fee is treated as replace, not put.
* * 2. The value for old_A is not deleted.

Migration DB Access logic
* 1. First DB search with New Key
* 2. If there is no value, DB search with Old Key.

Container ID is set only once after address.
* The default is DICT_DB_ID
* Ex) bytes(Address) + DICT_DB_ID + PREFIX_KEY… ..

