### PR TITLE
Add block height and block hash to QUERY message

### DIFF
--- a/iconservice/iiss/engine.py
+++ b/iconservice/iiss/engine.py
@@ -25,8 +25,8 @@ from .reward_calc.data_creator import DataCreator as RewardCalcDataCreator
 from .reward_calc.ipc.message import CalculateDoneNotification, ReadyNotification
 from .reward_calc.ipc.reward_calc_proxy import RewardCalcProxy
 from ..base.ComponentBase import EngineBase
-from ..base.address import Address
-from ..base.address import SYSTEM_SCORE_ADDRESS
+from ..base.address import Address, SYSTEM_SCORE_ADDRESS
+from ..base.block import Block
 from ..base.exception import (
     InvalidParamsException, InvalidRequestException, OutOfBalanceException, FatalException,
     InternalServiceErrorException
@@ -51,7 +51,6 @@ if TYPE_CHECKING:
     from ..iiss.storage import RewardRate
     from ..icx import IcxStorage
     from ..prep.data import Term
-    from ..base.block import Block
 
 _TAG = IISS_LOG_TAG
 
@@ -717,7 +716,8 @@ class Engine(EngineBase):
             raise InvalidParamsException(f"Invalid address: {address}")
 
         tx_hash = context.tx.hash if isinstance(context.tx, Transaction) else None
-        iscore, block_height = self._reward_calc_proxy.query_iscore(address, tx_hash)
+        block = context.block if isinstance(context.block, Block) else None
+        iscore, block_height = self._reward_calc_proxy.query_iscore(address, block, tx_hash)
 
         data = {
             "iscore": iscore,

--- a/iconservice/iiss/reward_calc/ipc/message.py
+++ b/iconservice/iiss/reward_calc/ipc/message.py
@@ -333,22 +333,25 @@ class QueryRequest(Request):
     """queryIScore
     """
 
-    def __init__(self, address: 'Address', tx_hash: Optional[bytes]):
+    def __init__(self, address: 'Address', block_height: int, block_hash: Optional[bytes], tx_hash: Optional[bytes]):
         super().__init__(MessageType.QUERY)
 
         self.address = address
+        self.block_height = block_height
+        self.block_hash = block_hash
         self.tx_hash = tx_hash
 
     def __str__(self) -> str:
         return (
-            f"{self.msg_type.name}"
-            f"({self.msg_id}, {self.address}, {bytes_to_hex(self.tx_hash)})"
+            f"{self.msg_type.name}, "
+            f"({self.msg_id}, {self.address}, {self.block_height}, {bytes_to_hex(self.block_hash)}, "
+            f"{bytes_to_hex(self.tx_hash)})"
         )
 
     def _to_list(self) -> tuple:
         return self.msg_type, \
                self.msg_id, \
-               (self.address.to_bytes_including_prefix(), self.tx_hash)
+               (self.address.to_bytes_including_prefix(), self.block_height, self.block_hash, self.tx_hash)
 
 
 class QueryResponse(Response):


### PR DESCRIPTION
It takes too long when SCORE calls queryIScore intercall.

To fix this, the block height and block hash were added to the QUERY message.

Now RC does not iterate through preCommit DB when receiving QUERY message, it gets the element with key.