### PR TITLE
Fix integer type validation check

### DIFF
--- a/iconservice/iconscore/icon_pre_validator.py
+++ b/iconservice/iconscore/icon_pre_validator.py
@@ -139,7 +139,7 @@ class IconPreValidator:
     def is_integer_type(cls, value: str) -> bool:
         try:
             if value.startswith('0x'):
-                return value == hex(int(value, 16))
+                return "0x" + value[2:].lstrip("0") == hex(int(value, 16))
         except ValueError:
             return False
         else:


### PR DESCRIPTION
Geo dude from ICONbet found a type validation check error with the following value in a method parameter :

"0xde0b6b3a7640000"

The value above returns the following error message : 

```json
{
  "code": -32005,
  "message": "Unexpected INT Type, got 0x0de0b6b3a7640000"
}
```

Indeed, the code responsible of checking that value is the following : 

```py
    @classmethod
    def is_integer_type(cls, value: str) -> bool:
        try:
            if value.startswith('0x'):
                return value == hex(int(value, 16))
        except ValueError:
            return False
        else:
            return False
```

However, by default, Python strips the 0 on the left when calling hex().
Therefore, that method returns the following values : 


```py
0x0de0b6b3a7640000 returns False
0xde0b6b3a7640000 returns True
```

Both these values are valid integers and both should return `True`.
