### PR TITLE
IS-1157: Backword compatibility for divide Node key

### DIFF
--- a/iconservice/__version__.py
+++ b/iconservice/__version__.py
@@ -1,1 +1,1 @@
-__version__ = '1.7.0rc4'
+__version__ = '1.7.0rc5'

--- a/iconservice/prep/engine.py
+++ b/iconservice/prep/engine.py
@@ -480,7 +480,7 @@ class Engine(EngineBase, IISSEngineListener):
                                          f"not {value}")
 
         if context.revision < Revision.DIVIDE_NODE_ADDRESS.value:
-            self._remove_node_key_from_params(params=kwargs)
+            self._remove_node_address_from_params(params=kwargs)
 
         validate_prep_data(context=context,
                            prep_address=address,
@@ -519,7 +519,11 @@ class Engine(EngineBase, IISSEngineListener):
         )
 
     @classmethod
-    def _remove_node_key_from_params(cls, params: dict):
+    def _remove_node_address_from_params(cls, params: dict):
+        """Just for backward compatibility with the previous version
+
+        :param params: parameters of registerPRep or setPRep
+        """
         if ConstantKeys.NODE_ADDRESS in params:
             del params[ConstantKeys.NODE_ADDRESS]
 
@@ -658,7 +662,7 @@ class Engine(EngineBase, IISSEngineListener):
             raise InvalidParamsException(f"P-Rep not found: {address}")
 
         if context.revision < Revision.DIVIDE_NODE_ADDRESS.value:
-            cls._remove_node_key_from_params(params=kwargs)
+            cls._remove_node_address_from_params(params=kwargs)
 
         params = deepcopy(kwargs)
         validate_prep_data(context=context,

--- a/iconservice/prep/engine.py
+++ b/iconservice/prep/engine.py
@@ -479,6 +479,9 @@ class Engine(EngineBase, IISSEngineListener):
                                          f"Registration Fee Must be {context.storage.prep.prep_registration_fee} "
                                          f"not {value}")
 
+        if context.revision < Revision.DIVIDE_NODE_ADDRESS.value:
+            self._remove_node_key_from_params(params=kwargs)
+
         validate_prep_data(context=context,
                            prep_address=address,
                            tx_data=kwargs)
@@ -514,6 +517,11 @@ class Engine(EngineBase, IISSEngineListener):
             arguments=[address],
             indexed_args_count=0
         )
+
+    @classmethod
+    def _remove_node_key_from_params(cls, params: dict):
+        if ConstantKeys.NODE_ADDRESS in params:
+            del params[ConstantKeys.NODE_ADDRESS]
 
     @classmethod
     def _put_reg_prep_in_rc_db(cls, context: 'IconScoreContext', address: 'Address'):
@@ -648,6 +656,9 @@ class Engine(EngineBase, IISSEngineListener):
         dirty_prep: Optional['PRep'] = context.get_prep(address, mutable=True)
         if dirty_prep is None:
             raise InvalidParamsException(f"P-Rep not found: {address}")
+
+        if context.revision < Revision.DIVIDE_NODE_ADDRESS.value:
+            cls._remove_node_key_from_params(params=kwargs)
 
         params = deepcopy(kwargs)
         validate_prep_data(context=context,

--- a/iconservice/prep/validator.py
+++ b/iconservice/prep/validator.py
@@ -86,11 +86,6 @@ def validate_prep_data(context: 'IconScoreContext',
 
     # register_prep or is_update_node_address is True
     node_address: 'Address' = tx_data[ConstantKeys.NODE_ADDRESS] if is_update_node_address else prep_address
-
-    # must prevent to change node address before divide node address revision.
-    if context.revision < Revision.DIVIDE_NODE_ADDRESS.value:
-        if prep_address != node_address:
-            raise InvalidParamsException(f"nodeAddress not supported: revision={context.revision}")
     context.prep_address_converter.validate_node_address(node_address)
 
 

--- a/tests/integrate_test/iiss/decentralized/test_preps_divide_node_address.py
+++ b/tests/integrate_test/iiss/decentralized/test_preps_divide_node_address.py
@@ -54,10 +54,12 @@ class TestPRepNodeAddressDivision(TestIISSBase):
         tx: dict = self.create_register_prep_tx(from_=account,
                                                 reg_data=reg_data)
 
-        _, tx_results, _, _, next_preps = self.debug_make_and_req_block(tx_list=[tx])
-        self.assertEqual(tx_results[1].failure.code, ExceptionCode.INVALID_PARAMETER)
-        self.assertEqual(tx_results[1].failure.message,
-                         f"nodeAddress not supported: revision={Revision.DECENTRALIZATION.value}")
+        block, tx_results, _, _, next_preps = self.debug_make_and_req_block(tx_list=[tx])
+        self._write_precommit_state(block)
+
+        response = self.get_prep(account)
+        self.assertEqual(str(response["nodeAddress"]), str(account.address))
+        self.assertNotEqual(str(response["nodeAddress"]), str(dummy_node))
 
     def test_prep_set_node_address_before_rev_DIVIDE_NODE_ADDRESS(self):
         self.distribute_icx(accounts=self._accounts[:PREP_MAIN_PREPS],
@@ -70,10 +72,12 @@ class TestPRepNodeAddressDivision(TestIISSBase):
         tx: dict = self.create_set_prep_tx(from_=account,
                                            set_data={"nodeAddress": str(dummy_node)})
 
-        _, tx_results, _, _, next_preps = self.debug_make_and_req_block(tx_list=[tx])
-        self.assertEqual(tx_results[1].failure.code, ExceptionCode.INVALID_PARAMETER)
-        self.assertEqual(tx_results[1].failure.message,
-                         f"nodeAddress not supported: revision={Revision.DECENTRALIZATION.value}")
+        block, tx_results, _, _, next_preps = self.debug_make_and_req_block(tx_list=[tx])
+        self._write_precommit_state(block)
+
+        response = self.get_prep(account)
+        self.assertEqual(str(response["nodeAddress"]), str(account.address))
+        self.assertNotEqual(str(response["nodeAddress"]), str(dummy_node))
 
     def test_prep_register_node_address(self):
         self.set_revision(Revision.DIVIDE_NODE_ADDRESS.value)


### PR DESCRIPTION
If engine received registerPRep, setPRep transaction before rev9, that logic filter params about nodeAddress For backword compatibility.