### PR TITLE
[IS-1375] update typing-extensions requires

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ earlgrey~=0.2.1
 iconcommons~=1.1.3
 msgpack~=1.0.0
 iso3166~=1.0.1
-typing_extensions~=3.7.4.2
+typing-extensions~=3.7.4


### PR DESCRIPTION
 - fixed mismatch `typing-extensions` version with iconrpcserver requires