### PR TITLE
IS-1167: Fix inserting unstake slot and refactor normalizing stakePart

### DIFF
--- a/tests/legacy_unittest/icx/test_stake_part.py
+++ b/tests/legacy_unittest/icx/test_stake_part.py
@@ -100,7 +100,7 @@ class TestStakePart(unittest.TestCase):
         unstakes_info = [unstake_info1, unstake_info2, unstake_info3, unstake_info4, unstake_info5]
         part = StakePart(stake=stake, unstakes_info=unstakes_info)
         part.set_complete(True)
-        part.normalize(block_height, Revision.IISS.value)
+        part.normalize(block_height, Revision.MULTIPLE_UNSTAKE.value)
         self.assertEqual(stake, part.stake)
         self.assertEqual(0, part.unstake)
         self.assertEqual(0, part.unstake_block_height)


### PR DESCRIPTION
Fix inserting unstake slot and refactor normalizing stakePart
* use linear search rather than wrong binary search to find index of new unstake slot
* use revision to divide logic in normalizing stakePart method
* if unstake slot if full and user add unstake, unstakeBlockHeight of last slot is max(unstakeInfo[-1][1], unstke_block_height)